### PR TITLE
feat(ml0): add rejection notification dispatch for failed validations

### DIFF
--- a/modules/l0/src/main/scala/xyz/kd5ujc/metagraph_l0/webhooks/Subscriber.scala
+++ b/modules/l0/src/main/scala/xyz/kd5ujc/metagraph_l0/webhooks/Subscriber.scala
@@ -89,3 +89,47 @@ case class NotificationStats(
 object NotificationStats {
   implicit val encoder: Encoder[NotificationStats] = deriveEncoder[NotificationStats]
 }
+
+/**
+ * Rejection notification payload sent to subscribers when ML0 validation fails.
+ * This surfaces transactions that were accepted by DL1 but rejected at ML0
+ * due to contextual validation (ownership, state checks, etc.)
+ */
+case class RejectionNotification(
+  event:       String,
+  ordinal:     Long,
+  timestamp:   Instant,
+  metagraphId: String,
+  rejection:   RejectedUpdate
+)
+
+object RejectionNotification {
+  implicit val encoder: Encoder[RejectionNotification] = deriveEncoder[RejectionNotification]
+}
+
+/**
+ * Details of a rejected transaction update
+ */
+case class RejectedUpdate(
+  updateType: String, // "CreateStateMachine", "TransitionStateMachine", etc.
+  fiberId:    String, // UUID of target fiber
+  errors:     List[ValidationErrorInfo],
+  signers:    List[String], // DAG addresses from signature proofs
+  updateHash: String // Hash of the signed update for dedup
+)
+
+object RejectedUpdate {
+  implicit val encoder: Encoder[RejectedUpdate] = deriveEncoder[RejectedUpdate]
+}
+
+/**
+ * Validation error details
+ */
+case class ValidationErrorInfo(
+  code:    String, // Error class name e.g. "FiberNotActive", "NotSignedByOwner"
+  message: String // Human-readable error message
+)
+
+object ValidationErrorInfo {
+  implicit val encoder: Encoder[ValidationErrorInfo] = deriveEncoder[ValidationErrorInfo]
+}


### PR DESCRIPTION
## Summary

Extends the webhook system to notify subscribers when ML0 validation fails. This surfaces transactions that were accepted by DL1 but rejected at ML0 due to contextual validation (ownership checks, state verification, etc.).

## Problem

Users submitting transactions have no visibility when their transaction is:
1. Accepted by Data L1 (DL1) - structural validation passes
2. Rejected by Metagraph L0 (ML0) - contextual validation fails

This creates a poor UX where transactions silently disappear.

## Solution

Add a `transaction.rejected` webhook notification that dispatches alongside `snapshot.finalized`, using the same subscriber infrastructure.

## Changes

### Subscriber.scala
- Add `RejectionNotification` case class
- Add `RejectedUpdate` with updateType, fiberId, errors, signers, updateHash
- Add `ValidationErrorInfo` with code and message

### WebhookDispatcher.scala
- Add `dispatchRejection` method to trait
- Implement rejection dispatch to all active subscribers
- Extract signer addresses from signature proofs
- Fire-and-forget delivery (non-blocking)

### ML0Service.scala
- Wrap `validateData` to capture per-update validation results
- Dispatch rejection notifications for failed validations
- Preserve existing validation behavior

## Rejection Notification Payload

```json
{
  "event": "transaction.rejected",
  "ordinal": 12345,
  "timestamp": "2026-02-07T22:00:00Z",
  "metagraphId": "DAG3KNy...",
  "rejection": {
    "updateType": "TransitionStateMachine",
    "fiberId": "550e8400-e29b-41d4-a716-446655440000",
    "errors": [
      { "code": "NotSignedByOwner", "message": "Update not signed by any fiber owner" }
    ],
    "signers": ["DAG4abc..."],
    "updateHash": "1a2b3c4d"
  }
}
```

## Testing

- All 223 existing tests pass
- Compilation verified with `sbt currencyL0/compile`

## Epic

This is card 1 of 6 in the Rejection Notifications epic:
1. **[This PR]** ML0 rejection dispatch
2. Indexer rejection handler
3. Rejections API endpoints
4. Explorer rejections page
5. Deploy updates
6. E2E testing

Trello: https://trello.com/c/SkMFKjwC