### PR TITLE
docs: add governance domain state machine definitions

### DIFF
--- a/docs/domains/governance/GOVERNANCE.md
+++ b/docs/domains/governance/GOVERNANCE.md
@@ -1,0 +1,65 @@
+# Governance Domain
+
+State machine definitions for decentralized governance on OttoChain.
+
+## Overview
+
+The governance domain provides building blocks for decentralized decision-making, from simple DAOs to complex multi-branch constitutional systems.
+
+## DAO State Machines
+
+### Token DAO (`dao-token.json`)
+Token-weighted voting governance with delegation support.
+- **States**: ACTIVE → VOTING → QUEUED → (back to ACTIVE or DISSOLVED)
+- **Features**: Token delegation, proposal thresholds, timelock, quorum requirements
+
+### Multisig DAO (`dao-multisig.json`)
+N-of-M signature threshold governance.
+- **States**: ACTIVE ↔ PENDING → (back to ACTIVE or DISSOLVED)
+- **Features**: Configurable threshold, proposal TTL, signer management
+
+### Threshold DAO (`dao-threshold.json`)
+Reputation-based threshold governance.
+- **States**: ACTIVE ↔ VOTING → (back to ACTIVE or DISSOLVED)
+- **Features**: Member/vote/propose thresholds, open membership
+
+### Single DAO (`dao-single.json`)
+Simple majority voting DAO.
+- **States**: ACTIVE ↔ VOTING → (back to ACTIVE or DISSOLVED)
+- **Features**: One-member-one-vote, simple quorum
+
+## Constitutional Governance
+
+For complex organizations requiring separation of powers:
+
+### Legislature (`governance-legislature.json`)
+Bill creation, committee review, floor voting.
+- **States**: DRAFT → COMMITTEE → FLOOR → PASSED/FAILED/VETOED
+
+### Executive (`governance-executive.json`)
+Appointments, orders, veto power.
+- **States**: ACTIVE with appointment and veto workflows
+
+### Judiciary (`governance-judiciary.json`)
+Case filing, hearings, appeals, constitutional review.
+- **States**: FILED → HEARING → DECIDED → (APPEALED) → FINAL
+
+### Constitution (`governance-constitution.json`)
+Amendment process with ratification requirements.
+- **States**: PROPOSED → DELIBERATION → RATIFICATION → RATIFIED/REJECTED
+
+### Simple Governance (`governance-simple.json`)
+Basic member management with rule changes and disputes.
+- **States**: ACTIVE ↔ VOTING ↔ DISPUTE → (back to ACTIVE or DISSOLVED)
+
+## SDK Integration
+
+These state machines are implemented in the OttoChain SDK via protobuf definitions. See [ottochain-sdk](https://github.com/ottobot-ai/ottochain-sdk) for TypeScript types and client libraries.
+
+## Usage
+
+State machines define valid transitions. The OttoChain metagraph validates all governance actions against these definitions, ensuring:
+- Only valid state transitions occur
+- Required thresholds are met before execution
+- Timelocks and deadlines are enforced
+- Audit trail of all governance actions

--- a/docs/domains/governance/dao-multisig.json
+++ b/docs/domains/governance/dao-multisig.json
@@ -1,0 +1,300 @@
+{
+  "metadata": {
+    "name": "MultisigDAO",
+    "description": "N-of-M multisig governance. Requires threshold signatures for actions.",
+    "version": "1.0.0",
+    "category": "governance/dao"
+  },
+  "states": {
+    "ACTIVE": { "id": { "value": "ACTIVE" }, "isFinal": false },
+    "PENDING": { "id": { "value": "PENDING" }, "isFinal": false },
+    "DISSOLVED": { "id": { "value": "DISSOLVED" }, "isFinal": true }
+  },
+  "initialState": { "value": "ACTIVE" },
+  "transitions": [
+    {
+      "_comment": "Propose action",
+      "from": { "value": "ACTIVE" },
+      "to": { "value": "PENDING" },
+      "eventName": "propose",
+      "guard": {
+        "in": [{ "var": "event.agent" }, { "var": "state.signers" }]
+      },
+      "effect": {
+        "merge": [
+          { "var": "state" },
+          {
+            "proposal": {
+              "id": { "var": "event.proposalId" },
+              "actionType": { "var": "event.actionType" },
+              "payload": { "var": "event.payload" },
+              "proposer": { "var": "event.agent" },
+              "proposedAt": { "var": "$timestamp" },
+              "expiresAt": { "+": [{ "var": "$timestamp" }, { "var": "state.proposalTTLMs" }] }
+            },
+            "signatures": {
+              "setKey": [{}, { "var": "event.agent" }, { "var": "$timestamp" }]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "Sign proposal",
+      "from": { "value": "PENDING" },
+      "to": { "value": "PENDING" },
+      "eventName": "sign",
+      "guard": {
+        "and": [
+          { "in": [{ "var": "event.agent" }, { "var": "state.signers" }] },
+          { "!": { "getKey": [{ "var": "state.signatures" }, { "var": "event.agent" }] } },
+          { "<": [{ "size": { "var": "state.signatures" } }, { "var": "state.threshold" }] }
+        ]
+      },
+      "effect": {
+        "merge": [
+          { "var": "state" },
+          {
+            "signatures": {
+              "setKey": [
+                { "var": "state.signatures" },
+                { "var": "event.agent" },
+                { "var": "$timestamp" }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "Execute when threshold met",
+      "from": { "value": "PENDING" },
+      "to": { "value": "ACTIVE" },
+      "eventName": "execute",
+      "guard": {
+        ">=": [{ "size": { "var": "state.signatures" } }, { "var": "state.threshold" }]
+      },
+      "effect": {
+        "merge": [
+          { "var": "state" },
+          {
+            "actions": {
+              "cat": [
+                { "var": "state.actions" },
+                [{
+                  "id": { "var": "state.proposal.id" },
+                  "type": { "var": "state.proposal.actionType" },
+                  "payload": { "var": "state.proposal.payload" },
+                  "signatures": { "var": "state.signatures" },
+                  "executedAt": { "var": "$timestamp" }
+                }]
+              ]
+            },
+            "proposal": null,
+            "signatures": {}
+          }
+        ]
+      },
+      "emits": [
+        { "event": "multisig_executed", "to": "external" }
+      ]
+    },
+    {
+      "_comment": "Cancel expired proposal",
+      "from": { "value": "PENDING" },
+      "to": { "value": "ACTIVE" },
+      "eventName": "cancel",
+      "guard": {
+        "or": [
+          { ">": [{ "var": "$timestamp" }, { "var": "state.proposal.expiresAt" }] },
+          { "===": [{ "var": "event.agent" }, { "var": "state.proposal.proposer" }] }
+        ]
+      },
+      "effect": {
+        "merge": [
+          { "var": "state" },
+          {
+            "cancelledProposals": {
+              "cat": [
+                { "var": "state.cancelledProposals" },
+                [{ "merge": [{ "var": "state.proposal" }, { "cancelledAt": { "var": "$timestamp" } }] }]
+              ]
+            },
+            "proposal": null,
+            "signatures": {}
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "Add signer (requires threshold)",
+      "from": { "value": "ACTIVE" },
+      "to": { "value": "PENDING" },
+      "eventName": "propose_add_signer",
+      "guard": {
+        "in": [{ "var": "event.agent" }, { "var": "state.signers" }]
+      },
+      "effect": {
+        "merge": [
+          { "var": "state" },
+          {
+            "proposal": {
+              "id": { "var": "event.proposalId" },
+              "actionType": "add_signer",
+              "payload": { "newSigner": { "var": "event.newSigner" } },
+              "proposer": { "var": "event.agent" },
+              "proposedAt": { "var": "$timestamp" },
+              "expiresAt": { "+": [{ "var": "$timestamp" }, { "var": "state.proposalTTLMs" }] }
+            },
+            "signatures": {
+              "setKey": [{}, { "var": "event.agent" }, { "var": "$timestamp" }]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "Remove signer (requires threshold)",
+      "from": { "value": "ACTIVE" },
+      "to": { "value": "PENDING" },
+      "eventName": "propose_remove_signer",
+      "guard": {
+        "and": [
+          { "in": [{ "var": "event.agent" }, { "var": "state.signers" }] },
+          { ">": [{ "size": { "var": "state.signers" } }, { "var": "state.threshold" }] }
+        ]
+      },
+      "effect": {
+        "merge": [
+          { "var": "state" },
+          {
+            "proposal": {
+              "id": { "var": "event.proposalId" },
+              "actionType": "remove_signer",
+              "payload": { "removeSigner": { "var": "event.removeSigner" } },
+              "proposer": { "var": "event.agent" },
+              "proposedAt": { "var": "$timestamp" },
+              "expiresAt": { "+": [{ "var": "$timestamp" }, { "var": "state.proposalTTLMs" }] }
+            },
+            "signatures": {
+              "setKey": [{}, { "var": "event.agent" }, { "var": "$timestamp" }]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "Change threshold (requires current threshold)",
+      "from": { "value": "ACTIVE" },
+      "to": { "value": "PENDING" },
+      "eventName": "propose_change_threshold",
+      "guard": {
+        "and": [
+          { "in": [{ "var": "event.agent" }, { "var": "state.signers" }] },
+          { ">=": [{ "var": "event.newThreshold" }, 1] },
+          { "<=": [{ "var": "event.newThreshold" }, { "size": { "var": "state.signers" } }] }
+        ]
+      },
+      "effect": {
+        "merge": [
+          { "var": "state" },
+          {
+            "proposal": {
+              "id": { "var": "event.proposalId" },
+              "actionType": "change_threshold",
+              "payload": { "newThreshold": { "var": "event.newThreshold" } },
+              "proposer": { "var": "event.agent" },
+              "proposedAt": { "var": "$timestamp" },
+              "expiresAt": { "+": [{ "var": "$timestamp" }, { "var": "state.proposalTTLMs" }] }
+            },
+            "signatures": {
+              "setKey": [{}, { "var": "event.agent" }, { "var": "$timestamp" }]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "Apply signer management action",
+      "from": { "value": "PENDING" },
+      "to": { "value": "ACTIVE" },
+      "eventName": "apply_signer_change",
+      "guard": {
+        "and": [
+          { ">=": [{ "size": { "var": "state.signatures" } }, { "var": "state.threshold" }] },
+          { "in": [{ "var": "state.proposal.actionType" }, ["add_signer", "remove_signer", "change_threshold"]] }
+        ]
+      },
+      "effect": {
+        "if": [
+          { "===": [{ "var": "state.proposal.actionType" }, "add_signer"] },
+          {
+            "merge": [
+              { "var": "state" },
+              {
+                "signers": { "cat": [{ "var": "state.signers" }, [{ "var": "state.proposal.payload.newSigner" }]] },
+                "proposal": null,
+                "signatures": {}
+              }
+            ]
+          },
+          { "===": [{ "var": "state.proposal.actionType" }, "remove_signer"] },
+          {
+            "merge": [
+              { "var": "state" },
+              {
+                "signers": { "filter": [{ "var": "state.signers" }, { "!==": [{ "var": "" }, { "var": "state.proposal.payload.removeSigner" }] }] },
+                "proposal": null,
+                "signatures": {}
+              }
+            ]
+          },
+          {
+            "merge": [
+              { "var": "state" },
+              {
+                "threshold": { "var": "state.proposal.payload.newThreshold" },
+                "proposal": null,
+                "signatures": {}
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "Dissolve (requires all signers)",
+      "from": { "value": "ACTIVE" },
+      "to": { "value": "DISSOLVED" },
+      "eventName": "dissolve",
+      "guard": {
+        "===": [{ "var": "event.signatureCount" }, { "size": { "var": "state.signers" } }]
+      },
+      "effect": {
+        "merge": [
+          { "var": "state" },
+          { "dissolvedAt": { "var": "$timestamp" }, "status": "DISSOLVED" }
+        ]
+      }
+    }
+  ],
+  "initialDataTemplate": {
+    "schema": "MultisigDAO",
+    "name": "",
+    "signers": [],
+    "threshold": 1,
+    "proposalTTLMs": 604800000,
+    "proposal": null,
+    "signatures": {},
+    "actions": [],
+    "cancelledProposals": [],
+    "metadata": {},
+    "status": "ACTIVE"
+  },
+  "crossReferences": {
+    "Identity": "signer verification",
+    "Contract": "action execution targets",
+    "Treasury": "fund management",
+    "Escrow": "controlled release"
+  }
+}

--- a/docs/domains/governance/dao-single.json
+++ b/docs/domains/governance/dao-single.json
@@ -1,0 +1,142 @@
+{
+  "metadata": {
+    "name": "SingleOwnerDAO",
+    "description": "Single owner controls all actions. Simplest governance model.",
+    "version": "1.0.0",
+    "category": "governance/dao"
+  },
+  "states": {
+    "ACTIVE": { "id": { "value": "ACTIVE" }, "isFinal": false },
+    "TRANSFERRING": { "id": { "value": "TRANSFERRING" }, "isFinal": false },
+    "DISSOLVED": { "id": { "value": "DISSOLVED" }, "isFinal": true }
+  },
+  "initialState": { "value": "ACTIVE" },
+  "transitions": [
+    {
+      "_comment": "Execute any action as owner",
+      "from": { "value": "ACTIVE" },
+      "to": { "value": "ACTIVE" },
+      "eventName": "execute",
+      "guard": {
+        "===": [{ "var": "event.agent" }, { "var": "state.owner" }]
+      },
+      "effect": {
+        "merge": [
+          { "var": "state" },
+          {
+            "actions": {
+              "cat": [
+                { "var": "state.actions" },
+                [{
+                  "id": { "var": "event.actionId" },
+                  "type": { "var": "event.actionType" },
+                  "payload": { "var": "event.payload" },
+                  "executedAt": { "var": "$timestamp" }
+                }]
+              ]
+            }
+          }
+        ]
+      },
+      "emits": [
+        { "event": "action_executed", "to": "external" }
+      ]
+    },
+    {
+      "_comment": "Initiate ownership transfer",
+      "from": { "value": "ACTIVE" },
+      "to": { "value": "TRANSFERRING" },
+      "eventName": "transfer_ownership",
+      "guard": {
+        "===": [{ "var": "event.agent" }, { "var": "state.owner" }]
+      },
+      "effect": {
+        "merge": [
+          { "var": "state" },
+          {
+            "pendingOwner": { "var": "event.newOwner" },
+            "transferInitiatedAt": { "var": "$timestamp" }
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "Accept ownership",
+      "from": { "value": "TRANSFERRING" },
+      "to": { "value": "ACTIVE" },
+      "eventName": "accept_ownership",
+      "guard": {
+        "===": [{ "var": "event.agent" }, { "var": "state.pendingOwner" }]
+      },
+      "effect": {
+        "merge": [
+          { "var": "state" },
+          {
+            "owner": { "var": "state.pendingOwner" },
+            "pendingOwner": null,
+            "transferInitiatedAt": null,
+            "ownershipHistory": {
+              "cat": [
+                { "var": "state.ownershipHistory" },
+                [{
+                  "from": { "var": "state.owner" },
+                  "to": { "var": "state.pendingOwner" },
+                  "at": { "var": "$timestamp" }
+                }]
+              ]
+            }
+          }
+        ]
+      },
+      "emits": [
+        { "event": "ownership_transferred", "to": "Identity" }
+      ]
+    },
+    {
+      "_comment": "Cancel transfer",
+      "from": { "value": "TRANSFERRING" },
+      "to": { "value": "ACTIVE" },
+      "eventName": "cancel_transfer",
+      "guard": {
+        "===": [{ "var": "event.agent" }, { "var": "state.owner" }]
+      },
+      "effect": {
+        "merge": [
+          { "var": "state" },
+          { "pendingOwner": null, "transferInitiatedAt": null }
+        ]
+      }
+    },
+    {
+      "_comment": "Dissolve DAO",
+      "from": { "value": "ACTIVE" },
+      "to": { "value": "DISSOLVED" },
+      "eventName": "dissolve",
+      "guard": {
+        "===": [{ "var": "event.agent" }, { "var": "state.owner" }]
+      },
+      "effect": {
+        "merge": [
+          { "var": "state" },
+          { "dissolvedAt": { "var": "$timestamp" }, "status": "DISSOLVED" }
+        ]
+      }
+    }
+  ],
+  "initialDataTemplate": {
+    "schema": "SingleOwnerDAO",
+    "name": "",
+    "owner": "",
+    "pendingOwner": null,
+    "transferInitiatedAt": null,
+    "actions": [],
+    "ownershipHistory": [],
+    "metadata": {},
+    "status": "ACTIVE"
+  },
+  "crossReferences": {
+    "Identity": "owner registration",
+    "Contract": "action execution targets",
+    "Treasury": "fund management"
+  }
+}

--- a/docs/domains/governance/dao-threshold.json
+++ b/docs/domains/governance/dao-threshold.json
@@ -1,0 +1,256 @@
+{
+  "metadata": {
+    "name": "ThresholdDAO",
+    "description": "Reputation-threshold governance. Minimum reputation required for participation.",
+    "version": "1.0.0",
+    "category": "governance/dao"
+  },
+  "states": {
+    "ACTIVE": { "id": { "value": "ACTIVE" }, "isFinal": false },
+    "VOTING": { "id": { "value": "VOTING" }, "isFinal": false },
+    "DISSOLVED": { "id": { "value": "DISSOLVED" }, "isFinal": true }
+  },
+  "initialState": { "value": "ACTIVE" },
+  "transitions": [
+    {
+      "_comment": "Propose (requires proposer reputation threshold)",
+      "from": { "value": "ACTIVE" },
+      "to": { "value": "VOTING" },
+      "eventName": "propose",
+      "guard": {
+        ">=": [{ "var": "event.agentReputation" }, { "var": "state.proposeThreshold" }]
+      },
+      "effect": {
+        "merge": [
+          { "var": "state" },
+          {
+            "proposal": {
+              "id": { "var": "event.proposalId" },
+              "title": { "var": "event.title" },
+              "description": { "var": "event.description" },
+              "actionType": { "var": "event.actionType" },
+              "payload": { "var": "event.payload" },
+              "proposer": { "var": "event.agent" },
+              "proposedAt": { "var": "$timestamp" },
+              "deadline": { "+": [{ "var": "$timestamp" }, { "var": "state.votingPeriodMs" }] }
+            },
+            "votes": {
+              "for": [],
+              "against": [],
+              "abstain": []
+            }
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "Vote (requires voter reputation threshold)",
+      "from": { "value": "VOTING" },
+      "to": { "value": "VOTING" },
+      "eventName": "vote",
+      "guard": {
+        "and": [
+          { ">=": [{ "var": "event.agentReputation" }, { "var": "state.voteThreshold" }] },
+          { "!": { "in": [{ "var": "event.agent" }, { "var": "state.votes.for" }] } },
+          { "!": { "in": [{ "var": "event.agent" }, { "var": "state.votes.against" }] } },
+          { "!": { "in": [{ "var": "event.agent" }, { "var": "state.votes.abstain" }] } },
+          { "<=": [{ "var": "$timestamp" }, { "var": "state.proposal.deadline" }] }
+        ]
+      },
+      "effect": {
+        "merge": [
+          { "var": "state" },
+          {
+            "votes": {
+              "if": [
+                { "===": [{ "var": "event.vote" }, "for"] },
+                { "merge": [{ "var": "state.votes" }, { "for": { "cat": [{ "var": "state.votes.for" }, [{ "var": "event.agent" }]] } }] },
+                { "===": [{ "var": "event.vote" }, "against"] },
+                { "merge": [{ "var": "state.votes" }, { "against": { "cat": [{ "var": "state.votes.against" }, [{ "var": "event.agent" }]] } }] },
+                { "merge": [{ "var": "state.votes" }, { "abstain": { "cat": [{ "var": "state.votes.abstain" }, [{ "var": "event.agent" }]] } }] }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "Execute (majority + quorum)",
+      "from": { "value": "VOTING" },
+      "to": { "value": "ACTIVE" },
+      "eventName": "execute",
+      "guard": {
+        "and": [
+          { ">": [{ "var": "$timestamp" }, { "var": "state.proposal.deadline" }] },
+          { ">": [{ "size": { "var": "state.votes.for" } }, { "size": { "var": "state.votes.against" } }] },
+          { ">=": [
+            { "+": [{ "size": { "var": "state.votes.for" } }, { "size": { "var": "state.votes.against" } }] },
+            { "var": "state.quorum" }
+          ]}
+        ]
+      },
+      "effect": {
+        "merge": [
+          { "var": "state" },
+          {
+            "history": {
+              "cat": [
+                { "var": "state.history" },
+                [{
+                  "type": "executed",
+                  "proposal": { "var": "state.proposal" },
+                  "votes": { "var": "state.votes" },
+                  "at": { "var": "$timestamp" }
+                }]
+              ]
+            },
+            "proposal": null,
+            "votes": null
+          }
+        ]
+      },
+      "emits": [
+        { "event": "proposal_executed", "to": "Reputation", "payload": { "action": "increase", "agents": { "var": "state.votes.for" } } }
+      ]
+    },
+    {
+      "_comment": "Reject (didn't pass)",
+      "from": { "value": "VOTING" },
+      "to": { "value": "ACTIVE" },
+      "eventName": "reject",
+      "guard": {
+        "and": [
+          { ">": [{ "var": "$timestamp" }, { "var": "state.proposal.deadline" }] },
+          { "or": [
+            { "<=": [{ "size": { "var": "state.votes.for" } }, { "size": { "var": "state.votes.against" } }] },
+            { "<": [
+              { "+": [{ "size": { "var": "state.votes.for" } }, { "size": { "var": "state.votes.against" } }] },
+              { "var": "state.quorum" }
+            ]}
+          ]}
+        ]
+      },
+      "effect": {
+        "merge": [
+          { "var": "state" },
+          {
+            "history": {
+              "cat": [
+                { "var": "state.history" },
+                [{
+                  "type": "rejected",
+                  "proposal": { "var": "state.proposal" },
+                  "votes": { "var": "state.votes" },
+                  "at": { "var": "$timestamp" }
+                }]
+              ]
+            },
+            "proposal": null,
+            "votes": null
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "Add member (if meets threshold)",
+      "from": { "value": "ACTIVE" },
+      "to": { "value": "ACTIVE" },
+      "eventName": "join",
+      "guard": {
+        "and": [
+          { ">=": [{ "var": "event.agentReputation" }, { "var": "state.memberThreshold" }] },
+          { "!": { "in": [{ "var": "event.agent" }, { "var": "state.members" }] } }
+        ]
+      },
+      "effect": {
+        "merge": [
+          { "var": "state" },
+          {
+            "members": { "cat": [{ "var": "state.members" }, [{ "var": "event.agent" }]] },
+            "memberJoinedAt": {
+              "setKey": [
+                { "var": "state.memberJoinedAt" },
+                { "var": "event.agent" },
+                { "var": "$timestamp" }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "Leave",
+      "from": { "value": "ACTIVE" },
+      "to": { "value": "ACTIVE" },
+      "eventName": "leave",
+      "guard": {
+        "in": [{ "var": "event.agent" }, { "var": "state.members" }]
+      },
+      "effect": {
+        "merge": [
+          { "var": "state" },
+          {
+            "members": {
+              "filter": [{ "var": "state.members" }, { "!==": [{ "var": "" }, { "var": "event.agent" }] }]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "Update thresholds (via vote)",
+      "from": { "value": "ACTIVE" },
+      "to": { "value": "VOTING" },
+      "eventName": "propose_threshold_change",
+      "guard": {
+        ">=": [{ "var": "event.agentReputation" }, { "var": "state.proposeThreshold" }]
+      },
+      "effect": {
+        "merge": [
+          { "var": "state" },
+          {
+            "proposal": {
+              "id": { "var": "event.proposalId" },
+              "title": "Threshold Change",
+              "actionType": "threshold_change",
+              "payload": {
+                "memberThreshold": { "var": "event.memberThreshold" },
+                "voteThreshold": { "var": "event.voteThreshold" },
+                "proposeThreshold": { "var": "event.proposeThreshold" }
+              },
+              "proposer": { "var": "event.agent" },
+              "proposedAt": { "var": "$timestamp" },
+              "deadline": { "+": [{ "var": "$timestamp" }, { "var": "state.votingPeriodMs" }] }
+            },
+            "votes": { "for": [], "against": [], "abstain": [] }
+          }
+        ]
+      }
+    }
+  ],
+  "initialDataTemplate": {
+    "schema": "ThresholdDAO",
+    "name": "",
+    
+    "members": [],
+    "memberJoinedAt": {},
+    
+    "memberThreshold": 20,
+    "voteThreshold": 30,
+    "proposeThreshold": 50,
+    "quorum": 3,
+    "votingPeriodMs": 604800000,
+    
+    "proposal": null,
+    "votes": null,
+    "history": [],
+    
+    "metadata": {},
+    "status": "ACTIVE"
+  },
+  "crossReferences": {
+    "Identity": "member verification",
+    "Reputation": "threshold checks",
+    "Contract": "action execution"
+  }
+}

--- a/docs/domains/governance/dao-token.json
+++ b/docs/domains/governance/dao-token.json
@@ -1,0 +1,306 @@
+{
+  "metadata": {
+    "name": "TokenDAO",
+    "description": "Token-weighted voting. Voting power proportional to token holdings.",
+    "version": "1.0.0",
+    "category": "governance/dao"
+  },
+  "states": {
+    "ACTIVE": { "id": { "value": "ACTIVE" }, "isFinal": false },
+    "VOTING": { "id": { "value": "VOTING" }, "isFinal": false },
+    "QUEUED": { "id": { "value": "QUEUED" }, "isFinal": false },
+    "DISSOLVED": { "id": { "value": "DISSOLVED" }, "isFinal": true }
+  },
+  "initialState": { "value": "ACTIVE" },
+  "transitions": [
+    {
+      "_comment": "Create proposal (requires min tokens to propose)",
+      "from": { "value": "ACTIVE" },
+      "to": { "value": "VOTING" },
+      "eventName": "propose",
+      "guard": {
+        ">=": [
+          { "getKey": [{ "var": "state.balances" }, { "var": "event.agent" }] },
+          { "var": "state.proposalThreshold" }
+        ]
+      },
+      "effect": {
+        "merge": [
+          { "var": "state" },
+          {
+            "proposal": {
+              "id": { "var": "event.proposalId" },
+              "title": { "var": "event.title" },
+              "description": { "var": "event.description" },
+              "actionType": { "var": "event.actionType" },
+              "payload": { "var": "event.payload" },
+              "proposer": { "var": "event.agent" },
+              "proposedAt": { "var": "$timestamp" },
+              "votingEndsAt": { "+": [{ "var": "$timestamp" }, { "var": "state.votingPeriodMs" }] },
+              "snapshotBlock": { "var": "event.snapshotBlock" }
+            },
+            "votes": {
+              "for": 0,
+              "against": 0,
+              "abstain": 0,
+              "voters": {}
+            }
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "Cast vote (weight = token balance at snapshot)",
+      "from": { "value": "VOTING" },
+      "to": { "value": "VOTING" },
+      "eventName": "vote",
+      "guard": {
+        "and": [
+          { ">": [{ "getKey": [{ "var": "state.balances" }, { "var": "event.agent" }] }, 0] },
+          { "!": { "getKey": [{ "var": "state.votes.voters" }, { "var": "event.agent" }] } },
+          { "<=": [{ "var": "$timestamp" }, { "var": "state.proposal.votingEndsAt" }] }
+        ]
+      },
+      "effect": {
+        "merge": [
+          { "var": "state" },
+          {
+            "votes": {
+              "merge": [
+                { "var": "state.votes" },
+                {
+                  "if": [
+                    { "===": [{ "var": "event.vote" }, "for"] },
+                    { "for": { "+": [{ "var": "state.votes.for" }, { "getKey": [{ "var": "state.balances" }, { "var": "event.agent" }] }] } },
+                    { "===": [{ "var": "event.vote" }, "against"] },
+                    { "against": { "+": [{ "var": "state.votes.against" }, { "getKey": [{ "var": "state.balances" }, { "var": "event.agent" }] }] } },
+                    { "abstain": { "+": [{ "var": "state.votes.abstain" }, { "getKey": [{ "var": "state.balances" }, { "var": "event.agent" }] }] } }
+                  ]
+                },
+                {
+                  "voters": {
+                    "setKey": [
+                      { "var": "state.votes.voters" },
+                      { "var": "event.agent" },
+                      {
+                        "vote": { "var": "event.vote" },
+                        "weight": { "getKey": [{ "var": "state.balances" }, { "var": "event.agent" }] },
+                        "votedAt": { "var": "$timestamp" }
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "Queue proposal after voting ends (if passed)",
+      "from": { "value": "VOTING" },
+      "to": { "value": "QUEUED" },
+      "eventName": "queue",
+      "guard": {
+        "and": [
+          { ">": [{ "var": "$timestamp" }, { "var": "state.proposal.votingEndsAt" }] },
+          { ">": [{ "var": "state.votes.for" }, { "var": "state.votes.against" }] },
+          { ">=": [
+            { "+": [{ "var": "state.votes.for" }, { "var": "state.votes.against" }, { "var": "state.votes.abstain" }] },
+            { "var": "state.quorum" }
+          ]}
+        ]
+      },
+      "effect": {
+        "merge": [
+          { "var": "state" },
+          {
+            "proposal": {
+              "merge": [
+                { "var": "state.proposal" },
+                {
+                  "queuedAt": { "var": "$timestamp" },
+                  "executableAt": { "+": [{ "var": "$timestamp" }, { "var": "state.timelockMs" }] }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "Execute after timelock",
+      "from": { "value": "QUEUED" },
+      "to": { "value": "ACTIVE" },
+      "eventName": "execute",
+      "guard": {
+        ">=": [{ "var": "$timestamp" }, { "var": "state.proposal.executableAt" }]
+      },
+      "effect": {
+        "merge": [
+          { "var": "state" },
+          {
+            "executedProposals": {
+              "cat": [
+                { "var": "state.executedProposals" },
+                [{
+                  "merge": [
+                    { "var": "state.proposal" },
+                    {
+                      "votes": { "var": "state.votes" },
+                      "executedAt": { "var": "$timestamp" }
+                    }
+                  ]
+                }]
+              ]
+            },
+            "proposal": null,
+            "votes": null
+          }
+        ]
+      },
+      "emits": [
+        { "event": "proposal_executed", "to": "external" }
+      ]
+    },
+    {
+      "_comment": "Reject proposal (voting ended, didn't pass)",
+      "from": { "value": "VOTING" },
+      "to": { "value": "ACTIVE" },
+      "eventName": "reject",
+      "guard": {
+        "and": [
+          { ">": [{ "var": "$timestamp" }, { "var": "state.proposal.votingEndsAt" }] },
+          { "or": [
+            { "<=": [{ "var": "state.votes.for" }, { "var": "state.votes.against" }] },
+            { "<": [
+              { "+": [{ "var": "state.votes.for" }, { "var": "state.votes.against" }, { "var": "state.votes.abstain" }] },
+              { "var": "state.quorum" }
+            ]}
+          ]}
+        ]
+      },
+      "effect": {
+        "merge": [
+          { "var": "state" },
+          {
+            "rejectedProposals": {
+              "cat": [
+                { "var": "state.rejectedProposals" },
+                [{
+                  "merge": [
+                    { "var": "state.proposal" },
+                    {
+                      "votes": { "var": "state.votes" },
+                      "rejectedAt": { "var": "$timestamp" }
+                    }
+                  ]
+                }]
+              ]
+            },
+            "proposal": null,
+            "votes": null
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "Cancel from queue (proposer can cancel)",
+      "from": { "value": "QUEUED" },
+      "to": { "value": "ACTIVE" },
+      "eventName": "cancel",
+      "guard": {
+        "===": [{ "var": "event.agent" }, { "var": "state.proposal.proposer" }]
+      },
+      "effect": {
+        "merge": [
+          { "var": "state" },
+          {
+            "cancelledProposals": {
+              "cat": [
+                { "var": "state.cancelledProposals" },
+                [{
+                  "merge": [
+                    { "var": "state.proposal" },
+                    { "cancelledAt": { "var": "$timestamp" } }
+                  ]
+                }]
+              ]
+            },
+            "proposal": null,
+            "votes": null
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "Delegate votes",
+      "from": { "value": "ACTIVE" },
+      "to": { "value": "ACTIVE" },
+      "eventName": "delegate",
+      "guard": {
+        ">": [{ "getKey": [{ "var": "state.balances" }, { "var": "event.agent" }] }, 0]
+      },
+      "effect": {
+        "merge": [
+          { "var": "state" },
+          {
+            "delegations": {
+              "setKey": [
+                { "var": "state.delegations" },
+                { "var": "event.agent" },
+                { "var": "event.delegateTo" }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "Undelegate",
+      "from": { "value": "ACTIVE" },
+      "to": { "value": "ACTIVE" },
+      "eventName": "undelegate",
+      "guard": {
+        "getKey": [{ "var": "state.delegations" }, { "var": "event.agent" }]
+      },
+      "effect": {
+        "merge": [
+          { "var": "state" },
+          {
+            "delegations": {
+              "deleteKey": [{ "var": "state.delegations" }, { "var": "event.agent" }]
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "initialDataTemplate": {
+    "schema": "TokenDAO",
+    "name": "",
+    "tokenId": "",
+    "balances": {},
+    "delegations": {},
+    
+    "proposalThreshold": 1000,
+    "votingPeriodMs": 259200000,
+    "timelockMs": 86400000,
+    "quorum": 10000,
+    
+    "proposal": null,
+    "votes": null,
+    "executedProposals": [],
+    "rejectedProposals": [],
+    "cancelledProposals": [],
+    
+    "metadata": {},
+    "status": "ACTIVE"
+  },
+  "crossReferences": {
+    "Identity": "voter verification",
+    "Token": "balance snapshots",
+    "Contract": "action execution",
+    "Treasury": "fund management"
+  }
+}

--- a/docs/domains/governance/governance-constitution.json
+++ b/docs/domains/governance/governance-constitution.json
@@ -1,0 +1,247 @@
+{
+  "metadata": {
+    "name": "Constitution",
+    "description": "Foundational charter that defines governance structure, branch powers, and amendment rules",
+    "version": "1.0.0"
+  },
+  "states": {
+    "DRAFT": { "id": { "value": "DRAFT" }, "isFinal": false },
+    "RATIFIED": { "id": { "value": "RATIFIED" }, "isFinal": false },
+    "AMENDING": { "id": { "value": "AMENDING" }, "isFinal": false },
+    "SUSPENDED": { "id": { "value": "SUSPENDED" }, "isFinal": false },
+    "DISSOLVED": { "id": { "value": "DISSOLVED" }, "isFinal": true }
+  },
+  "initialState": { "value": "DRAFT" },
+  "transitions": [
+    {
+      "_comment": "Founders ratify the constitution",
+      "from": { "value": "DRAFT" },
+      "to": { "value": "RATIFIED" },
+      "eventName": "ratify",
+      "guard": {
+        ">=": [
+          { "size": { "var": "state.ratifications" } },
+          { "var": "state.ratificationThreshold" }
+        ]
+      },
+      "effect": {
+        "merge": [
+          { "var": "state" },
+          { "status": "RATIFIED", "ratifiedAt": { "var": "$timestamp" } }
+        ]
+      }
+    },
+    {
+      "_comment": "Founder signs ratification",
+      "from": { "value": "DRAFT" },
+      "to": { "value": "DRAFT" },
+      "eventName": "sign",
+      "guard": {
+        "and": [
+          { "in": [{ "var": "event.agent" }, { "var": "state.founders" }] },
+          { "!": { "in": [{ "var": "event.agent" }, { "var": "state.ratifications" }] } }
+        ]
+      },
+      "effect": {
+        "merge": [
+          { "var": "state" },
+          {
+            "ratifications": {
+              "cat": [{ "var": "state.ratifications" }, [{ "var": "event.agent" }]]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "Begin amendment process",
+      "from": { "value": "RATIFIED" },
+      "to": { "value": "AMENDING" },
+      "eventName": "propose_amendment",
+      "guard": {
+        "or": [
+          { "in": [{ "var": "event.agent" }, { "var": "state.branches.legislature.members" }] },
+          { ">=": [{ "var": "event.petitionSignatures" }, { "var": "state.amendmentPetitionThreshold" }] }
+        ]
+      },
+      "effect": {
+        "merge": [
+          { "var": "state" },
+          {
+            "status": "AMENDING",
+            "pendingAmendment": {
+              "id": { "var": "event.amendmentId" },
+              "proposer": { "var": "event.agent" },
+              "changes": { "var": "event.changes" },
+              "proposedAt": { "var": "$timestamp" },
+              "votes": {}
+            }
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "Amendment passes",
+      "from": { "value": "AMENDING" },
+      "to": { "value": "RATIFIED" },
+      "eventName": "ratify_amendment",
+      "guard": {
+        ">=": [
+          { "var": "state.pendingAmendment.approvalCount" },
+          { "var": "state.amendmentThreshold" }
+        ]
+      },
+      "effect": {
+        "merge": [
+          { "var": "state" },
+          {
+            "status": "RATIFIED",
+            "amendments": {
+              "cat": [
+                { "var": "state.amendments" },
+                [{
+                  "id": { "var": "state.pendingAmendment.id" },
+                  "changes": { "var": "state.pendingAmendment.changes" },
+                  "ratifiedAt": { "var": "$timestamp" }
+                }]
+              ]
+            },
+            "pendingAmendment": null
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "Amendment fails",
+      "from": { "value": "AMENDING" },
+      "to": { "value": "RATIFIED" },
+      "eventName": "reject_amendment",
+      "guard": { "var": "state.pendingAmendment.rejected" },
+      "effect": {
+        "merge": [
+          { "var": "state" },
+          {
+            "status": "RATIFIED",
+            "failedAmendments": {
+              "cat": [
+                { "var": "state.failedAmendments" },
+                [{ "var": "state.pendingAmendment" }]
+              ]
+            },
+            "pendingAmendment": null
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "Emergency suspension",
+      "from": { "value": "RATIFIED" },
+      "to": { "value": "SUSPENDED" },
+      "eventName": "suspend",
+      "guard": {
+        "and": [
+          { "in": [{ "var": "event.agent" }, { "var": "state.emergencyCouncil" }] },
+          { "var": "event.reason" }
+        ]
+      },
+      "effect": {
+        "merge": [
+          { "var": "state" },
+          {
+            "status": "SUSPENDED",
+            "suspendedBy": { "var": "event.agent" },
+            "suspensionReason": { "var": "event.reason" },
+            "suspendedAt": { "var": "$timestamp" }
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "Restore from suspension",
+      "from": { "value": "SUSPENDED" },
+      "to": { "value": "RATIFIED" },
+      "eventName": "restore",
+      "guard": {
+        ">=": [
+          { "var": "event.restorationVotes" },
+          { "var": "state.restorationThreshold" }
+        ]
+      },
+      "effect": {
+        "merge": [
+          { "var": "state" },
+          { "status": "RATIFIED", "restoredAt": { "var": "$timestamp" } }
+        ]
+      }
+    },
+    {
+      "_comment": "Dissolve the constitution entirely",
+      "from": { "value": "RATIFIED" },
+      "to": { "value": "DISSOLVED" },
+      "eventName": "dissolve",
+      "guard": {
+        ">=": [
+          { "var": "event.dissolutionVotes" },
+          { "var": "state.dissolutionThreshold" }
+        ]
+      },
+      "effect": {
+        "merge": [
+          { "var": "state" },
+          { "status": "DISSOLVED", "dissolvedAt": { "var": "$timestamp" } }
+        ]
+      }
+    }
+  ],
+  "initialDataTemplate": {
+    "schema": "Constitution",
+    
+    "name": "",
+    "preamble": "",
+    
+    "founders": [],
+    "ratifications": [],
+    "ratificationThreshold": 0,
+    
+    "branches": {
+      "legislature": {
+        "name": "Legislature",
+        "powers": ["propose_law", "vote_law", "impeach", "amend_constitution"],
+        "members": [],
+        "quorum": 0.5,
+        "passingThreshold": 0.5
+      },
+      "executive": {
+        "name": "Executive",
+        "powers": ["execute_law", "veto", "appoint", "emergency_action"],
+        "members": [],
+        "head": null
+      },
+      "judiciary": {
+        "name": "Judiciary",
+        "powers": ["interpret", "review", "overturn", "resolve_dispute"],
+        "members": [],
+        "quorum": 0.5
+      }
+    },
+    
+    "checksAndBalances": {
+      "executiveVeto": true,
+      "legislativeOverride": 0.67,
+      "judicialReview": true,
+      "impeachment": true
+    },
+    
+    "amendmentThreshold": 0.67,
+    "amendmentPetitionThreshold": 100,
+    "dissolutionThreshold": 0.9,
+    "restorationThreshold": 0.67,
+    "emergencyCouncil": [],
+    
+    "amendments": [],
+    "failedAmendments": [],
+    "pendingAmendment": null,
+    
+    "status": "DRAFT"
+  }
+}

--- a/docs/domains/governance/governance-executive.json
+++ b/docs/domains/governance/governance-executive.json
@@ -1,0 +1,241 @@
+{
+  "metadata": {
+    "name": "Executive",
+    "description": "Execution branch - implements mandates, manages operations, reports outcomes",
+    "version": "1.0.0"
+  },
+  "states": {
+    "RECEIVED": { "id": { "value": "RECEIVED" }, "isFinal": false },
+    "PLANNING": { "id": { "value": "PLANNING" }, "isFinal": false },
+    "EXECUTING": { "id": { "value": "EXECUTING" }, "isFinal": false },
+    "PAUSED": { "id": { "value": "PAUSED" }, "isFinal": false },
+    "COMPLETED": { "id": { "value": "COMPLETED" }, "isFinal": true },
+    "FAILED": { "id": { "value": "FAILED" }, "isFinal": true },
+    "BLOCKED": { "id": { "value": "BLOCKED" }, "isFinal": true },
+    "VETOED": { "id": { "value": "VETOED" }, "isFinal": true }
+  },
+  "initialState": { "value": "RECEIVED" },
+  "transitions": [
+    {
+      "_comment": "Executive receives mandate from legislature",
+      "from": { "value": "RECEIVED" },
+      "to": { "value": "PLANNING" },
+      "eventName": "accept",
+      "guard": {
+        "in": [{ "var": "event.agent" }, { "var": "state.executors" }]
+      },
+      "effect": {
+        "merge": [
+          { "var": "state" },
+          {
+            "status": "PLANNING",
+            "acceptedBy": { "var": "event.agent" },
+            "acceptedAt": { "var": "$timestamp" },
+            "plan": { "var": "event.plan" }
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "Executive vetoes mandate (if has veto power)",
+      "from": { "value": "RECEIVED" },
+      "to": { "value": "VETOED" },
+      "eventName": "veto",
+      "guard": {
+        "and": [
+          { "var": "state.config.executiveVeto" },
+          { "===": [{ "var": "event.agent" }, { "var": "state.executiveHead" }] }
+        ]
+      },
+      "effect": {
+        "merge": [
+          { "var": "state" },
+          {
+            "status": "VETOED",
+            "vetoedBy": { "var": "event.agent" },
+            "vetoReason": { "var": "event.reason" },
+            "vetoedAt": { "var": "$timestamp" }
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "Begin execution",
+      "from": { "value": "PLANNING" },
+      "to": { "value": "EXECUTING" },
+      "eventName": "begin",
+      "guard": {
+        "in": [{ "var": "event.agent" }, { "var": "state.executors" }]
+      },
+      "effect": {
+        "merge": [
+          { "var": "state" },
+          {
+            "status": "EXECUTING",
+            "executionStartedAt": { "var": "$timestamp" },
+            "milestones": []
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "Report progress milestone",
+      "from": { "value": "EXECUTING" },
+      "to": { "value": "EXECUTING" },
+      "eventName": "report_progress",
+      "guard": {
+        "in": [{ "var": "event.agent" }, { "var": "state.executors" }]
+      },
+      "effect": {
+        "merge": [
+          { "var": "state" },
+          {
+            "milestones": {
+              "cat": [
+                { "var": "state.milestones" },
+                [{
+                  "description": { "var": "event.description" },
+                  "completedAt": { "var": "$timestamp" },
+                  "evidence": { "var": "event.evidence" }
+                }]
+              ]
+            },
+            "lastProgressAt": { "var": "$timestamp" }
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "Pause execution (self or judiciary order)",
+      "from": { "value": "EXECUTING" },
+      "to": { "value": "PAUSED" },
+      "eventName": "pause",
+      "guard": {
+        "or": [
+          { "in": [{ "var": "event.agent" }, { "var": "state.executors" }] },
+          { "var": "event.judicialOrder" }
+        ]
+      },
+      "effect": {
+        "merge": [
+          { "var": "state" },
+          {
+            "status": "PAUSED",
+            "pausedBy": { "var": "event.agent" },
+            "pauseReason": { "var": "event.reason" },
+            "pausedAt": { "var": "$timestamp" },
+            "judicialHold": { "var": "event.judicialOrder" }
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "Resume from pause",
+      "from": { "value": "PAUSED" },
+      "to": { "value": "EXECUTING" },
+      "eventName": "resume",
+      "guard": {
+        "and": [
+          { "in": [{ "var": "event.agent" }, { "var": "state.executors" }] },
+          { "!": { "var": "state.judicialHold" } }
+        ]
+      },
+      "effect": {
+        "merge": [
+          { "var": "state" },
+          {
+            "status": "EXECUTING",
+            "resumedAt": { "var": "$timestamp" }
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "Judiciary blocks execution permanently",
+      "from": { "value": "PAUSED" },
+      "to": { "value": "BLOCKED" },
+      "eventName": "block",
+      "guard": { "var": "event.judicialRuling" },
+      "effect": {
+        "merge": [
+          { "var": "state" },
+          {
+            "status": "BLOCKED",
+            "blockedBy": { "var": "event.agent" },
+            "rulingId": { "var": "event.rulingId" },
+            "blockedAt": { "var": "$timestamp" }
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "Complete execution successfully",
+      "from": { "value": "EXECUTING" },
+      "to": { "value": "COMPLETED" },
+      "eventName": "complete",
+      "guard": {
+        "in": [{ "var": "event.agent" }, { "var": "state.executors" }]
+      },
+      "effect": {
+        "merge": [
+          { "var": "state" },
+          {
+            "status": "COMPLETED",
+            "completedAt": { "var": "$timestamp" },
+            "outcome": { "var": "event.outcome" },
+            "finalReport": { "var": "event.report" }
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "Execution fails",
+      "from": { "value": "EXECUTING" },
+      "to": { "value": "FAILED" },
+      "eventName": "fail",
+      "guard": {
+        "in": [{ "var": "event.agent" }, { "var": "state.executors" }]
+      },
+      "effect": {
+        "merge": [
+          { "var": "state" },
+          {
+            "status": "FAILED",
+            "failedAt": { "var": "$timestamp" },
+            "failureReason": { "var": "event.reason" }
+          }
+        ]
+      }
+    }
+  ],
+  "initialDataTemplate": {
+    "schema": "Executive",
+    
+    "mandateId": "",
+    "mandateFrom": "",
+    "mandate": {
+      "title": "",
+      "description": "",
+      "actions": [],
+      "deadline": null,
+      "budget": null
+    },
+    
+    "constitutionId": "",
+    "executiveHead": null,
+    "executors": [],
+    
+    "config": {
+      "executiveVeto": false,
+      "requirePlan": true,
+      "progressReportingInterval": null
+    },
+    
+    "plan": null,
+    "milestones": [],
+    "outcome": null,
+    "finalReport": null,
+    
+    "status": "RECEIVED"
+  }
+}

--- a/docs/domains/governance/governance-judiciary.json
+++ b/docs/domains/governance/governance-judiciary.json
@@ -1,0 +1,326 @@
+{
+  "metadata": {
+    "name": "Judiciary",
+    "description": "Judicial branch - interprets rules, reviews actions, resolves disputes, issues rulings",
+    "version": "1.0.0"
+  },
+  "states": {
+    "FILED": { "id": { "value": "FILED" }, "isFinal": false },
+    "REVIEW": { "id": { "value": "REVIEW" }, "isFinal": false },
+    "HEARING": { "id": { "value": "HEARING" }, "isFinal": false },
+    "DELIBERATION": { "id": { "value": "DELIBERATION" }, "isFinal": false },
+    "RULING": { "id": { "value": "RULING" }, "isFinal": false },
+    "ENFORCING": { "id": { "value": "ENFORCING" }, "isFinal": false },
+    "CLOSED": { "id": { "value": "CLOSED" }, "isFinal": true },
+    "DISMISSED": { "id": { "value": "DISMISSED" }, "isFinal": true },
+    "APPEALED": { "id": { "value": "APPEALED" }, "isFinal": false }
+  },
+  "initialState": { "value": "FILED" },
+  "transitions": [
+    {
+      "_comment": "Case accepted for review",
+      "from": { "value": "FILED" },
+      "to": { "value": "REVIEW" },
+      "eventName": "accept",
+      "guard": {
+        "in": [{ "var": "event.agent" }, { "var": "state.judges" }]
+      },
+      "effect": {
+        "merge": [
+          { "var": "state" },
+          {
+            "status": "REVIEW",
+            "acceptedBy": { "var": "event.agent" },
+            "acceptedAt": { "var": "$timestamp" },
+            "assignedJudges": { "var": "event.panel" }
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "Case dismissed (lacks standing, jurisdiction, or merit)",
+      "from": { "value": "FILED" },
+      "to": { "value": "DISMISSED" },
+      "eventName": "dismiss",
+      "guard": {
+        "in": [{ "var": "event.agent" }, { "var": "state.judges" }]
+      },
+      "effect": {
+        "merge": [
+          { "var": "state" },
+          {
+            "status": "DISMISSED",
+            "dismissedBy": { "var": "event.agent" },
+            "dismissReason": { "var": "event.reason" },
+            "dismissedAt": { "var": "$timestamp" }
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "Issue emergency stay/injunction",
+      "from": { "value": "REVIEW" },
+      "to": { "value": "REVIEW" },
+      "eventName": "issue_stay",
+      "guard": {
+        "in": [{ "var": "event.agent" }, { "var": "state.assignedJudges" }]
+      },
+      "effect": {
+        "merge": [
+          { "var": "state" },
+          {
+            "emergencyStay": {
+              "issuedBy": { "var": "event.agent" },
+              "issuedAt": { "var": "$timestamp" },
+              "targetFiberId": { "var": "event.targetFiberId" },
+              "reason": { "var": "event.reason" },
+              "expiresAt": { "var": "event.expiresAt" }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "Begin hearing phase",
+      "from": { "value": "REVIEW" },
+      "to": { "value": "HEARING" },
+      "eventName": "schedule_hearing",
+      "guard": {
+        "in": [{ "var": "event.agent" }, { "var": "state.assignedJudges" }]
+      },
+      "effect": {
+        "merge": [
+          { "var": "state" },
+          {
+            "status": "HEARING",
+            "hearingScheduledAt": { "var": "event.hearingDate" },
+            "submissions": []
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "Party submits evidence/argument",
+      "from": { "value": "HEARING" },
+      "to": { "value": "HEARING" },
+      "eventName": "submit_evidence",
+      "guard": {
+        "or": [
+          { "===": [{ "var": "event.agent" }, { "var": "state.plaintiff" }] },
+          { "===": [{ "var": "event.agent" }, { "var": "state.defendant" }] },
+          { "in": [{ "var": "event.agent" }, { "var": "state.interestedParties" }] }
+        ]
+      },
+      "effect": {
+        "merge": [
+          { "var": "state" },
+          {
+            "submissions": {
+              "cat": [
+                { "var": "state.submissions" },
+                [{
+                  "party": { "var": "event.agent" },
+                  "type": { "var": "event.type" },
+                  "content": { "var": "event.content" },
+                  "submittedAt": { "var": "$timestamp" }
+                }]
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "Close hearing, begin deliberation",
+      "from": { "value": "HEARING" },
+      "to": { "value": "DELIBERATION" },
+      "eventName": "close_hearing",
+      "guard": {
+        "in": [{ "var": "event.agent" }, { "var": "state.assignedJudges" }]
+      },
+      "effect": {
+        "merge": [
+          { "var": "state" },
+          {
+            "status": "DELIBERATION",
+            "hearingClosedAt": { "var": "$timestamp" },
+            "votes": {}
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "Judge casts vote during deliberation",
+      "from": { "value": "DELIBERATION" },
+      "to": { "value": "DELIBERATION" },
+      "eventName": "vote",
+      "guard": {
+        "and": [
+          { "in": [{ "var": "event.agent" }, { "var": "state.assignedJudges" }] },
+          { "!": { "getKey": [{ "var": "state.votes" }, { "var": "event.agent" }] } }
+        ]
+      },
+      "effect": {
+        "merge": [
+          { "var": "state" },
+          {
+            "votes": {
+              "setKey": [
+                { "var": "state.votes" },
+                { "var": "event.agent" },
+                {
+                  "position": { "var": "event.position" },
+                  "opinion": { "var": "event.opinion" },
+                  "votedAt": { "var": "$timestamp" }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "Issue ruling after deliberation",
+      "from": { "value": "DELIBERATION" },
+      "to": { "value": "RULING" },
+      "eventName": "issue_ruling",
+      "guard": {
+        ">=": [
+          { "size": { "var": "state.votes" } },
+          { "var": "state.quorum" }
+        ]
+      },
+      "effect": {
+        "merge": [
+          { "var": "state" },
+          {
+            "status": "RULING",
+            "ruling": {
+              "decision": { "var": "event.decision" },
+              "majority": { "var": "event.majority" },
+              "dissent": { "var": "event.dissent" },
+              "remedy": { "var": "event.remedy" },
+              "issuedAt": { "var": "$timestamp" }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "Ruling requires enforcement action",
+      "from": { "value": "RULING" },
+      "to": { "value": "ENFORCING" },
+      "eventName": "begin_enforcement",
+      "guard": { "var": "state.ruling.remedy" },
+      "effect": {
+        "merge": [
+          { "var": "state" },
+          {
+            "status": "ENFORCING",
+            "enforcementStartedAt": { "var": "$timestamp" }
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "Case closed after enforcement or no remedy needed",
+      "from": { "value": "RULING" },
+      "to": { "value": "CLOSED" },
+      "eventName": "close",
+      "guard": { "!": { "var": "state.ruling.remedy" } },
+      "effect": {
+        "merge": [
+          { "var": "state" },
+          { "status": "CLOSED", "closedAt": { "var": "$timestamp" } }
+        ]
+      }
+    },
+    {
+      "_comment": "Enforcement complete",
+      "from": { "value": "ENFORCING" },
+      "to": { "value": "CLOSED" },
+      "eventName": "enforcement_complete",
+      "guard": { "var": "event.evidence" },
+      "effect": {
+        "merge": [
+          { "var": "state" },
+          {
+            "status": "CLOSED",
+            "enforcementCompletedAt": { "var": "$timestamp" },
+            "enforcementEvidence": { "var": "event.evidence" }
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "Party appeals ruling",
+      "from": { "value": "RULING" },
+      "to": { "value": "APPEALED" },
+      "eventName": "appeal",
+      "guard": {
+        "and": [
+          { "var": "state.config.allowAppeals" },
+          { "or": [
+            { "===": [{ "var": "event.agent" }, { "var": "state.plaintiff" }] },
+            { "===": [{ "var": "event.agent" }, { "var": "state.defendant" }] }
+          ]},
+          { "<=": [
+            { "-": [{ "var": "$timestamp" }, { "var": "state.ruling.issuedAt" }] },
+            { "var": "state.config.appealWindowMs" }
+          ]}
+        ]
+      },
+      "effect": {
+        "merge": [
+          { "var": "state" },
+          {
+            "status": "APPEALED",
+            "appeal": {
+              "filedBy": { "var": "event.agent" },
+              "grounds": { "var": "event.grounds" },
+              "filedAt": { "var": "$timestamp" }
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "initialDataTemplate": {
+    "schema": "Judiciary",
+    
+    "caseType": "dispute | challenge | interpretation | review",
+    "caseNumber": "",
+    
+    "plaintiff": null,
+    "defendant": null,
+    "interestedParties": [],
+    
+    "claim": {
+      "summary": "",
+      "facts": [],
+      "legalBasis": [],
+      "reliefSought": []
+    },
+    
+    "targetFiberId": null,
+    "constitutionId": null,
+    
+    "judges": [],
+    "assignedJudges": [],
+    "quorum": 1,
+    
+    "config": {
+      "allowAppeals": true,
+      "appealWindowMs": 604800000,
+      "expedited": false
+    },
+    
+    "emergencyStay": null,
+    "submissions": [],
+    "votes": {},
+    "ruling": null,
+    "appeal": null,
+    
+    "status": "FILED"
+  }
+}

--- a/docs/domains/governance/governance-legislature.json
+++ b/docs/domains/governance/governance-legislature.json
@@ -1,0 +1,397 @@
+{
+  "metadata": {
+    "name": "Governance",
+    "description": "Flexible governance for proposals, voting, delegation, and execution across relationship types",
+    "version": "1.0.0"
+  },
+  "states": {
+    "DRAFT": { "id": { "value": "DRAFT" }, "isFinal": false },
+    "ACTIVE": { "id": { "value": "ACTIVE" }, "isFinal": false },
+    "PENDING": { "id": { "value": "PENDING" }, "isFinal": false },
+    "EXECUTING": { "id": { "value": "EXECUTING" }, "isFinal": false },
+    "EXECUTED": { "id": { "value": "EXECUTED" }, "isFinal": true },
+    "VETOED": { "id": { "value": "VETOED" }, "isFinal": true },
+    "DEFEATED": { "id": { "value": "DEFEATED" }, "isFinal": true },
+    "EXPIRED": { "id": { "value": "EXPIRED" }, "isFinal": true },
+    "CANCELLED": { "id": { "value": "CANCELLED" }, "isFinal": true }
+  },
+  "initialState": { "value": "DRAFT" },
+  "transitions": [
+    {
+      "_comment": "Proposer submits proposal for voting",
+      "from": { "value": "DRAFT" },
+      "to": { "value": "ACTIVE" },
+      "eventName": "submit",
+      "guard": {
+        "and": [
+          { "in": [{ "var": "event.agent" }, { "var": "state.proposers" }] },
+          { "var": "state.proposal.title" },
+          { "var": "state.proposal.actions" }
+        ]
+      },
+      "effect": {
+        "merge": [
+          { "var": "state" },
+          {
+            "status": "ACTIVE",
+            "submittedAt": { "var": "$timestamp" },
+            "votingEndsAt": { "+": [{ "var": "$timestamp" }, { "var": "state.config.votingPeriodMs" }] }
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "Cast vote (supports multiple voting mechanisms)",
+      "from": { "value": "ACTIVE" },
+      "to": { "value": "ACTIVE" },
+      "eventName": "vote",
+      "guard": {
+        "and": [
+          { "<=": [{ "var": "$timestamp" }, { "var": "state.votingEndsAt" }] },
+          { "!": { "getKey": [{ "var": "state.votes" }, { "var": "event.agent" }] } },
+          { "or": [
+            { "in": [{ "var": "event.agent" }, { "var": "state.voters" }] },
+            { "===": [{ "var": "state.config.openVoting" }, true] }
+          ]}
+        ]
+      },
+      "effect": {
+        "merge": [
+          { "var": "state" },
+          {
+            "votes": {
+              "setKey": [
+                { "var": "state.votes" },
+                { "var": "event.agent" },
+                {
+                  "choice": { "var": "event.choice" },
+                  "weight": { "var": "event.weight" },
+                  "conviction": { "var": "event.conviction" },
+                  "delegatedFrom": { "var": "event.delegatedFrom" },
+                  "votedAt": { "var": "$timestamp" }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "Delegate voting power to another address",
+      "from": { "value": "ACTIVE" },
+      "to": { "value": "ACTIVE" },
+      "eventName": "delegate",
+      "guard": {
+        "and": [
+          { "var": "state.config.allowDelegation" },
+          { "!==": [{ "var": "event.agent" }, { "var": "event.delegateTo" }] },
+          { "!": { "getKey": [{ "var": "state.votes" }, { "var": "event.agent" }] } }
+        ]
+      },
+      "effect": {
+        "merge": [
+          { "var": "state" },
+          {
+            "delegations": {
+              "setKey": [
+                { "var": "state.delegations" },
+                { "var": "event.agent" },
+                {
+                  "delegateTo": { "var": "event.delegateTo" },
+                  "weight": { "var": "event.weight" },
+                  "delegatedAt": { "var": "$timestamp" }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "Voting period ends, tally and move to pending/defeated",
+      "from": { "value": "ACTIVE" },
+      "to": { "value": "PENDING" },
+      "eventName": "finalize_voting",
+      "guard": {
+        "and": [
+          { ">=": [{ "var": "$timestamp" }, { "var": "state.votingEndsAt" }] },
+          { "var": "state.tally.passed" }
+        ]
+      },
+      "effect": {
+        "merge": [
+          { "var": "state" },
+          {
+            "status": "PENDING",
+            "finalizedAt": { "var": "$timestamp" },
+            "vetoEndsAt": { "+": [{ "var": "$timestamp" }, { "var": "state.config.vetoPeriodMs" }] }
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "Voting failed - quorum not met or majority against",
+      "from": { "value": "ACTIVE" },
+      "to": { "value": "DEFEATED" },
+      "eventName": "finalize_voting",
+      "guard": {
+        "and": [
+          { ">=": [{ "var": "$timestamp" }, { "var": "state.votingEndsAt" }] },
+          { "!": { "var": "state.tally.passed" } }
+        ]
+      },
+      "effect": {
+        "merge": [
+          { "var": "state" },
+          {
+            "status": "DEFEATED",
+            "finalizedAt": { "var": "$timestamp" },
+            "defeatReason": { "var": "state.tally.reason" }
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "Vetoer blocks execution during veto period",
+      "from": { "value": "PENDING" },
+      "to": { "value": "VETOED" },
+      "eventName": "veto",
+      "guard": {
+        "and": [
+          { "<=": [{ "var": "$timestamp" }, { "var": "state.vetoEndsAt" }] },
+          { "in": [{ "var": "event.agent" }, { "var": "state.vetoers" }] }
+        ]
+      },
+      "effect": {
+        "merge": [
+          { "var": "state" },
+          {
+            "status": "VETOED",
+            "vetoedBy": { "var": "event.agent" },
+            "vetoReason": { "var": "event.reason" },
+            "vetoedAt": { "var": "$timestamp" }
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "Begin execution after veto period",
+      "from": { "value": "PENDING" },
+      "to": { "value": "EXECUTING" },
+      "eventName": "execute",
+      "guard": {
+        "and": [
+          { ">=": [{ "var": "$timestamp" }, { "var": "state.vetoEndsAt" }] },
+          { "in": [{ "var": "event.agent" }, { "var": "state.executors" }] }
+        ]
+      },
+      "effect": {
+        "merge": [
+          { "var": "state" },
+          {
+            "status": "EXECUTING",
+            "executedBy": { "var": "event.agent" },
+            "executionStartedAt": { "var": "$timestamp" }
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "Mark execution complete",
+      "from": { "value": "EXECUTING" },
+      "to": { "value": "EXECUTED" },
+      "eventName": "complete",
+      "guard": {
+        "in": [{ "var": "event.agent" }, { "var": "state.executors" }]
+      },
+      "effect": {
+        "merge": [
+          { "var": "state" },
+          {
+            "status": "EXECUTED",
+            "completedAt": { "var": "$timestamp" },
+            "executionProof": { "var": "event.proof" }
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "Proposer cancels before voting ends",
+      "from": { "value": "DRAFT" },
+      "to": { "value": "CANCELLED" },
+      "eventName": "cancel",
+      "guard": {
+        "===": [{ "var": "event.agent" }, { "var": "state.proposer" }]
+      },
+      "effect": {
+        "merge": [
+          { "var": "state" },
+          { "status": "CANCELLED", "cancelledAt": { "var": "$timestamp" } }
+        ]
+      }
+    },
+    {
+      "_comment": "Cancel from active (proposer or admin)",
+      "from": { "value": "ACTIVE" },
+      "to": { "value": "CANCELLED" },
+      "eventName": "cancel",
+      "guard": {
+        "or": [
+          { "===": [{ "var": "event.agent" }, { "var": "state.proposer" }] },
+          { "in": [{ "var": "event.agent" }, { "var": "state.admins" }] }
+        ]
+      },
+      "effect": {
+        "merge": [
+          { "var": "state" },
+          {
+            "status": "CANCELLED",
+            "cancelledBy": { "var": "event.agent" },
+            "cancelledAt": { "var": "$timestamp" }
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "Expire if not finalized in time",
+      "from": { "value": "ACTIVE" },
+      "to": { "value": "EXPIRED" },
+      "eventName": "expire",
+      "guard": {
+        ">": [{ "var": "$timestamp" }, { "+": [{ "var": "state.votingEndsAt" }, { "var": "state.config.gracePeriodMs" }] }]
+      },
+      "effect": {
+        "merge": [
+          { "var": "state" },
+          { "status": "EXPIRED", "expiredAt": { "var": "$timestamp" } }
+        ]
+      }
+    }
+  ],
+  "initialDataTemplate": {
+    "_comment": "Template for creating governance proposals",
+    "schema": "Governance",
+    
+    "governanceType": "dao | multisig | council | bilateral | dictator",
+    
+    "proposal": {
+      "title": "",
+      "description": "",
+      "discussionUrl": "",
+      "actions": []
+    },
+    
+    "config": {
+      "votingMechanism": "simple | supermajority | quadratic | conviction | ranked",
+      "quorumType": "percentage | absolute",
+      "quorumValue": 0.1,
+      "passingThreshold": 0.5,
+      "votingPeriodMs": 259200000,
+      "vetoPeriodMs": 86400000,
+      "gracePeriodMs": 86400000,
+      "allowDelegation": true,
+      "openVoting": false,
+      "onePersonOneVote": false,
+      "convictionHalfLifeMs": 604800000
+    },
+    
+    "roles": {
+      "_comment": "Role arrays - empty means open/unrestricted",
+      "proposers": [],
+      "voters": [],
+      "executors": [],
+      "vetoers": [],
+      "admins": []
+    },
+    
+    "votes": {},
+    "delegations": {},
+    "tally": {
+      "for": 0,
+      "against": 0,
+      "abstain": 0,
+      "quorumReached": false,
+      "passed": false
+    },
+    
+    "status": "DRAFT"
+  },
+  
+  "presets": {
+    "_comment": "Common governance configurations",
+    
+    "bilateral": {
+      "description": "Two-party mutual consent (like a contract)",
+      "config": {
+        "votingMechanism": "simple",
+        "quorumType": "absolute",
+        "quorumValue": 2,
+        "passingThreshold": 1.0,
+        "allowDelegation": false,
+        "openVoting": false
+      }
+    },
+    
+    "multisig": {
+      "description": "N-of-M threshold signing",
+      "config": {
+        "votingMechanism": "simple",
+        "quorumType": "absolute",
+        "passingThreshold": 0.6,
+        "vetoPeriodMs": 0,
+        "allowDelegation": false
+      }
+    },
+    
+    "council": {
+      "description": "Small elected/appointed body",
+      "config": {
+        "votingMechanism": "simple",
+        "quorumType": "percentage",
+        "quorumValue": 0.5,
+        "passingThreshold": 0.5,
+        "openVoting": false,
+        "allowDelegation": true
+      }
+    },
+    
+    "liquid_democracy": {
+      "description": "Delegatable voting power",
+      "config": {
+        "votingMechanism": "simple",
+        "allowDelegation": true,
+        "openVoting": true,
+        "onePersonOneVote": true
+      }
+    },
+    
+    "conviction": {
+      "description": "Time-weighted conviction voting",
+      "config": {
+        "votingMechanism": "conviction",
+        "allowDelegation": true,
+        "convictionHalfLifeMs": 604800000
+      }
+    },
+    
+    "quadratic": {
+      "description": "Quadratic voting to reduce whale power",
+      "config": {
+        "votingMechanism": "quadratic",
+        "onePersonOneVote": false
+      }
+    },
+    
+    "dictator": {
+      "description": "Single admin with full control",
+      "config": {
+        "votingMechanism": "simple",
+        "quorumType": "absolute",
+        "quorumValue": 1,
+        "passingThreshold": 1.0,
+        "vetoPeriodMs": 0,
+        "allowDelegation": false
+      }
+    }
+  }
+}

--- a/docs/domains/governance/governance-simple.json
+++ b/docs/domains/governance/governance-simple.json
@@ -1,0 +1,323 @@
+{
+  "metadata": {
+    "name": "Governance",
+    "description": "Simple org governance: manage members, update rules, resolve disputes",
+    "version": "1.0.0"
+  },
+  "states": {
+    "ACTIVE": { "id": { "value": "ACTIVE" }, "isFinal": false },
+    "VOTING": { "id": { "value": "VOTING" }, "isFinal": false },
+    "DISPUTE": { "id": { "value": "DISPUTE" }, "isFinal": false },
+    "DISSOLVED": { "id": { "value": "DISSOLVED" }, "isFinal": true }
+  },
+  "initialState": { "value": "ACTIVE" },
+  "transitions": [
+    {
+      "_comment": "Add member",
+      "from": { "value": "ACTIVE" },
+      "to": { "value": "ACTIVE" },
+      "eventName": "add_member",
+      "guard": {
+        "in": [{ "var": "event.agent" }, { "var": "state.admins" }]
+      },
+      "effect": {
+        "merge": [
+          { "var": "state" },
+          {
+            "members": {
+              "setKey": [
+                { "var": "state.members" },
+                { "var": "event.member" },
+                { "role": { "var": "event.role" }, "addedAt": { "var": "$timestamp" } }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "Remove member",
+      "from": { "value": "ACTIVE" },
+      "to": { "value": "ACTIVE" },
+      "eventName": "remove_member",
+      "guard": {
+        "in": [{ "var": "event.agent" }, { "var": "state.admins" }]
+      },
+      "effect": {
+        "merge": [
+          { "var": "state" },
+          {
+            "members": {
+              "deleteKey": [{ "var": "state.members" }, { "var": "event.member" }]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "Propose rule change",
+      "from": { "value": "ACTIVE" },
+      "to": { "value": "VOTING" },
+      "eventName": "propose",
+      "guard": {
+        "getKey": [{ "var": "state.members" }, { "var": "event.agent" }]
+      },
+      "effect": {
+        "merge": [
+          { "var": "state" },
+          {
+            "proposal": {
+              "id": { "var": "event.proposalId" },
+              "type": { "var": "event.type" },
+              "changes": { "var": "event.changes" },
+              "proposer": { "var": "event.agent" },
+              "proposedAt": { "var": "$timestamp" },
+              "deadline": { "+": [{ "var": "$timestamp" }, { "var": "state.votingPeriodMs" }] }
+            },
+            "votes": {}
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "Cast vote",
+      "from": { "value": "VOTING" },
+      "to": { "value": "VOTING" },
+      "eventName": "vote",
+      "guard": {
+        "and": [
+          { "getKey": [{ "var": "state.members" }, { "var": "event.agent" }] },
+          { "!": { "getKey": [{ "var": "state.votes" }, { "var": "event.agent" }] } }
+        ]
+      },
+      "effect": {
+        "merge": [
+          { "var": "state" },
+          {
+            "votes": {
+              "setKey": [
+                { "var": "state.votes" },
+                { "var": "event.agent" },
+                { "vote": { "var": "event.vote" }, "votedAt": { "var": "$timestamp" } }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "Finalize vote - passes",
+      "from": { "value": "VOTING" },
+      "to": { "value": "ACTIVE" },
+      "eventName": "finalize",
+      "guard": {
+        ">=": [
+          { "var": "event.forCount" },
+          { "*": [{ "size": { "var": "state.members" } }, { "var": "state.passingThreshold" }] }
+        ]
+      },
+      "effect": {
+        "merge": [
+          { "var": "state" },
+          {
+            "rules": { "merge": [{ "var": "state.rules" }, { "var": "state.proposal.changes" }] },
+            "history": {
+              "cat": [
+                { "var": "state.history" },
+                [{
+                  "type": "rule_change",
+                  "proposal": { "var": "state.proposal" },
+                  "outcome": "passed",
+                  "finalizedAt": { "var": "$timestamp" }
+                }]
+              ]
+            },
+            "proposal": null,
+            "votes": {}
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "Finalize vote - fails",
+      "from": { "value": "VOTING" },
+      "to": { "value": "ACTIVE" },
+      "eventName": "finalize",
+      "guard": {
+        "<": [
+          { "var": "event.forCount" },
+          { "*": [{ "size": { "var": "state.members" } }, { "var": "state.passingThreshold" }] }
+        ]
+      },
+      "effect": {
+        "merge": [
+          { "var": "state" },
+          {
+            "history": {
+              "cat": [
+                { "var": "state.history" },
+                [{
+                  "type": "rule_change",
+                  "proposal": { "var": "state.proposal" },
+                  "outcome": "failed",
+                  "finalizedAt": { "var": "$timestamp" }
+                }]
+              ]
+            },
+            "proposal": null,
+            "votes": {}
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "File dispute",
+      "from": { "value": "ACTIVE" },
+      "to": { "value": "DISPUTE" },
+      "eventName": "file_dispute",
+      "guard": {
+        "getKey": [{ "var": "state.members" }, { "var": "event.agent" }]
+      },
+      "effect": {
+        "merge": [
+          { "var": "state" },
+          {
+            "dispute": {
+              "id": { "var": "event.disputeId" },
+              "plaintiff": { "var": "event.agent" },
+              "defendant": { "var": "event.defendant" },
+              "claim": { "var": "event.claim" },
+              "filedAt": { "var": "$timestamp" },
+              "evidence": []
+            },
+            "votes": {}
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "Submit evidence",
+      "from": { "value": "DISPUTE" },
+      "to": { "value": "DISPUTE" },
+      "eventName": "submit_evidence",
+      "guard": {
+        "or": [
+          { "===": [{ "var": "event.agent" }, { "var": "state.dispute.plaintiff" }] },
+          { "===": [{ "var": "event.agent" }, { "var": "state.dispute.defendant" }] }
+        ]
+      },
+      "effect": {
+        "merge": [
+          { "var": "state" },
+          {
+            "dispute": {
+              "merge": [
+                { "var": "state.dispute" },
+                {
+                  "evidence": {
+                    "cat": [
+                      { "var": "state.dispute.evidence" },
+                      [{ "from": { "var": "event.agent" }, "content": { "var": "event.content" }, "at": { "var": "$timestamp" } }]
+                    ]
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "Vote on dispute",
+      "from": { "value": "DISPUTE" },
+      "to": { "value": "DISPUTE" },
+      "eventName": "vote",
+      "guard": {
+        "and": [
+          { "getKey": [{ "var": "state.members" }, { "var": "event.agent" }] },
+          { "!==": [{ "var": "event.agent" }, { "var": "state.dispute.plaintiff" }] },
+          { "!==": [{ "var": "event.agent" }, { "var": "state.dispute.defendant" }] },
+          { "!": { "getKey": [{ "var": "state.votes" }, { "var": "event.agent" }] } }
+        ]
+      },
+      "effect": {
+        "merge": [
+          { "var": "state" },
+          {
+            "votes": {
+              "setKey": [
+                { "var": "state.votes" },
+                { "var": "event.agent" },
+                { "ruling": { "var": "event.ruling" }, "votedAt": { "var": "$timestamp" } }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "Resolve dispute",
+      "from": { "value": "DISPUTE" },
+      "to": { "value": "ACTIVE" },
+      "eventName": "resolve",
+      "guard": {
+        ">=": [{ "size": { "var": "state.votes" } }, { "var": "state.disputeQuorum" }]
+      },
+      "effect": {
+        "merge": [
+          { "var": "state" },
+          {
+            "history": {
+              "cat": [
+                { "var": "state.history" },
+                [{
+                  "type": "dispute",
+                  "dispute": { "var": "state.dispute" },
+                  "ruling": { "var": "event.ruling" },
+                  "remedy": { "var": "event.remedy" },
+                  "resolvedAt": { "var": "$timestamp" }
+                }]
+              ]
+            },
+            "dispute": null,
+            "votes": {}
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "Dissolve org",
+      "from": { "value": "ACTIVE" },
+      "to": { "value": "DISSOLVED" },
+      "eventName": "dissolve",
+      "guard": {
+        ">=": [{ "var": "event.approvalCount" }, { "*": [{ "size": { "var": "state.members" } }, 0.9] }]
+      },
+      "effect": {
+        "merge": [
+          { "var": "state" },
+          { "dissolvedAt": { "var": "$timestamp" } }
+        ]
+      }
+    }
+  ],
+  "initialDataTemplate": {
+    "schema": "Governance",
+    
+    "name": "",
+    "admins": [],
+    "members": {},
+    "rules": {},
+    
+    "votingPeriodMs": 604800000,
+    "passingThreshold": 0.5,
+    "disputeQuorum": 3,
+    
+    "proposal": null,
+    "dispute": null,
+    "votes": {},
+    "history": [],
+    
+    "status": "ACTIVE"
+  }
+}


### PR DESCRIPTION
Adds documentation for the governance domain - DAO variants and constitutional governance.

## Contents
- `docs/domains/governance/GOVERNANCE.md` - Overview and usage
- `docs/domains/governance/*.json` - State machine definitions

## DAO Types
- Token DAO (token-weighted voting)
- Multisig DAO (N-of-M signatures)
- Threshold DAO (reputation-based)
- Single DAO (simple majority)

## Constitutional Governance
- Legislature (bills, committees, floor voting)
- Executive (appointments, orders, veto)
- Judiciary (cases, hearings, appeals)
- Constitution (amendments, ratification)
- Simple (basic member voting)

**Note:** SDK models (protobuf/TypeScript) will be in ottochain-sdk.