### PR TITLE
feat(validation): reject reserved JSON Logic operators as field names

### DIFF
--- a/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/validate/FiberValidator.scala
+++ b/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/validate/FiberValidator.scala
@@ -38,6 +38,7 @@ object FiberValidator {
         definitionOk   <- FiberRules.L1.validStateMachineDefinition(update.definition)
         limitsOk       <- FiberRules.L1.definitionWithinLimits(update.definition)
         expressionsOk  <- FiberRules.L1.definitionExpressionsWithinDepthLimits(update.definition)
+        reservedOk     <- FiberRules.L1.noReservedOperatorFieldNames(update.definition)
         initialDataMap <- CommonRules.isMapValue(update.initialData, "initialData")
         initialDataSize <- CommonRules.valueWithinSizeLimit(
           update.initialData,
@@ -50,6 +51,7 @@ object FiberValidator {
         definitionOk,
         limitsOk,
         expressionsOk,
+        reservedOk,
         initialDataMap,
         initialDataSize,
         parentExists


### PR DESCRIPTION
## Summary

Adds L1 validation to detect when field names in guard/effect expressions collide with reserved JSON Logic operator names (e.g., `count`, `merge`, `map`).

## Problem

Using operator names as object keys causes signature validation failures because the SDK's JSON canonicalization may interpret them as operator calls rather than plain field names during serialization.

For example, this guard causes "Invalid signature in data transactions":
```json
{ "guard": { ">=": [{ "count": { "var": "state.completions" } }, 2] } }
```

## Solution

Added validation in the Data-L1 layer that:
1. Walks through all guard and effect expressions in state machine definitions
2. Extracts all map keys from `MapExpression` objects
3. Checks if any keys match reserved operators from `JsonLogicOp.knownOperatorTags`
4. Rejects the update with a clear error message if collision detected

## Changes

- `FiberRules.scala`: Added `noReservedOperatorFieldNames` rule and `extractMapKeys` helper
- `FiberValidator.scala`: Integrated check into `L1Validator.createFiber`
- `ValidatorSuite.scala`: Added 3 test cases + 2 fixture definitions

## Testing

All 38 tests pass including 3 new ones:
- `noReservedOperatorFieldNames: reserved operator in guard rejected`
- `noReservedOperatorFieldNames: reserved operator in effect rejected`  
- `noReservedOperatorFieldNames: valid field names accepted`