### PR TITLE
feat: multi-party fiber signing [A2+A3]

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owners for all files
+* @scasplte2

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+## Changes
+- 
+
+## Type
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Infrastructure/config change
+- [ ] Documentation
+
+## Testing
+- [ ] Tested locally
+- [ ] CI passes
+
+## Deployment Notes
+<!-- Any special steps needed after merge? -->

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -44,9 +44,11 @@ jobs:
           git clone --depth 1 --branch "v${TESSELLATION_VERSION}" \
             https://github.com/Constellation-Labs/tessellation.git tessellation
 
-      - name: Apply tessellation compile fix
+      - name: Apply tessellation patches
         working-directory: tessellation
-        run: git apply ../e2e-test/patches/v4.0.0-rc.2-compile-fix.patch
+        run: |
+          git apply ../e2e-test/patches/v4.0.0-rc.2-compile-fix.patch
+          git apply ../e2e-test/patches/v4.0.0-rc.2-java21-deps.patch
 
       - name: Start cluster
         working-directory: tessellation
@@ -74,12 +76,6 @@ jobs:
           wait_for_node "DL1-0" 9400
           wait_for_node "DL1-1" 9410
           wait_for_node "DL1-2" 9420
-
-      - name: Build SDK
-        working-directory: sdk
-        run: |
-          npm install
-          npm run build
 
       - name: Install E2E dependencies
         working-directory: e2e-test

--- a/build.sbt
+++ b/build.sbt
@@ -8,6 +8,7 @@ ThisBuild / evictionErrorLevel := Level.Warn
 
 ThisBuild / assemblyMergeStrategy := {
   case "logback.xml" => MergeStrategy.first
+  case "dag-l1.conf" => MergeStrategy.first
   case x if x.contains("io.netty.versions.properties") => MergeStrategy.discard
   case PathList("xyz", "kd5ujc", "buildinfo", xs @ _*) => MergeStrategy.first
   case PathList(xs@_*) if xs.last == "module-info.class" => MergeStrategy.first

--- a/deploy/DEPLOY-FROM-SCRATCH.md
+++ b/deploy/DEPLOY-FROM-SCRATCH.md
@@ -1,0 +1,774 @@
+# OttoChain: Complete Deployment from Scratch
+
+**Tested:** 2026-02-04
+**Tessellation:** v4.0.0-rc.2
+**OttoChain:** metakit 1.7.0-rc.4
+
+## Prerequisites
+
+- 2 Hetzner servers (or similar):
+  - **Metagraph Node**: 4+ CPU, 8GB+ RAM (runs GL0, ML0, CL1×3, DL1×3)
+  - **Services Node**: 2+ CPU, 4GB+ RAM (runs Bridge, Indexer, Gateway, Explorer, Postgres, Redis)
+- Ubuntu 22.04 LTS
+- Docker installed on both
+- Ports open: 9000-9422 (metagraph), 3030-8080 (services)
+
+## Part 1: Metagraph Node Setup
+
+### 1.1 SSH to Metagraph Node
+
+```bash
+ssh root@<METAGRAPH_IP>
+```
+
+### 1.2 Install Dependencies
+
+```bash
+apt update && apt install -y docker.io curl jq
+systemctl enable docker && systemctl start docker
+```
+
+### 1.3 Create Directory Structure
+
+```bash
+mkdir -p /opt/ottochain/{jars,keys1,keys2,keys3,keys4,data/{gl0,ml0,cl1,cl1-2,cl1-3,dl1,dl1-2,dl1-3}}
+cd /opt/ottochain
+```
+
+### 1.4 Download Tessellation Tools
+
+```bash
+cd /opt/ottochain/jars
+TESS_VERSION="v4.0.0-rc.2"
+
+# Download keytool and wallet
+curl -L -o cl-keytool.jar "https://github.com/Constellation-Labs/tessellation/releases/download/${TESS_VERSION}/cl-keytool.jar"
+curl -L -o cl-wallet.jar "https://github.com/Constellation-Labs/tessellation/releases/download/${TESS_VERSION}/cl-wallet.jar"
+
+# Download global-l0 (needed for standalone GL0)
+curl -L -o global-l0.jar "https://github.com/Constellation-Labs/tessellation/releases/download/${TESS_VERSION}/cl-dag-l1.jar"
+```
+
+### 1.5 Build OttoChain JARs (on dev machine)
+
+```bash
+# On your dev machine with sbt installed
+cd /path/to/ottochain
+source ~/.sdkman/bin/sdkman-init.sh  # Ensure Java 21
+
+sbt "l0/assembly" "l1/assembly" "dataL1/assembly"
+
+# Copy JARs to server
+scp modules/l0/target/scala-2.13/*-assembly-*.jar root@<METAGRAPH_IP>:/opt/ottochain/jars/metagraph-l0.jar
+scp modules/l1/target/scala-2.13/*-assembly-*.jar root@<METAGRAPH_IP>:/opt/ottochain/jars/currency-l1.jar
+scp modules/data_l1/target/scala-2.13/*-assembly-*.jar root@<METAGRAPH_IP>:/opt/ottochain/jars/data-l1.jar
+```
+
+### 1.6 Generate Keys (4 unique keys)
+
+```bash
+cd /opt/ottochain
+
+# Generate 4 keys with tessellation keytool
+for i in 1 2 3 4; do
+  cd /opt/ottochain/keys$i
+  CL_KEYSTORE=key.p12 CL_KEYALIAS=alias CL_PASSWORD=password \
+    java -jar /opt/ottochain/jars/cl-keytool.jar generate
+  echo "Generated key $i"
+done
+
+# Get peer IDs for each key
+for i in 1 2 3 4; do
+  echo "Key $i peer ID:"
+  cd /opt/ottochain/keys$i
+  CL_KEYSTORE=key.p12 CL_KEYALIAS=alias CL_PASSWORD=password \
+    java -jar /opt/ottochain/jars/cl-wallet.jar show-id
+done
+```
+
+**Save the peer ID from keys1** - this is your primary node ID.
+
+### 1.7 Set Environment Variables
+
+```bash
+# Edit these for your setup
+export HOST="<METAGRAPH_IP>"
+export GL0_PEER_ID="<peer-id-from-keys1>"
+export TOKEN="DAG2NLnsdCvDovUT7nJxP4kPznqEramWozMhuKzN"  # Your metagraph token ID
+```
+
+### 1.8 Start GL0 (Global L0)
+
+```bash
+docker run -d --name gl0 --restart unless-stopped \
+  --network host \
+  -v /opt/ottochain/jars:/jars:ro \
+  -v /opt/ottochain/keys1:/keys:ro \
+  -v /opt/ottochain/data/gl0:/data \
+  -w /data \
+  -e CL_KEYSTORE=/keys/key.p12 \
+  -e CL_KEYALIAS=alias \
+  -e CL_PASSWORD=password \
+  -e CL_EXTERNAL_IP=$HOST \
+  -e CL_PUBLIC_HTTP_PORT=9000 \
+  -e CL_P2P_HTTP_PORT=9001 \
+  -e CL_CLI_HTTP_PORT=9002 \
+  -e CL_APP_ENV=dev \
+  -e CL_COLLATERAL=0 \
+  eclipse-temurin:21-jre-jammy \
+  java -Xmx2g -jar /jars/global-l0.jar run-initial-validator
+
+# Wait for GL0 to be ready
+sleep 15
+curl -s http://localhost:9000/node/info | jq .state
+# Should show "Ready"
+```
+
+### 1.9 Start ML0 (Metagraph L0)
+
+**⚠️ CRITICAL: ML0 requires a two-step genesis process!**
+
+#### Step 1: Create genesis.csv
+
+```bash
+# Create genesis.csv with initial token distribution
+# Format: <address>,<amount> (amount in DAG units × 10^8)
+cat > /opt/ottochain/genesis.csv << 'EOF'
+DAG3yG9CRoYd4XF4PTBtLo95h8uiGNWYXXrASJGg,1000000000000000
+EOF
+```
+
+#### Step 2: Create genesis.snapshot
+
+The `create-genesis` command creates the `genesis.snapshot` file that ML0 needs.
+This must be done BEFORE starting ML0 with `run-genesis`.
+
+```bash
+# Run create-genesis to generate genesis.snapshot
+docker run --rm \
+  -v /opt/ottochain/jars:/jars:ro \
+  -v /opt/ottochain/keys1:/keys:ro \
+  -v /opt/ottochain/genesis.csv:/genesis.csv:ro \
+  -v /opt/ottochain/data/ml0:/data \
+  -w /data \
+  -e CL_KEYSTORE=/keys/key.p12 \
+  -e CL_KEYALIAS=alias \
+  -e CL_PASSWORD=password \
+  -e CL_APP_ENV=dev \
+  -e CL_COLLATERAL=0 \
+  -e CL_EXTERNAL_IP=$HOST \
+  -e CL_PUBLIC_HTTP_PORT=9200 \
+  -e CL_P2P_HTTP_PORT=9201 \
+  -e CL_CLI_HTTP_PORT=9202 \
+  -e CL_GLOBAL_L0_PEER_ID=$GL0_PEER_ID \
+  -e CL_GLOBAL_L0_PEER_HTTP_HOST=$HOST \
+  -e CL_GLOBAL_L0_PEER_HTTP_PORT=9000 \
+  eclipse-temurin:21-jre-jammy \
+  java -jar /jars/metagraph-l0.jar create-genesis /data/genesis.csv
+
+# Verify genesis files were created
+ls -la /opt/ottochain/data/ml0/genesis.*
+# Should show: genesis.snapshot, genesis.address
+
+# Save the metagraph ID (this is your new TOKEN)
+export TOKEN=$(cat /opt/ottochain/data/ml0/genesis.address)
+echo "Metagraph ID: $TOKEN"
+```
+
+#### Step 3: Start ML0 with run-genesis
+
+```bash
+docker run -d --name ml0 --restart unless-stopped \
+  --network host \
+  -v /opt/ottochain/jars:/jars:ro \
+  -v /opt/ottochain/keys1:/keys:ro \
+  -v /opt/ottochain/data/ml0:/data \
+  -w /data \
+  -e CL_KEYSTORE=/keys/key.p12 \
+  -e CL_KEYALIAS=alias \
+  -e CL_PASSWORD=password \
+  -e CL_L0_TOKEN_IDENTIFIER=$TOKEN \
+  -e CL_GLOBAL_L0_PEER_ID=$GL0_PEER_ID \
+  -e CL_GLOBAL_L0_PEER_HTTP_HOST=$HOST \
+  -e CL_GLOBAL_L0_PEER_HTTP_PORT=9000 \
+  -e CL_EXTERNAL_IP=$HOST \
+  -e CL_PUBLIC_HTTP_PORT=9200 \
+  -e CL_P2P_HTTP_PORT=9201 \
+  -e CL_CLI_HTTP_PORT=9202 \
+  -e CL_APP_ENV=dev \
+  -e CL_COLLATERAL=0 \
+  eclipse-temurin:21-jre-jammy \
+  java -Xmx2g -jar /jars/metagraph-l0.jar run-genesis \
+    --global-l0-peer-id $GL0_PEER_ID \
+    --global-l0-peer-host $HOST \
+    --global-l0-peer-port 9000 \
+    /data/genesis.snapshot
+
+# Wait and verify
+sleep 20
+curl -s http://localhost:9200/node/info | jq .state
+# Should show: "Ready"
+```
+
+**Note:** After genesis, subsequent restarts use `run-validator` (not `run-genesis`).
+
+### 1.10 Start CL1 (Currency L1 - 3 nodes)
+
+```bash
+# Node 1 (initial validator with keys1)
+docker run -d --name cl1 --restart unless-stopped \
+  --network host \
+  -v /opt/ottochain/jars:/jars:ro \
+  -v /opt/ottochain/keys1:/keys:ro \
+  -v /opt/ottochain/data/cl1:/data \
+  -w /data \
+  -e CL_KEYSTORE=/keys/key.p12 \
+  -e CL_KEYALIAS=alias \
+  -e CL_PASSWORD=password \
+  -e CL_L0_TOKEN_IDENTIFIER=$TOKEN \
+  -e CL_GLOBAL_L0_PEER_ID=$GL0_PEER_ID \
+  -e CL_GLOBAL_L0_PEER_HTTP_HOST=$HOST \
+  -e CL_GLOBAL_L0_PEER_HTTP_PORT=9000 \
+  -e CL_L0_PEER_ID=$GL0_PEER_ID \
+  -e CL_L0_PEER_HTTP_HOST=$HOST \
+  -e CL_L0_PEER_HTTP_PORT=9200 \
+  -e CL_EXTERNAL_IP=$HOST \
+  -e CL_PUBLIC_HTTP_PORT=9300 \
+  -e CL_P2P_HTTP_PORT=9301 \
+  -e CL_CLI_HTTP_PORT=9302 \
+  -e CL_APP_ENV=dev \
+  -e CL_COLLATERAL=0 \
+  eclipse-temurin:21-jre-jammy \
+  java -Xmx1g -jar /jars/currency-l1.jar run-initial-validator
+
+sleep 10
+
+# Node 2 (validator with keys2)
+docker run -d --name cl1-1 --restart unless-stopped \
+  --network host \
+  -v /opt/ottochain/jars:/jars:ro \
+  -v /opt/ottochain/keys2:/keys:ro \
+  -v /opt/ottochain/data/cl1-2:/data \
+  -w /data \
+  -e CL_KEYSTORE=/keys/key.p12 \
+  -e CL_KEYALIAS=alias \
+  -e CL_PASSWORD=password \
+  -e CL_L0_TOKEN_IDENTIFIER=$TOKEN \
+  -e CL_GLOBAL_L0_PEER_ID=$GL0_PEER_ID \
+  -e CL_GLOBAL_L0_PEER_HTTP_HOST=$HOST \
+  -e CL_GLOBAL_L0_PEER_HTTP_PORT=9000 \
+  -e CL_L0_PEER_ID=$GL0_PEER_ID \
+  -e CL_L0_PEER_HTTP_HOST=$HOST \
+  -e CL_L0_PEER_HTTP_PORT=9200 \
+  -e CL_EXTERNAL_IP=$HOST \
+  -e CL_PUBLIC_HTTP_PORT=9310 \
+  -e CL_P2P_HTTP_PORT=9311 \
+  -e CL_CLI_HTTP_PORT=9312 \
+  -e CL_APP_ENV=dev \
+  -e CL_COLLATERAL=0 \
+  eclipse-temurin:21-jre-jammy \
+  java -Xmx1g -jar /jars/currency-l1.jar run-validator
+
+# Node 3 (validator with keys3)
+docker run -d --name cl1-2 --restart unless-stopped \
+  --network host \
+  -v /opt/ottochain/jars:/jars:ro \
+  -v /opt/ottochain/keys3:/keys:ro \
+  -v /opt/ottochain/data/cl1-3:/data \
+  -w /data \
+  -e CL_KEYSTORE=/keys/key.p12 \
+  -e CL_KEYALIAS=alias \
+  -e CL_PASSWORD=password \
+  -e CL_L0_TOKEN_IDENTIFIER=$TOKEN \
+  -e CL_GLOBAL_L0_PEER_ID=$GL0_PEER_ID \
+  -e CL_GLOBAL_L0_PEER_HTTP_HOST=$HOST \
+  -e CL_GLOBAL_L0_PEER_HTTP_PORT=9000 \
+  -e CL_L0_PEER_ID=$GL0_PEER_ID \
+  -e CL_L0_PEER_HTTP_HOST=$HOST \
+  -e CL_L0_PEER_HTTP_PORT=9200 \
+  -e CL_EXTERNAL_IP=$HOST \
+  -e CL_PUBLIC_HTTP_PORT=9320 \
+  -e CL_P2P_HTTP_PORT=9321 \
+  -e CL_CLI_HTTP_PORT=9322 \
+  -e CL_APP_ENV=dev \
+  -e CL_COLLATERAL=0 \
+  eclipse-temurin:21-jre-jammy \
+  java -Xmx1g -jar /jars/currency-l1.jar run-validator
+
+# Wait for nodes to start
+sleep 10
+
+# Join nodes 2 and 3 to the cluster (via their CLI ports)
+curl -X POST "http://localhost:9312/cluster/join" \
+  -H "Content-Type: application/json" \
+  -d '{"id": "'$GL0_PEER_ID'", "ip": "'$HOST'", "p2pPort": 9301}'
+
+curl -X POST "http://localhost:9322/cluster/join" \
+  -H "Content-Type: application/json" \
+  -d '{"id": "'$GL0_PEER_ID'", "ip": "'$HOST'", "p2pPort": 9301}'
+
+# Verify cluster
+sleep 5
+echo "CL1 cluster size:"
+curl -s http://localhost:9300/cluster/info | jq length
+```
+
+### 1.11 Start DL1 (Data L1 - 3 nodes)
+
+```bash
+# Node 1 (initial validator with keys1)
+docker run -d --name dl1 --restart unless-stopped \
+  --network host \
+  -v /opt/ottochain/jars:/jars:ro \
+  -v /opt/ottochain/keys1:/keys:ro \
+  -v /opt/ottochain/data/dl1:/data \
+  -w /data \
+  -e CL_KEYSTORE=/keys/key.p12 \
+  -e CL_KEYALIAS=alias \
+  -e CL_PASSWORD=password \
+  -e CL_L0_TOKEN_IDENTIFIER=$TOKEN \
+  -e CL_GLOBAL_L0_PEER_ID=$GL0_PEER_ID \
+  -e CL_GLOBAL_L0_PEER_HTTP_HOST=$HOST \
+  -e CL_GLOBAL_L0_PEER_HTTP_PORT=9000 \
+  -e CL_L0_PEER_ID=$GL0_PEER_ID \
+  -e CL_L0_PEER_HTTP_HOST=$HOST \
+  -e CL_L0_PEER_HTTP_PORT=9200 \
+  -e CL_EXTERNAL_IP=$HOST \
+  -e CL_PUBLIC_HTTP_PORT=9400 \
+  -e CL_P2P_HTTP_PORT=9401 \
+  -e CL_CLI_HTTP_PORT=9402 \
+  -e CL_APP_ENV=dev \
+  -e CL_COLLATERAL=0 \
+  eclipse-temurin:21-jre-jammy \
+  java -Xmx1g -jar /jars/data-l1.jar run-initial-validator
+
+sleep 10
+
+# Node 2 (validator with keys2)
+docker run -d --name dl1-1 --restart unless-stopped \
+  --network host \
+  -v /opt/ottochain/jars:/jars:ro \
+  -v /opt/ottochain/keys2:/keys:ro \
+  -v /opt/ottochain/data/dl1-2:/data \
+  -w /data \
+  -e CL_KEYSTORE=/keys/key.p12 \
+  -e CL_KEYALIAS=alias \
+  -e CL_PASSWORD=password \
+  -e CL_L0_TOKEN_IDENTIFIER=$TOKEN \
+  -e CL_GLOBAL_L0_PEER_ID=$GL0_PEER_ID \
+  -e CL_GLOBAL_L0_PEER_HTTP_HOST=$HOST \
+  -e CL_GLOBAL_L0_PEER_HTTP_PORT=9000 \
+  -e CL_L0_PEER_ID=$GL0_PEER_ID \
+  -e CL_L0_PEER_HTTP_HOST=$HOST \
+  -e CL_L0_PEER_HTTP_PORT=9200 \
+  -e CL_EXTERNAL_IP=$HOST \
+  -e CL_PUBLIC_HTTP_PORT=9410 \
+  -e CL_P2P_HTTP_PORT=9411 \
+  -e CL_CLI_HTTP_PORT=9412 \
+  -e CL_APP_ENV=dev \
+  -e CL_COLLATERAL=0 \
+  eclipse-temurin:21-jre-jammy \
+  java -Xmx1g -jar /jars/data-l1.jar run-validator
+
+# Node 3 (validator with keys3)
+docker run -d --name dl1-2 --restart unless-stopped \
+  --network host \
+  -v /opt/ottochain/jars:/jars:ro \
+  -v /opt/ottochain/keys3:/keys:ro \
+  -v /opt/ottochain/data/dl1-3:/data \
+  -w /data \
+  -e CL_KEYSTORE=/keys/key.p12 \
+  -e CL_KEYALIAS=alias \
+  -e CL_PASSWORD=password \
+  -e CL_L0_TOKEN_IDENTIFIER=$TOKEN \
+  -e CL_GLOBAL_L0_PEER_ID=$GL0_PEER_ID \
+  -e CL_GLOBAL_L0_PEER_HTTP_HOST=$HOST \
+  -e CL_GLOBAL_L0_PEER_HTTP_PORT=9000 \
+  -e CL_L0_PEER_ID=$GL0_PEER_ID \
+  -e CL_L0_PEER_HTTP_HOST=$HOST \
+  -e CL_L0_PEER_HTTP_PORT=9200 \
+  -e CL_EXTERNAL_IP=$HOST \
+  -e CL_PUBLIC_HTTP_PORT=9420 \
+  -e CL_P2P_HTTP_PORT=9421 \
+  -e CL_CLI_HTTP_PORT=9422 \
+  -e CL_APP_ENV=dev \
+  -e CL_COLLATERAL=0 \
+  eclipse-temurin:21-jre-jammy \
+  java -Xmx1g -jar /jars/data-l1.jar run-validator
+
+# Wait for nodes to start
+sleep 30
+
+# Check DL1-0 is ready
+curl -s http://localhost:9400/node/info | jq .state
+# Should show: "Ready"
+
+# DL1-1 and DL1-2 will be in "ReadyToJoin" state
+# They need to join the cluster via CLI port (localhost-only)
+
+# ⚠️ CRITICAL: CLI port is bound to 127.0.0.1, so join must be called from inside container
+# Get DL1-0's peer ID first
+DL1_PEER_ID=$(curl -s http://localhost:9400/node/info | jq -r .id)
+
+# Join DL1-1 to cluster (via docker exec)
+docker exec dl1-1 bash -c "apt-get update -qq && apt-get install -y -qq curl > /dev/null 2>&1 && \
+  curl -s -X POST 'http://127.0.0.1:9412/cluster/join' \
+    -H 'Content-Type: application/json' \
+    -d '{\"id\": \"$DL1_PEER_ID\", \"ip\": \"$HOST\", \"p2pPort\": 9401}'"
+
+# Join DL1-2 to cluster (via docker exec)
+docker exec dl1-2 bash -c "apt-get update -qq && apt-get install -y -qq curl > /dev/null 2>&1 && \
+  curl -s -X POST 'http://127.0.0.1:9422/cluster/join' \
+    -H 'Content-Type: application/json' \
+    -d '{\"id\": \"$DL1_PEER_ID\", \"ip\": \"$HOST\", \"p2pPort\": 9401}'"
+
+# Verify cluster
+sleep 10
+echo "DL1 states:"
+for port in 9400 9410 9420; do
+  echo "  $port: $(curl -s http://localhost:$port/node/info | jq -r .state)"
+done
+echo "DL1 cluster size:"
+curl -s http://localhost:9400/cluster/info | jq length
+# Should show: 3
+```
+
+**Note:** The CLI join endpoint format is `{id, ip, p2pPort}` (simpler than P2P join).
+The P2P `/cluster/join` endpoint expects a different, more complex `JoinRequest` format.
+
+### 1.12 Verify Metagraph Stack
+
+```bash
+echo "=== Stack Status ==="
+echo "GL0: $(curl -s http://localhost:9000/node/info | jq -r .state)"
+echo "ML0: $(curl -s http://localhost:9200/node/info | jq -r .state)"
+echo "CL1 cluster: $(curl -s http://localhost:9300/cluster/info | jq length) nodes"
+echo "DL1 cluster: $(curl -s http://localhost:9400/cluster/info | jq length) nodes"
+```
+
+---
+
+## Part 2: Services Node Setup
+
+### 2.1 SSH to Services Node
+
+```bash
+ssh root@<SERVICES_IP>
+```
+
+### 2.2 Install Dependencies
+
+```bash
+apt update && apt install -y docker.io docker-compose-plugin nginx curl jq git nodejs npm
+systemctl enable docker nginx
+systemctl start docker nginx
+```
+
+### 2.3 Clone and Build Services
+
+```bash
+cd /opt
+git clone https://github.com/ottobot-ai/ottochain-services.git
+cd ottochain-services
+
+# Install dependencies and build
+npm install -g pnpm
+pnpm install
+pnpm build
+```
+
+### 2.4 Create Docker Compose
+
+```bash
+cat > /opt/ottochain-services/docker-compose.yml << 'EOF'
+version: '3.8'
+
+services:
+  postgres:
+    image: postgres:15
+    restart: unless-stopped
+    environment:
+      - POSTGRES_USER=ottochain
+      - POSTGRES_PASSWORD=ottochain
+      - POSTGRES_DB=ottochain
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ottochain"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  redis:
+    image: redis:7-alpine
+    restart: unless-stopped
+    ports:
+      - "6379:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  bridge:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    restart: unless-stopped
+    environment:
+      - PORT=3030
+      - METAGRAPH_ML0_URL=http://<METAGRAPH_IP>:9200
+      - METAGRAPH_DL1_URL=http://<METAGRAPH_IP>:9400
+      - DATABASE_URL=postgresql://ottochain:ottochain@postgres:5432/ottochain
+      - REDIS_URL=redis://redis:6379
+    command: ["node", "packages/bridge/dist/index.js"]
+    ports:
+      - "3030:3030"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+
+  indexer:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    restart: unless-stopped
+    environment:
+      - PORT=3031
+      - METAGRAPH_ML0_URL=http://<METAGRAPH_IP>:9200
+      - METAGRAPH_DL1_URL=http://<METAGRAPH_IP>:9400
+      - DATABASE_URL=postgresql://ottochain:ottochain@postgres:5432/ottochain
+      - REDIS_URL=redis://redis:6379
+    command: ["node", "packages/indexer/dist/index.js"]
+    ports:
+      - "3031:3031"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+
+  gateway:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    restart: unless-stopped
+    environment:
+      - GATEWAY_PORT=4000
+      - DATABASE_URL=postgresql://ottochain:ottochain@postgres:5432/ottochain
+      - REDIS_URL=redis://redis:6379
+    command: ["node", "packages/gateway/dist/index.js"]
+    ports:
+      - "4000:4000"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+
+volumes:
+  postgres_data:
+EOF
+
+# Replace <METAGRAPH_IP> with actual IP
+sed -i 's/<METAGRAPH_IP>/5.78.90.207/g' docker-compose.yml
+```
+
+### 2.5 Create Dockerfile
+
+```bash
+cat > /opt/ottochain-services/Dockerfile << 'EOF'
+FROM node:20-slim
+WORKDIR /app
+COPY package.json pnpm-lock.yaml ./
+COPY packages ./packages
+RUN npm install -g pnpm && pnpm install --frozen-lockfile
+RUN pnpm build
+EOF
+```
+
+### 2.6 Start Services
+
+```bash
+cd /opt/ottochain-services
+docker compose up -d
+
+# Wait for services
+sleep 10
+
+# Run database migrations
+docker exec ottochain-services-indexer-1 npx prisma db push --accept-data-loss
+```
+
+### 2.7 Build and Deploy Explorer
+
+```bash
+cd /opt
+git clone https://github.com/ottobot-ai/ottochain-explorer.git
+cd ottochain-explorer
+
+# Build
+pnpm install
+pnpm build
+
+# Deploy to nginx
+cp -r dist /opt/ottochain-explorer/dist
+```
+
+### 2.8 Configure Nginx
+
+```bash
+cat > /etc/nginx/conf.d/explorer.conf << 'EOF'
+server {
+    listen 8080;
+    root /opt/ottochain-explorer/dist;
+    index index.html;
+
+    # GraphQL proxy to gateway
+    location /graphql {
+        proxy_pass http://127.0.0.1:4000/graphql;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+    }
+
+    # REST API proxy to indexer
+    location /api/ {
+        proxy_pass http://127.0.0.1:3031/;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+    }
+
+    # WebSocket proxy
+    location /ws {
+        proxy_pass http://127.0.0.1:4000;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+    }
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    location /assets/ {
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+    }
+}
+EOF
+
+# Remove default site if exists
+rm -f /etc/nginx/sites-enabled/default
+
+# Test and reload
+nginx -t && nginx -s reload
+```
+
+### 2.9 Verify Services
+
+```bash
+echo "=== Services Status ==="
+echo "Bridge: $(curl -s http://localhost:3030/health | jq -r .status)"
+echo "Indexer: $(curl -s http://localhost:3031/health | jq -r .status)"
+echo "Gateway: $(curl -s http://localhost:4000/health | jq -r .status)"
+echo "Explorer: http://<SERVICES_IP>:8080"
+```
+
+---
+
+## Part 3: Trigger Initial Index
+
+```bash
+# Get current ordinal from ML0
+ORDINAL=$(curl -s http://<METAGRAPH_IP>:9200/data-application/v1/checkpoint | jq -r '.ordinal')
+
+# Trigger indexer webhook
+curl -X POST http://localhost:3031/webhook/snapshot \
+  -H "Content-Type: application/json" \
+  -d '{"ordinal": '$ORDINAL', "hash": "initial", "timestamp": "'$(date -u +%Y-%m-%dT%H:%M:%SZ)'"}'
+
+# Check indexer status
+curl -s http://localhost:3031/status | jq .
+```
+
+---
+
+## Part 4: Generate Traffic (Optional)
+
+```bash
+cd /opt/ottochain-services
+
+# Run traffic generator
+BRIDGE_URL=http://localhost:3030 ITERATIONS=50 \
+  pnpm exec tsx scripts/demo/metagraph-activity.ts
+```
+
+---
+
+## Verification Checklist
+
+- [ ] GL0 state is "Ready"
+- [ ] ML0 state is "Ready"
+- [ ] CL1 cluster has 3 nodes
+- [ ] DL1 cluster has 3 nodes
+- [ ] Bridge health returns "ok"
+- [ ] Indexer health returns "ok"
+- [ ] Gateway health returns "ok"
+- [ ] Explorer loads at http://<SERVICES_IP>:8080
+- [ ] GraphQL query returns data
+- [ ] Traffic generator creates agents/contracts
+
+---
+
+## Troubleshooting
+
+### Nodes stuck in "Initial" state
+- Check they can reach the L0 peer (GL0 or ML0)
+- Verify environment variables are correct
+- Check docker logs: `docker logs <container>`
+
+### L1 cluster not forming
+- Ensure each node has a DIFFERENT key
+- Verify join command uses correct peer ID and p2p port
+- Wait longer - joining can take 10-30 seconds
+
+### Indexer shows empty data
+- Trigger webhook manually with current ordinal
+- Check `METAGRAPH_ML0_URL` env var is correct
+- Verify database migrations ran
+
+### Bridge fails to submit
+- Check `METAGRAPH_DL1_URL` env var is correct
+- Verify DL1 is accessible from services node
+- Check bridge logs for specific error
+
+---
+
+## Quick Reference
+
+| Layer | Port (Public) | Port (P2P) | Port (CLI) |
+|-------|---------------|------------|------------|
+| GL0   | 9000          | 9001       | 9002       |
+| ML0   | 9200          | 9201       | 9202       |
+| CL1-1 | 9300          | 9301       | 9302       |
+| CL1-2 | 9310          | 9311       | 9312       |
+| CL1-3 | 9320          | 9321       | 9322       |
+| DL1-1 | 9400          | 9401       | 9402       |
+| DL1-2 | 9410          | 9411       | 9412       |
+| DL1-3 | 9420          | 9421       | 9422       |
+
+| Service  | Port |
+|----------|------|
+| Bridge   | 3030 |
+| Indexer  | 3031 |
+| Gateway  | 4000 |
+| Explorer | 8080 |
+| Postgres | 5432 |
+| Redis    | 6379 |

--- a/deploy/OPERATIONS.md
+++ b/deploy/OPERATIONS.md
@@ -1,0 +1,728 @@
+# OttoChain Operations Guide
+
+**How to evolve, update, and maintain your deployment.**
+
+## Table of Contents
+1. [Restarting Layers](#restarting-layers)
+2. [Rollback Procedures](#rollback-procedures)
+3. [Updating OttoChain Code](#updating-ottochain-code)
+4. [Adding Nodes](#adding-nodes)
+5. [Removing/Replacing Nodes](#removingreplacing-nodes)
+6. [Resetting Genesis](#resetting-genesis)
+7. [Monitoring](#monitoring)
+8. [Backup & Recovery](#backup--recovery)
+9. [Scaling](#scaling)
+10. [Upgrading Tessellation](#upgrading-tessellation)
+
+---
+
+## Restarting Layers
+
+### Layer Dependency Order
+
+```
+GL0 (Global L0)
+  ↓
+ML0 (Metagraph L0)
+  ↓
+┌─────────┬─────────┐
+CL1       DL1
+(Currency) (Data)
+```
+
+**Rule:** Always restart bottom-up. Children depend on parents.
+
+### Restart GL0 Only
+
+```bash
+# WARNING: This affects ALL layers - they will reconnect
+docker restart gl0
+
+# Wait for GL0 to be ready
+sleep 15
+curl -s http://localhost:9000/node/info | jq .state
+
+# Other layers should auto-reconnect, but verify:
+curl -s http://localhost:9200/node/info | jq .state  # ML0
+```
+
+### Restart ML0 Only
+
+```bash
+# CL1 and DL1 will temporarily lose their L0 peer
+docker restart ml0
+
+sleep 15
+curl -s http://localhost:9200/node/info | jq .state
+
+# L1 layers should auto-reconnect
+```
+
+### Restart CL1 Cluster
+
+```bash
+# Option 1: Rolling restart (maintains consensus)
+for node in cl1-2 cl1-1 cl1; do
+  docker restart $node
+  sleep 15
+  echo "$node restarted"
+done
+
+# Verify cluster reformed
+curl -s http://localhost:9300/cluster/info | jq length
+
+# Option 2: Full cluster restart
+docker restart cl1 cl1-1 cl1-2
+
+# Wait and rejoin
+sleep 15
+curl -X POST "http://localhost:9312/cluster/join" -H "Content-Type: application/json" \
+  -d '{"id": "'$GL0_PEER_ID'", "ip": "'$HOST'", "p2pPort": 9301}'
+curl -X POST "http://localhost:9322/cluster/join" -H "Content-Type: application/json" \
+  -d '{"id": "'$GL0_PEER_ID'", "ip": "'$HOST'", "p2pPort": 9301}'
+```
+
+### Restart DL1 Cluster
+
+```bash
+# Option 1: Rolling restart
+for node in dl1-2 dl1-1 dl1; do
+  docker restart $node
+  sleep 15
+done
+
+# Verify cluster
+curl -s http://localhost:9400/cluster/info | jq length
+
+# Option 2: Full cluster restart
+docker restart dl1 dl1-1 dl1-2
+
+sleep 15
+curl -X POST "http://localhost:9412/cluster/join" -H "Content-Type: application/json" \
+  -d '{"id": "'$GL0_PEER_ID'", "ip": "'$HOST'", "p2pPort": 9401}'
+curl -X POST "http://localhost:9422/cluster/join" -H "Content-Type: application/json" \
+  -d '{"id": "'$GL0_PEER_ID'", "ip": "'$HOST'", "p2pPort": 9401}'
+```
+
+### Restart Single L1 Node
+
+```bash
+# Restart one node - cluster continues with others
+docker restart cl1-1
+
+# It should auto-rejoin, but if not:
+sleep 10
+curl -X POST "http://localhost:9312/cluster/join" -H "Content-Type: application/json" \
+  -d '{"id": "'$GL0_PEER_ID'", "ip": "'$HOST'", "p2pPort": 9301}'
+```
+
+### Restart Entire Stack
+
+```bash
+#!/bin/bash
+# Save as restart-stack.sh
+
+echo "Stopping all layers..."
+docker stop dl1-2 dl1-1 dl1 cl1-2 cl1-1 cl1 ml0 gl0
+
+echo "Starting GL0..."
+docker start gl0
+sleep 15
+echo "GL0: $(curl -s http://localhost:9000/node/info | jq -r .state)"
+
+echo "Starting ML0..."
+docker start ml0
+sleep 15
+echo "ML0: $(curl -s http://localhost:9200/node/info | jq -r .state)"
+
+echo "Starting CL1 cluster..."
+docker start cl1
+sleep 10
+docker start cl1-1 cl1-2
+sleep 10
+curl -s -X POST "http://localhost:9312/cluster/join" -H "Content-Type: application/json" \
+  -d '{"id": "'$GL0_PEER_ID'", "ip": "'$HOST'", "p2pPort": 9301}'
+curl -s -X POST "http://localhost:9322/cluster/join" -H "Content-Type: application/json" \
+  -d '{"id": "'$GL0_PEER_ID'", "ip": "'$HOST'", "p2pPort": 9301}'
+echo "CL1: $(curl -s http://localhost:9300/cluster/info | jq length) nodes"
+
+echo "Starting DL1 cluster..."
+docker start dl1
+sleep 10
+docker start dl1-1 dl1-2
+sleep 10
+curl -s -X POST "http://localhost:9412/cluster/join" -H "Content-Type: application/json" \
+  -d '{"id": "'$GL0_PEER_ID'", "ip": "'$HOST'", "p2pPort": 9401}'
+curl -s -X POST "http://localhost:9422/cluster/join" -H "Content-Type: application/json" \
+  -d '{"id": "'$GL0_PEER_ID'", "ip": "'$HOST'", "p2pPort": 9401}'
+echo "DL1: $(curl -s http://localhost:9400/cluster/info | jq length) nodes"
+
+echo "Stack restart complete!"
+```
+
+---
+
+## Rollback Procedures
+
+### Rollback JAR Version
+
+```bash
+# Keep previous JARs with version suffix
+cp /opt/ottochain/jars/data-l1.jar /opt/ottochain/jars/data-l1.jar.v1.0.0
+cp /opt/ottochain/jars/data-l1.jar.v0.9.0 /opt/ottochain/jars/data-l1.jar
+
+# Restart affected layer
+docker stop dl1 dl1-1 dl1-2
+docker rm dl1 dl1-1 dl1-2
+
+# Restart with old JAR (same docker run commands)
+# ... start dl1, dl1-1, dl1-2 ...
+# ... rejoin cluster ...
+```
+
+### Rollback with Data Preservation
+
+```bash
+# 1. Stop layer
+docker stop dl1 dl1-1 dl1-2
+
+# 2. Backup current data
+cp -r /opt/ottochain/data/dl1 /opt/ottochain/data/dl1.backup.$(date +%Y%m%d)
+cp -r /opt/ottochain/data/dl1-2 /opt/ottochain/data/dl1-2.backup.$(date +%Y%m%d)
+cp -r /opt/ottochain/data/dl1-3 /opt/ottochain/data/dl1-3.backup.$(date +%Y%m%d)
+
+# 3. Restore previous JAR
+cp /opt/ottochain/jars/data-l1.jar.previous /opt/ottochain/jars/data-l1.jar
+
+# 4. Restart (data should be compatible if minor version change)
+docker rm dl1 dl1-1 dl1-2
+# ... start dl1, dl1-1, dl1-2 ...
+```
+
+### Rollback with Data Reset
+
+If data format changed between versions:
+
+```bash
+# 1. Stop layer
+docker stop dl1 dl1-1 dl1-2
+docker rm dl1 dl1-1 dl1-2
+
+# 2. Backup and clear data
+mv /opt/ottochain/data/dl1 /opt/ottochain/data/dl1.broken
+mv /opt/ottochain/data/dl1-2 /opt/ottochain/data/dl1-2.broken
+mv /opt/ottochain/data/dl1-3 /opt/ottochain/data/dl1-3.broken
+mkdir -p /opt/ottochain/data/{dl1,dl1-2,dl1-3}
+
+# 3. Restore previous JAR
+cp /opt/ottochain/jars/data-l1.jar.previous /opt/ottochain/jars/data-l1.jar
+
+# 4. Restart - will sync from ML0
+# Node 1 as initial-validator (fresh genesis for this layer)
+docker run -d --name dl1 ... java -jar /jars/data-l1.jar run-initial-validator
+# Nodes 2,3 as validators
+docker run -d --name dl1-1 ... java -jar /jars/data-l1.jar run-validator
+docker run -d --name dl1-2 ... java -jar /jars/data-l1.jar run-validator
+# Rejoin cluster
+```
+
+### Rollback Entire Stack to Backup
+
+```bash
+# 1. Stop everything
+docker stop gl0 ml0 cl1 cl1-1 cl1-2 dl1 dl1-1 dl1-2
+docker rm gl0 ml0 cl1 cl1-1 cl1-2 dl1 dl1-1 dl1-2
+
+# 2. Restore JARs
+cp /opt/ottochain/jars.backup/*.jar /opt/ottochain/jars/
+
+# 3. Restore data
+rm -rf /opt/ottochain/data/*
+tar -xzvf /opt/ottochain/backups/data-YYYYMMDD.tar.gz -C /opt/ottochain/
+
+# 4. Restart stack
+./restart-stack.sh
+```
+
+### Rollback Services
+
+```bash
+cd /opt/ottochain-services
+
+# Checkout previous version
+git log --oneline -10  # Find commit to rollback to
+git checkout <commit-hash>
+
+# Rebuild
+pnpm install
+pnpm build
+
+# Restart services
+docker compose down
+docker compose build
+docker compose up -d
+
+# Run migrations (if needed)
+docker exec ottochain-services-indexer-1 npx prisma db push
+```
+
+### Emergency Rollback Script
+
+```bash
+#!/bin/bash
+# Save as /opt/ottochain/emergency-rollback.sh
+
+BACKUP_DATE=${1:-$(ls -t /opt/ottochain/backups/*.tar.gz | head -1 | grep -oE '[0-9]{8}')}
+
+echo "Emergency rollback to $BACKUP_DATE"
+echo "WARNING: This will stop all services and restore from backup!"
+read -p "Continue? (yes/no) " confirm
+if [ "$confirm" != "yes" ]; then
+  echo "Aborted."
+  exit 1
+fi
+
+# Stop everything
+echo "Stopping all containers..."
+docker stop gl0 ml0 cl1 cl1-1 cl1-2 dl1 dl1-1 dl1-2 2>/dev/null
+docker rm gl0 ml0 cl1 cl1-1 cl1-2 dl1 dl1-1 dl1-2 2>/dev/null
+
+# Restore JARs
+if [ -d "/opt/ottochain/jars.backup.$BACKUP_DATE" ]; then
+  echo "Restoring JARs..."
+  cp /opt/ottochain/jars.backup.$BACKUP_DATE/*.jar /opt/ottochain/jars/
+fi
+
+# Restore data
+if [ -f "/opt/ottochain/backups/data-$BACKUP_DATE.tar.gz" ]; then
+  echo "Restoring data..."
+  rm -rf /opt/ottochain/data/*
+  tar -xzvf /opt/ottochain/backups/data-$BACKUP_DATE.tar.gz -C /opt/ottochain/
+fi
+
+# Restart
+echo "Restarting stack..."
+/opt/ottochain/restart-stack.sh
+
+echo "Rollback complete!"
+```
+
+### Version Management Best Practices
+
+```bash
+# Before any update, create versioned backup
+VERSION="1.0.0"
+DATE=$(date +%Y%m%d)
+
+# Backup JARs
+mkdir -p /opt/ottochain/jars.backup.$DATE
+cp /opt/ottochain/jars/*.jar /opt/ottochain/jars.backup.$DATE/
+
+# Backup data
+mkdir -p /opt/ottochain/backups
+tar -czvf /opt/ottochain/backups/data-$DATE.tar.gz /opt/ottochain/data/
+
+# Tag the backup
+echo "$VERSION - $DATE" >> /opt/ottochain/backups/versions.log
+
+# Now safe to update
+```
+
+---
+
+## Updating OttoChain Code
+
+### Build New JARs
+
+```bash
+# On dev machine
+cd /path/to/ottochain
+git pull origin main
+source ~/.sdkman/bin/sdkman-init.sh
+
+# Clean build
+sbt clean "l0/assembly" "l1/assembly" "dataL1/assembly"
+
+# Copy to server
+scp modules/l0/target/scala-2.13/*-assembly-*.jar root@<HOST>:/opt/ottochain/jars/metagraph-l0.jar
+scp modules/l1/target/scala-2.13/*-assembly-*.jar root@<HOST>:/opt/ottochain/jars/currency-l1.jar
+scp modules/data_l1/target/scala-2.13/*-assembly-*.jar root@<HOST>:/opt/ottochain/jars/data-l1.jar
+```
+
+### Rolling Update (Zero Downtime for L1)
+
+For L1 layers (CL1, DL1), you can do rolling updates:
+
+```bash
+# Update one node at a time
+# 1. Stop node 3
+docker stop cl1-2
+docker rm cl1-2
+
+# 2. Start with new JAR (it will rejoin automatically)
+docker run -d --name cl1-2 ... java -jar /jars/currency-l1.jar run-validator
+
+# 3. Wait for it to rejoin cluster
+sleep 30
+curl -s http://localhost:9300/cluster/info | jq length
+
+# 4. Repeat for nodes 2 and 1
+```
+
+### Full Restart (Downtime)
+
+```bash
+# Stop all containers in reverse order
+docker stop dl1-2 dl1-1 dl1 cl1-2 cl1-1 cl1 ml0 gl0
+
+# Start in order
+docker start gl0 && sleep 15
+docker start ml0 && sleep 15
+docker start cl1 && sleep 10
+docker start cl1-1 cl1-2 && sleep 10
+# Rejoin CL1 cluster
+curl -X POST "http://localhost:9312/cluster/join" ...
+curl -X POST "http://localhost:9322/cluster/join" ...
+
+docker start dl1 && sleep 10
+docker start dl1-1 dl1-2 && sleep 10
+# Rejoin DL1 cluster
+curl -X POST "http://localhost:9412/cluster/join" ...
+curl -X POST "http://localhost:9422/cluster/join" ...
+```
+
+---
+
+## Adding Nodes
+
+### Add a 4th CL1 Node
+
+```bash
+# Generate new key
+mkdir -p /opt/ottochain/keys5
+cd /opt/ottochain/keys5
+CL_KEYSTORE=key.p12 CL_KEYALIAS=alias CL_PASSWORD=password \
+  java -jar /opt/ottochain/jars/cl-keytool.jar generate
+
+# Create data dir
+mkdir -p /opt/ottochain/data/cl1-4
+
+# Start new node
+docker run -d --name cl1-3 --restart unless-stopped --network host \
+  -v /opt/ottochain/jars:/jars:ro \
+  -v /opt/ottochain/keys5:/keys:ro \
+  -v /opt/ottochain/data/cl1-4:/data -w /data \
+  -e CL_KEYSTORE=/keys/key.p12 -e CL_KEYALIAS=alias -e CL_PASSWORD=password \
+  -e CL_L0_TOKEN_IDENTIFIER=$TOKEN \
+  -e CL_GLOBAL_L0_PEER_ID=$GL0_PEER_ID -e CL_GLOBAL_L0_PEER_HTTP_HOST=$HOST -e CL_GLOBAL_L0_PEER_HTTP_PORT=9000 \
+  -e CL_L0_PEER_ID=$GL0_PEER_ID -e CL_L0_PEER_HTTP_HOST=$HOST -e CL_L0_PEER_HTTP_PORT=9200 \
+  -e CL_EXTERNAL_IP=$HOST \
+  -e CL_PUBLIC_HTTP_PORT=9330 -e CL_P2P_HTTP_PORT=9331 -e CL_CLI_HTTP_PORT=9332 \
+  -e CL_APP_ENV=dev -e CL_COLLATERAL=0 \
+  eclipse-temurin:21-jre-jammy java -Xmx1g -jar /jars/currency-l1.jar run-validator
+
+# Join to existing cluster
+sleep 10
+curl -X POST "http://localhost:9332/cluster/join" -H "Content-Type: application/json" \
+  -d '{"id": "'$GL0_PEER_ID'", "ip": "'$HOST'", "p2pPort": 9301}'
+```
+
+### Add Node on Different Machine
+
+```bash
+# On new machine
+# 1. Copy JARs and generate unique key
+# 2. Use the SAME GL0_PEER_ID and TOKEN
+# 3. Point CL_GLOBAL_L0_PEER_HTTP_HOST to the GL0 machine IP
+# 4. Point CL_L0_PEER_HTTP_HOST to the ML0 machine IP
+# 5. Set CL_EXTERNAL_IP to THIS machine's IP
+# 6. Run as run-validator (not run-initial-validator)
+# 7. Join to existing cluster node
+```
+
+---
+
+## Removing/Replacing Nodes
+
+### Graceful Node Removal
+
+```bash
+# Stop the node
+docker stop cl1-2
+docker rm cl1-2
+
+# Cluster will continue with remaining nodes (need at least 3 for consensus)
+# Remaining nodes will detect peer is gone
+```
+
+### Replace a Node's Key
+
+```bash
+# 1. Stop the node
+docker stop cl1-2
+docker rm cl1-2
+
+# 2. Generate new key
+rm -rf /opt/ottochain/keys3/*
+cd /opt/ottochain/keys3
+CL_KEYSTORE=key.p12 CL_KEYALIAS=alias CL_PASSWORD=password \
+  java -jar /opt/ottochain/jars/cl-keytool.jar generate
+
+# 3. Clear data (to avoid peer ID conflicts)
+rm -rf /opt/ottochain/data/cl1-3/*
+
+# 4. Restart node
+docker run -d --name cl1-2 ... run-validator
+
+# 5. Rejoin cluster
+curl -X POST "http://localhost:9322/cluster/join" ...
+```
+
+---
+
+## Resetting Genesis
+
+**WARNING: This destroys all state!**
+
+```bash
+# Stop everything
+docker stop gl0 ml0 cl1 cl1-1 cl1-2 dl1 dl1-1 dl1-2
+docker rm gl0 ml0 cl1 cl1-1 cl1-2 dl1 dl1-1 dl1-2
+
+# Clear all data
+rm -rf /opt/ottochain/data/*
+mkdir -p /opt/ottochain/data/{gl0,ml0,cl1,cl1-2,cl1-3,dl1,dl1-2,dl1-3}
+
+# Optionally regenerate keys
+# rm -rf /opt/ottochain/keys*
+# mkdir -p /opt/ottochain/keys{1,2,3,4}
+# ... regenerate ...
+
+# Restart from scratch
+./deploy/scripts/setup-metagraph.sh
+```
+
+---
+
+## Monitoring
+
+### Health Check Script
+
+```bash
+#!/bin/bash
+# save as /opt/ottochain/check-health.sh
+
+echo "=== OttoChain Health Check ==="
+echo "Time: $(date)"
+echo ""
+
+echo "GL0: $(curl -s http://localhost:9000/node/info | jq -r '.state // "DOWN"')"
+echo "ML0: $(curl -s http://localhost:9200/node/info | jq -r '.state // "DOWN"')"
+
+CL1_COUNT=$(curl -s http://localhost:9300/cluster/info 2>/dev/null | jq 'length // 0')
+DL1_COUNT=$(curl -s http://localhost:9400/cluster/info 2>/dev/null | jq 'length // 0')
+echo "CL1: $CL1_COUNT nodes"
+echo "DL1: $DL1_COUNT nodes"
+
+ML0_ORDINAL=$(curl -s http://localhost:9200/data-application/v1/checkpoint | jq -r '.ordinal // "N/A"')
+echo "ML0 Ordinal: $ML0_ORDINAL"
+
+echo ""
+echo "Container Status:"
+docker ps --format "table {{.Names}}\t{{.Status}}" | grep -E "gl0|ml0|cl1|dl1"
+```
+
+### Cron for Monitoring
+
+```bash
+# Add to crontab
+*/5 * * * * /opt/ottochain/check-health.sh >> /var/log/ottochain-health.log 2>&1
+```
+
+### Log Aggregation
+
+```bash
+# View all metagraph logs
+docker logs -f gl0 &
+docker logs -f ml0 &
+docker logs -f cl1 &
+docker logs -f dl1 &
+
+# Or use a combined log viewer
+docker logs --tail 100 -f gl0 2>&1 | sed 's/^/[GL0] /' &
+docker logs --tail 100 -f ml0 2>&1 | sed 's/^/[ML0] /' &
+```
+
+---
+
+## Backup & Recovery
+
+### Backup State
+
+```bash
+# Stop nodes first for consistent backup
+docker stop ml0 cl1 cl1-1 cl1-2 dl1 dl1-1 dl1-2
+
+# Backup data directories
+tar -czvf ottochain-backup-$(date +%Y%m%d).tar.gz /opt/ottochain/data/
+
+# Backup keys (store securely!)
+tar -czvf ottochain-keys-$(date +%Y%m%d).tar.gz /opt/ottochain/keys*/
+
+# Restart nodes
+docker start ml0 cl1 cl1-1 cl1-2 dl1 dl1-1 dl1-2
+```
+
+### Restore from Backup
+
+```bash
+# Stop everything
+docker stop gl0 ml0 cl1 cl1-1 cl1-2 dl1 dl1-1 dl1-2
+
+# Restore data
+rm -rf /opt/ottochain/data/*
+tar -xzvf ottochain-backup-YYYYMMDD.tar.gz -C /
+
+# Restart
+docker start gl0 ml0 cl1 cl1-1 cl1-2 dl1 dl1-1 dl1-2
+```
+
+---
+
+## Scaling
+
+### Horizontal Scaling (Multiple Machines)
+
+**Setup:**
+- Machine A: GL0, ML0
+- Machine B: CL1×3
+- Machine C: DL1×3
+
+**Key Changes:**
+1. All machines need the same `GL0_PEER_ID` and `TOKEN`
+2. Each machine uses its own IP for `CL_EXTERNAL_IP`
+3. Point `CL_GLOBAL_L0_PEER_HTTP_HOST` to Machine A
+4. Point `CL_L0_PEER_HTTP_HOST` to Machine A
+5. For cluster joins, use actual IPs not localhost
+
+### Vertical Scaling
+
+```bash
+# Increase memory for heavy nodes
+docker stop ml0
+docker rm ml0
+docker run -d --name ml0 ... java -Xmx4g -jar /jars/metagraph-l0.jar ...
+```
+
+---
+
+## Upgrading Tessellation
+
+**CRITICAL: Version must match across all components!**
+
+### Check Current Version
+
+```bash
+curl -s http://localhost:9200/node/info | jq .version
+```
+
+### Upgrade Process
+
+1. **Check Compatibility**
+   - OttoChain metakit version must be compatible with new tessellation
+   - Check release notes for breaking changes
+
+2. **Update OttoChain Dependencies**
+   ```scala
+   // In Dependencies.scala
+   val tessellation = "4.x.x"  // New version
+   ```
+
+3. **Rebuild JARs**
+   ```bash
+   sbt clean assembly
+   ```
+
+4. **Download New Tessellation Tools**
+   ```bash
+   NEW_VERSION="v4.x.x"
+   curl -L -o cl-keytool.jar "https://github.com/Constellation-Labs/tessellation/releases/download/${NEW_VERSION}/cl-keytool.jar"
+   curl -L -o cl-wallet.jar "https://github.com/Constellation-Labs/tessellation/releases/download/${NEW_VERSION}/cl-wallet.jar"
+   ```
+
+5. **Full Restart with New JARs**
+   - See "Full Restart" section above
+
+---
+
+## Services Stack Updates
+
+### Update Services Code
+
+```bash
+cd /opt/ottochain-services
+git pull origin main
+pnpm install
+pnpm build
+
+# Rebuild and restart containers
+docker compose build
+docker compose up -d
+```
+
+### Database Migrations
+
+```bash
+docker exec ottochain-services-indexer-1 npx prisma migrate deploy
+# Or for dev:
+docker exec ottochain-services-indexer-1 npx prisma db push
+```
+
+### Update Explorer
+
+```bash
+cd /opt/ottochain-explorer
+git pull origin main
+pnpm install
+pnpm build
+cp -r dist/* /opt/ottochain-explorer/dist/
+# Nginx will serve new files automatically
+```
+
+---
+
+## Troubleshooting Evolution Issues
+
+### Node Won't Rejoin After Update
+
+```bash
+# Clear node's data and rejoin fresh
+docker stop cl1-2
+docker rm cl1-2
+rm -rf /opt/ottochain/data/cl1-3/*
+# Restart and rejoin
+```
+
+### Version Mismatch Errors
+
+```bash
+# Check all node versions
+for p in 9000 9200 9300 9310 9320 9400 9410 9420; do
+  echo -n "Port $p: "
+  curl -s http://localhost:$p/node/info | jq -r .version
+done
+```
+
+### State Divergence
+
+If nodes have diverged state:
+1. Stop all L1 nodes
+2. Clear L1 data directories
+3. Restart L1 nodes (they'll sync from L0)
+
+```bash
+docker stop cl1 cl1-1 cl1-2 dl1 dl1-1 dl1-2
+rm -rf /opt/ottochain/data/cl1* /opt/ottochain/data/dl1*
+mkdir -p /opt/ottochain/data/{cl1,cl1-2,cl1-3,dl1,dl1-2,dl1-3}
+# Restart and rejoin clusters
+```

--- a/deploy/config/deploy-config.sh
+++ b/deploy/config/deploy-config.sh
@@ -23,18 +23,20 @@ SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o Connect
 #######################
 
 # Keystore files (from euclid configuration)
-KEYSTORE_FILES=("kd5ujc-01.p12" "kd5ujc-02.p12" "kd5ujc-03.p12")
-KEYSTORE_ALIAS=("kd5ujc-01" "kd5ujc-02" "kd5ujc-03")
+# Passwords should be set via environment variables or .env file
+# Generate new keystores: tessellation keytool generate --password <password>
+KEYSTORE_FILES=("node-01.p12" "node-02.p12" "node-03.p12")
+KEYSTORE_ALIAS=("node-01" "node-02" "node-03")
 KEYSTORE_PASSWORD=(
-  "Refusing-Avenge8-Repose-Garnish"
-  "Italicize6-Drippy-Stool-Trash"
-  "Huntress-Gossip6-Deflected-Jitters"
+  "${NODE1_KEYSTORE_PASSWORD:?Set NODE1_KEYSTORE_PASSWORD}"
+  "${NODE2_KEYSTORE_PASSWORD:?Set NODE2_KEYSTORE_PASSWORD}"
+  "${NODE3_KEYSTORE_PASSWORD:?Set NODE3_KEYSTORE_PASSWORD}"
 )
 
 # Owner wallet (using first keystore as owner)
-OWNER_KEYSTORE_FILE="kd5ujc-03.p12"
-OWNER_KEYSTORE_ALIAS="kd5ujc-03"
-OWNER_KEYSTORE_PASSWORD="Huntress-Gossip6-Deflected-Jitters"
+OWNER_KEYSTORE_FILE="node-01.p12"
+OWNER_KEYSTORE_ALIAS="node-01"
+OWNER_KEYSTORE_PASSWORD="${OWNER_KEYSTORE_PASSWORD:-$NODE1_KEYSTORE_PASSWORD}"
 
 #######################
 # Hypergraph Network Configuration

--- a/deploy/scripts/setup-metagraph.sh
+++ b/deploy/scripts/setup-metagraph.sh
@@ -1,0 +1,222 @@
+#!/bin/bash
+# OttoChain Metagraph Node Setup Script
+# Run this on your metagraph server
+
+set -e
+
+# Configuration - EDIT THESE
+HOST="${HOST:-$(curl -s ifconfig.me)}"
+TOKEN="${TOKEN:-DAG2NLnsdCvDovUT7nJxP4kPznqEramWozMhuKzN}"
+TESS_VERSION="${TESS_VERSION:-v4.0.0-rc.2}"
+BASE_DIR="${BASE_DIR:-/opt/ottochain}"
+
+echo "========================================"
+echo "OttoChain Metagraph Setup"
+echo "========================================"
+echo "Host: $HOST"
+echo "Token: $TOKEN"
+echo "Tessellation: $TESS_VERSION"
+echo "Base dir: $BASE_DIR"
+echo "========================================"
+
+# Create directories
+echo "[1/8] Creating directories..."
+mkdir -p $BASE_DIR/{jars,keys1,keys2,keys3,keys4}
+mkdir -p $BASE_DIR/data/{gl0,ml0,cl1,cl1-2,cl1-3,dl1,dl1-2,dl1-3}
+
+# Download tessellation tools
+echo "[2/8] Downloading tessellation tools..."
+cd $BASE_DIR/jars
+if [ ! -f cl-keytool.jar ]; then
+  curl -L -o cl-keytool.jar "https://github.com/Constellation-Labs/tessellation/releases/download/${TESS_VERSION}/cl-keytool.jar"
+fi
+if [ ! -f cl-wallet.jar ]; then
+  curl -L -o cl-wallet.jar "https://github.com/Constellation-Labs/tessellation/releases/download/${TESS_VERSION}/cl-wallet.jar"
+fi
+
+# Check for OttoChain JARs
+echo "[3/8] Checking for OttoChain JARs..."
+for jar in metagraph-l0.jar currency-l1.jar data-l1.jar; do
+  if [ ! -f $BASE_DIR/jars/$jar ]; then
+    echo "ERROR: Missing $jar - please copy OttoChain JARs to $BASE_DIR/jars/"
+    exit 1
+  fi
+done
+echo "All JARs present."
+
+# Generate keys
+echo "[4/8] Generating keys..."
+for i in 1 2 3 4; do
+  if [ ! -f $BASE_DIR/keys$i/key.p12 ]; then
+    cd $BASE_DIR/keys$i
+    CL_KEYSTORE=key.p12 CL_KEYALIAS=alias CL_PASSWORD=password \
+      java -jar $BASE_DIR/jars/cl-keytool.jar generate
+    echo "Generated key $i"
+  else
+    echo "Key $i already exists"
+  fi
+done
+
+# Get peer ID from key1
+cd $BASE_DIR/keys1
+GL0_PEER_ID=$(CL_KEYSTORE=key.p12 CL_KEYALIAS=alias CL_PASSWORD=password \
+  java -jar $BASE_DIR/jars/cl-wallet.jar show-id 2>/dev/null)
+echo "Primary peer ID: $GL0_PEER_ID"
+
+# Stop existing containers
+echo "[5/8] Stopping existing containers..."
+docker stop gl0 ml0 cl1 cl1-1 cl1-2 dl1 dl1-1 dl1-2 2>/dev/null || true
+docker rm gl0 ml0 cl1 cl1-1 cl1-2 dl1 dl1-1 dl1-2 2>/dev/null || true
+
+# Start GL0
+echo "[6/8] Starting GL0..."
+docker run -d --name gl0 --restart unless-stopped \
+  --network host \
+  -v $BASE_DIR/jars:/jars:ro \
+  -v $BASE_DIR/keys1:/keys:ro \
+  -v $BASE_DIR/data/gl0:/data -w /data \
+  -e CL_KEYSTORE=/keys/key.p12 -e CL_KEYALIAS=alias -e CL_PASSWORD=password \
+  -e CL_EXTERNAL_IP=$HOST \
+  -e CL_PUBLIC_HTTP_PORT=9000 -e CL_P2P_HTTP_PORT=9001 -e CL_CLI_HTTP_PORT=9002 \
+  -e CL_APP_ENV=dev -e CL_COLLATERAL=0 \
+  eclipse-temurin:21-jre-jammy java -Xmx2g -jar /jars/metagraph-l0.jar run-initial-validator
+
+echo "Waiting for GL0..."
+sleep 15
+curl -s http://localhost:9000/node/info | jq .state
+
+# Start ML0
+echo "[7/8] Starting ML0..."
+docker run -d --name ml0 --restart unless-stopped \
+  --network host \
+  -v $BASE_DIR/jars:/jars:ro \
+  -v $BASE_DIR/keys1:/keys:ro \
+  -v $BASE_DIR/data/ml0:/data -w /data \
+  -e CL_KEYSTORE=/keys/key.p12 -e CL_KEYALIAS=alias -e CL_PASSWORD=password \
+  -e CL_L0_TOKEN_IDENTIFIER=$TOKEN \
+  -e CL_GLOBAL_L0_PEER_ID=$GL0_PEER_ID \
+  -e CL_GLOBAL_L0_PEER_HTTP_HOST=$HOST -e CL_GLOBAL_L0_PEER_HTTP_PORT=9000 \
+  -e CL_EXTERNAL_IP=$HOST \
+  -e CL_PUBLIC_HTTP_PORT=9200 -e CL_P2P_HTTP_PORT=9201 -e CL_CLI_HTTP_PORT=9202 \
+  -e CL_APP_ENV=dev -e CL_COLLATERAL=0 \
+  eclipse-temurin:21-jre-jammy java -Xmx2g -jar /jars/metagraph-l0.jar run-initial-validator
+
+echo "Waiting for ML0..."
+sleep 15
+curl -s http://localhost:9200/node/info | jq .state
+
+# Start CL1 cluster (3 nodes)
+echo "[8/8] Starting CL1 and DL1 clusters..."
+
+# CL1 Node 1
+docker run -d --name cl1 --restart unless-stopped --network host \
+  -v $BASE_DIR/jars:/jars:ro -v $BASE_DIR/keys1:/keys:ro \
+  -v $BASE_DIR/data/cl1:/data -w /data \
+  -e CL_KEYSTORE=/keys/key.p12 -e CL_KEYALIAS=alias -e CL_PASSWORD=password \
+  -e CL_L0_TOKEN_IDENTIFIER=$TOKEN \
+  -e CL_GLOBAL_L0_PEER_ID=$GL0_PEER_ID -e CL_GLOBAL_L0_PEER_HTTP_HOST=$HOST -e CL_GLOBAL_L0_PEER_HTTP_PORT=9000 \
+  -e CL_L0_PEER_ID=$GL0_PEER_ID -e CL_L0_PEER_HTTP_HOST=$HOST -e CL_L0_PEER_HTTP_PORT=9200 \
+  -e CL_EXTERNAL_IP=$HOST \
+  -e CL_PUBLIC_HTTP_PORT=9300 -e CL_P2P_HTTP_PORT=9301 -e CL_CLI_HTTP_PORT=9302 \
+  -e CL_APP_ENV=dev -e CL_COLLATERAL=0 \
+  eclipse-temurin:21-jre-jammy java -Xmx1g -jar /jars/currency-l1.jar run-initial-validator
+
+sleep 8
+
+# CL1 Node 2
+docker run -d --name cl1-1 --restart unless-stopped --network host \
+  -v $BASE_DIR/jars:/jars:ro -v $BASE_DIR/keys2:/keys:ro \
+  -v $BASE_DIR/data/cl1-2:/data -w /data \
+  -e CL_KEYSTORE=/keys/key.p12 -e CL_KEYALIAS=alias -e CL_PASSWORD=password \
+  -e CL_L0_TOKEN_IDENTIFIER=$TOKEN \
+  -e CL_GLOBAL_L0_PEER_ID=$GL0_PEER_ID -e CL_GLOBAL_L0_PEER_HTTP_HOST=$HOST -e CL_GLOBAL_L0_PEER_HTTP_PORT=9000 \
+  -e CL_L0_PEER_ID=$GL0_PEER_ID -e CL_L0_PEER_HTTP_HOST=$HOST -e CL_L0_PEER_HTTP_PORT=9200 \
+  -e CL_EXTERNAL_IP=$HOST \
+  -e CL_PUBLIC_HTTP_PORT=9310 -e CL_P2P_HTTP_PORT=9311 -e CL_CLI_HTTP_PORT=9312 \
+  -e CL_APP_ENV=dev -e CL_COLLATERAL=0 \
+  eclipse-temurin:21-jre-jammy java -Xmx1g -jar /jars/currency-l1.jar run-validator
+
+# CL1 Node 3
+docker run -d --name cl1-2 --restart unless-stopped --network host \
+  -v $BASE_DIR/jars:/jars:ro -v $BASE_DIR/keys3:/keys:ro \
+  -v $BASE_DIR/data/cl1-3:/data -w /data \
+  -e CL_KEYSTORE=/keys/key.p12 -e CL_KEYALIAS=alias -e CL_PASSWORD=password \
+  -e CL_L0_TOKEN_IDENTIFIER=$TOKEN \
+  -e CL_GLOBAL_L0_PEER_ID=$GL0_PEER_ID -e CL_GLOBAL_L0_PEER_HTTP_HOST=$HOST -e CL_GLOBAL_L0_PEER_HTTP_PORT=9000 \
+  -e CL_L0_PEER_ID=$GL0_PEER_ID -e CL_L0_PEER_HTTP_HOST=$HOST -e CL_L0_PEER_HTTP_PORT=9200 \
+  -e CL_EXTERNAL_IP=$HOST \
+  -e CL_PUBLIC_HTTP_PORT=9320 -e CL_P2P_HTTP_PORT=9321 -e CL_CLI_HTTP_PORT=9322 \
+  -e CL_APP_ENV=dev -e CL_COLLATERAL=0 \
+  eclipse-temurin:21-jre-jammy java -Xmx1g -jar /jars/currency-l1.jar run-validator
+
+sleep 8
+
+# Join CL1 cluster
+curl -s -X POST "http://localhost:9312/cluster/join" -H "Content-Type: application/json" \
+  -d "{\"id\": \"$GL0_PEER_ID\", \"ip\": \"$HOST\", \"p2pPort\": 9301}"
+curl -s -X POST "http://localhost:9322/cluster/join" -H "Content-Type: application/json" \
+  -d "{\"id\": \"$GL0_PEER_ID\", \"ip\": \"$HOST\", \"p2pPort\": 9301}"
+
+# DL1 Node 1
+docker run -d --name dl1 --restart unless-stopped --network host \
+  -v $BASE_DIR/jars:/jars:ro -v $BASE_DIR/keys1:/keys:ro \
+  -v $BASE_DIR/data/dl1:/data -w /data \
+  -e CL_KEYSTORE=/keys/key.p12 -e CL_KEYALIAS=alias -e CL_PASSWORD=password \
+  -e CL_L0_TOKEN_IDENTIFIER=$TOKEN \
+  -e CL_GLOBAL_L0_PEER_ID=$GL0_PEER_ID -e CL_GLOBAL_L0_PEER_HTTP_HOST=$HOST -e CL_GLOBAL_L0_PEER_HTTP_PORT=9000 \
+  -e CL_L0_PEER_ID=$GL0_PEER_ID -e CL_L0_PEER_HTTP_HOST=$HOST -e CL_L0_PEER_HTTP_PORT=9200 \
+  -e CL_EXTERNAL_IP=$HOST \
+  -e CL_PUBLIC_HTTP_PORT=9400 -e CL_P2P_HTTP_PORT=9401 -e CL_CLI_HTTP_PORT=9402 \
+  -e CL_APP_ENV=dev -e CL_COLLATERAL=0 \
+  eclipse-temurin:21-jre-jammy java -Xmx1g -jar /jars/data-l1.jar run-initial-validator
+
+sleep 8
+
+# DL1 Node 2
+docker run -d --name dl1-1 --restart unless-stopped --network host \
+  -v $BASE_DIR/jars:/jars:ro -v $BASE_DIR/keys2:/keys:ro \
+  -v $BASE_DIR/data/dl1-2:/data -w /data \
+  -e CL_KEYSTORE=/keys/key.p12 -e CL_KEYALIAS=alias -e CL_PASSWORD=password \
+  -e CL_L0_TOKEN_IDENTIFIER=$TOKEN \
+  -e CL_GLOBAL_L0_PEER_ID=$GL0_PEER_ID -e CL_GLOBAL_L0_PEER_HTTP_HOST=$HOST -e CL_GLOBAL_L0_PEER_HTTP_PORT=9000 \
+  -e CL_L0_PEER_ID=$GL0_PEER_ID -e CL_L0_PEER_HTTP_HOST=$HOST -e CL_L0_PEER_HTTP_PORT=9200 \
+  -e CL_EXTERNAL_IP=$HOST \
+  -e CL_PUBLIC_HTTP_PORT=9410 -e CL_P2P_HTTP_PORT=9411 -e CL_CLI_HTTP_PORT=9412 \
+  -e CL_APP_ENV=dev -e CL_COLLATERAL=0 \
+  eclipse-temurin:21-jre-jammy java -Xmx1g -jar /jars/data-l1.jar run-validator
+
+# DL1 Node 3
+docker run -d --name dl1-2 --restart unless-stopped --network host \
+  -v $BASE_DIR/jars:/jars:ro -v $BASE_DIR/keys3:/keys:ro \
+  -v $BASE_DIR/data/dl1-3:/data -w /data \
+  -e CL_KEYSTORE=/keys/key.p12 -e CL_KEYALIAS=alias -e CL_PASSWORD=password \
+  -e CL_L0_TOKEN_IDENTIFIER=$TOKEN \
+  -e CL_GLOBAL_L0_PEER_ID=$GL0_PEER_ID -e CL_GLOBAL_L0_PEER_HTTP_HOST=$HOST -e CL_GLOBAL_L0_PEER_HTTP_PORT=9000 \
+  -e CL_L0_PEER_ID=$GL0_PEER_ID -e CL_L0_PEER_HTTP_HOST=$HOST -e CL_L0_PEER_HTTP_PORT=9200 \
+  -e CL_EXTERNAL_IP=$HOST \
+  -e CL_PUBLIC_HTTP_PORT=9420 -e CL_P2P_HTTP_PORT=9421 -e CL_CLI_HTTP_PORT=9422 \
+  -e CL_APP_ENV=dev -e CL_COLLATERAL=0 \
+  eclipse-temurin:21-jre-jammy java -Xmx1g -jar /jars/data-l1.jar run-validator
+
+sleep 8
+
+# Join DL1 cluster
+curl -s -X POST "http://localhost:9412/cluster/join" -H "Content-Type: application/json" \
+  -d "{\"id\": \"$GL0_PEER_ID\", \"ip\": \"$HOST\", \"p2pPort\": 9401}"
+curl -s -X POST "http://localhost:9422/cluster/join" -H "Content-Type: application/json" \
+  -d "{\"id\": \"$GL0_PEER_ID\", \"ip\": \"$HOST\", \"p2pPort\": 9401}"
+
+sleep 5
+
+echo ""
+echo "========================================"
+echo "Setup Complete!"
+echo "========================================"
+echo "GL0: $(curl -s http://localhost:9000/node/info | jq -r .state)"
+echo "ML0: $(curl -s http://localhost:9200/node/info | jq -r .state)"
+echo "CL1 cluster: $(curl -s http://localhost:9300/cluster/info | jq length) nodes"
+echo "DL1 cluster: $(curl -s http://localhost:9400/cluster/info | jq length) nodes"
+echo "========================================"
+echo "Peer ID: $GL0_PEER_ID"
+echo "Token: $TOKEN"
+echo "========================================"

--- a/docs/API-REFERENCE.md
+++ b/docs/API-REFERENCE.md
@@ -1,0 +1,357 @@
+# OttoChain API Reference
+
+This document covers all HTTP API endpoints for the OttoChain metagraph stack.
+
+## Layers & Default Ports
+
+| Layer | Port | Description |
+|-------|------|-------------|
+| GL0   | 9000 | Global L0 — DAG consensus, global snapshots |
+| GL1   | 9100 | Global L1 — DAG transaction batching |
+| ML0   | 9200 | Metagraph L0 — currency + data snapshots |
+| CL1   | 9300 | Currency L1 — currency transaction batching |
+| DL1   | 9400 | Data L1 — data transaction validation |
+
+---
+
+## Shared Endpoints (All Layers)
+
+These endpoints are available on **all** tessellation nodes (GL0, GL1, ML0, CL1, DL1).
+
+### Node Info
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/node/info` | Node state, version, peer ID, ports |
+| `GET` | `/node/state` | Current node state (Ready, Observing, etc.) |
+| `GET` | `/node/health` | Health check |
+| `GET` | `/node/session` | Current session ID |
+
+### Cluster Management
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/cluster/info` | List of peers in cluster |
+| `GET` | `/cluster/peers` | Peer details |
+| `GET` | `/cluster/session` | Cluster session token |
+| `POST` | `/cluster/join` | Join a cluster |
+| `POST` | `/cluster/leave` | Leave cluster |
+
+### Metrics
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/metrics` | Prometheus metrics |
+
+---
+
+## GL0 — Global L0 (Port 9000)
+
+### Snapshots
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/global-snapshots/latest` | Latest global snapshot |
+| `GET` | `/global-snapshots/latest/ordinal` | Latest ordinal number |
+| `GET` | `/global-snapshots/latest/metadata` | Latest snapshot metadata |
+| `GET` | `/global-snapshots/latest/combined` | Combined snapshot (full state) |
+| `GET` | `/global-snapshots/{ordinal}` | Snapshot by ordinal |
+| `GET` | `/global-snapshots/{hash}` | Snapshot by hash |
+
+### DAG Transactions
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/dag/{address}/balance` | DAG balance for address |
+| `GET` | `/dag/total-supply` | Total DAG supply |
+| `GET` | `/dag/circulated-supply` | Circulated DAG supply |
+| `GET` | `/dag/wallet-count` | Number of wallets |
+
+### State Channels (Metagraphs)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/state-channels` | List registered metagraphs |
+| `GET` | `/metagraph/info` | Metagraph registration info |
+
+### Staking & Delegation
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/delegated-stakes/{address}/info` | Delegation info for address |
+| `GET` | `/delegated-stakes/last-reference/{address}` | Last delegation reference |
+| `GET` | `/delegated-stakes/rewards-info` | Staking rewards info |
+
+### Token Locks
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/token-locks/{hash}` | Token lock by hash |
+| `GET` | `/token-locks/last-reference/{address}` | Last token lock reference |
+
+### Allow Spends
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/allow-spends/{hash}` | Allow spend by hash |
+| `GET` | `/allow-spends/last-reference/{address}` | Last allow spend reference |
+
+### Trust & Collateral
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/trust` | Trust scores |
+| `GET` | `/node-collateral` | Node collateral requirements |
+| `GET` | `/node-parameters` | Network parameters |
+
+---
+
+## GL1 — Global L1 (Port 9100)
+
+### Transactions
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `POST` | `/transactions` | Submit DAG transaction |
+| `GET` | `/transactions/{hash}` | Transaction by hash |
+| `GET` | `/transactions/last-reference/{address}` | Last transaction reference for address |
+
+### Peers
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/l0/peers` | Connected L0 peers |
+
+---
+
+## ML0 — Metagraph L0 (Port 9200)
+
+### Snapshots
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/snapshots/latest` | Latest metagraph snapshot |
+| `GET` | `/snapshots/latest/ordinal` | Latest ordinal |
+| `GET` | `/snapshots/{ordinal}` | Snapshot by ordinal |
+| `GET` | `/snapshots/{hash}` | Snapshot by hash |
+
+### Currency
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/currency/{address}/balance` | Token balance for address |
+| `GET` | `/currency/total-supply` | Total token supply |
+| `GET` | `/currency/circulated-supply` | Circulated supply |
+| `GET` | `/currency/wallet-count` | Number of wallets |
+
+### Data Application State
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/data/state/calculated` | Current calculated state |
+
+### Consensus
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/consensus/latest/peers` | Peers in latest consensus |
+
+---
+
+## CL1 — Currency L1 (Port 9300)
+
+### Transactions
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `POST` | `/transactions` | Submit currency transaction |
+| `GET` | `/transactions/{hash}` | Transaction by hash |
+| `GET` | `/transactions/last-reference/{address}` | Last reference for address |
+
+### Peers
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/l0/peers` | Connected L0 peers |
+
+---
+
+## DL1 — Data L1 (Port 9400)
+
+### Data Submission
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `POST` | `/data` | Submit data transaction |
+| `GET` | `/data` | Current pending data |
+
+### Peers
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/l0/peers` | Connected L0 peers |
+
+---
+
+## OttoChain Custom Endpoints
+
+These endpoints are specific to OttoChain and extend the base tessellation APIs.
+
+### ML0 Custom Routes (Port 9200)
+
+All custom routes are prefixed with `/v1/`.
+
+#### State Machines (Fibers)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/v1/state-machines` | List all state machines |
+| `GET` | `/v1/state-machines?status={status}` | Filter by status (ACTIVE, COMPLETED, etc.) |
+| `GET` | `/v1/state-machines/{fiberId}` | Get specific state machine by UUID |
+| `GET` | `/v1/state-machines/{fiberId}/events` | Event receipts for a fiber |
+
+#### Oracles (Scripts)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/v1/oracles` | List all script oracles |
+| `GET` | `/v1/oracles?status={status}` | Filter by status |
+| `GET` | `/v1/oracles/{oracleId}` | Get specific oracle by UUID |
+| `GET` | `/v1/oracles/{oracleId}/invocations` | Invocation history for oracle |
+
+#### State
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/v1/onchain` | Current on-chain state |
+| `GET` | `/v1/checkpoint` | Current checkpoint (calculated state) |
+
+#### Utilities
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `POST` | `/v1/util/hash` | Compute hash for signed message |
+
+**Request body:**
+```json
+{
+  "value": { ... },  // OttochainMessage
+  "proofs": [ ... ]  // Signatures
+}
+```
+
+**Response:**
+```json
+{
+  "protocol message hash": "abc123...",
+  "protocol message": { ... }
+}
+```
+
+#### Webhooks
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `POST` | `/v1/webhooks/subscribe` | Register webhook subscriber |
+| `DELETE` | `/v1/webhooks/subscribe/{id}` | Unregister subscriber |
+| `GET` | `/v1/webhooks/subscribers` | List all subscribers |
+
+**Subscribe request:**
+```json
+{
+  "callbackUrl": "https://your-server.com/webhook",
+  "secret": "optional-hmac-secret"
+}
+```
+
+**Subscribe response:**
+```json
+{
+  "id": "subscriber-uuid",
+  "callbackUrl": "https://...",
+  "createdAt": "2026-02-06T12:00:00Z"
+}
+```
+
+### DL1 Custom Routes (Port 9400)
+
+All custom routes are prefixed with `/v1/`.
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/v1/onchain` | Current on-chain state (from L1 perspective) |
+| `POST` | `/v1/util/hash` | Compute hash for signed message |
+
+---
+
+## FiberStatus Values
+
+Used in `?status=` query parameter:
+
+| Status | Description |
+|--------|-------------|
+| `ACTIVE` | State machine is running |
+| `COMPLETED` | Reached final state |
+| `SUSPENDED` | Paused/waiting |
+| `FAILED` | Error state |
+
+---
+
+## Common Response Patterns
+
+### Success
+```json
+{
+  "data": { ... }
+}
+```
+
+### Not Found
+```
+Not found
+```
+(Plain text, HTTP 404)
+
+### Validation Error
+```json
+{
+  "code": 3,
+  "message": "Invalid request body",
+  "retriable": false,
+  "details": { "reason": "..." }
+}
+```
+
+---
+
+## Example Queries
+
+### Check ML0 health
+```bash
+curl http://localhost:9200/node/info | jq '.state'
+# "Ready"
+```
+
+### Get token balance
+```bash
+curl http://localhost:9200/currency/DAG5VpYPJCqdv4K3VnpNrpTABvC8RjqrfZN8rUvE/balance
+# {"data":{"balance":100000000000000}}
+```
+
+### List active state machines
+```bash
+curl http://localhost:9200/v1/state-machines?status=ACTIVE | jq
+```
+
+### Submit data transaction to DL1
+```bash
+curl -X POST http://localhost:9400/data \
+  -H "Content-Type: application/json" \
+  -d '{"value":{"CreateStateMachine":{...}},"proofs":[...]}'
+```
+
+### Get total supply with ordinal
+```bash
+curl http://localhost:9200/currency/total-supply
+# {"ordinal":2600,"total":220000000000000}
+```

--- a/docs/design/multi-party-signing-spec.md
+++ b/docs/design/multi-party-signing-spec.md
@@ -1,0 +1,563 @@
+# Multi-Party Fiber Signing — TDD Specification
+
+**Card**: [A1] Spec: Multi-Party Fiber Signing (Metagraph)  
+**Epic**: Multi-Party Signing + Client-Side Signing Refactor (`699ce1fa`)  
+**Repo**: `scasplte2/ottochain`  
+**Branch**: `feat/multi-party-signing`  
+**Status**: Awaiting James's design approval before [A2] tests are written  
+**Last Updated**: 2026-02-23
+
+---
+
+## Problem Statement
+
+Tessellation's DL1 validates that a signed data update carries at least one valid signature — but it does **not** enforce who signed it. Ownership validation is entirely our metagraph's responsibility.
+
+The `FiberRules.L0.updateSignedByOwners` rule currently rejects any `TransitionStateMachine` not signed by one of the fiber's `owners`. The `owners` set is derived solely from the **signers of `CreateStateMachine`** — typically the fiber creator alone.
+
+This breaks multi-party state machines:
+
+```
+Alice creates a contract fiber → Alice is the only owner
+Bob accepts the contract → Bob signs TransitionStateMachine("accept", ...)
+Metagraph rejects: NotSignedByOwner ❌
+```
+
+Real-world use cases broken today:
+- **Contracts**: Creator proposes, counterparty accepts/rejects
+- **Markets**: Seller creates order, buyer fills it
+- **DAOs**: Proposal creator, voters, and treasury signatories are different parties
+- **Escrow**: Initiator and beneficiary both need signing rights
+
+---
+
+## Design Questions — Answered
+
+### Q1: Where does DL1 signer validation happen?
+
+**Answer**: It does **not** happen in Tessellation's DL1 at the application level. Tessellation checks cryptographic signature validity (proof format, hash integrity), but delegates *authorization* entirely to the metagraph's `validateData` / `validateUpdate` hooks.
+
+The `updateSignedByOwners` check is 100% our code in:
+```
+FiberRules.L0.updateSignedByOwners  →  FiberValidator.L0Validator.processEvent
+```
+
+We have full control to extend this rule without touching Tessellation.
+
+### Q2: Should authorized signers live in StateMachineDefinition or CreateStateMachine?
+
+**Answer**: `CreateStateMachine` (not `StateMachineDefinition`).
+
+Rationale:
+- `StateMachineDefinition` is the **template** — the same definition can be reused for many contract instances with different parties.
+- `CreateStateMachine` is the **instance creation message** — it carries instance-specific configuration (fiber ID, initial data, and now participants).
+- A "two-party escrow" definition is generic; the specific Alice/Bob addresses belong to this *instance*.
+
+### Q3: Can we use guard-level checking for signer authorization?
+
+**Answer**: No — not cleanly for Phase 1. The `updateSignedByOwners` check runs *before* guard evaluation in `FiberValidator.L0Validator.processEvent`:
+
+```scala
+def processEvent(update: TransitionStateMachine): F[ValidationResult] =
+  for {
+    fiberActive   <- FiberRules.L0.fiberIsActive(...)     // first
+    signedByOwner <- FiberRules.L0.updateSignedByOwners(...)  // second — before guards
+    transitionOk  <- FiberRules.L0.transitionExists(...)
+  } yield ...
+```
+
+Guard expressions evaluate JSON Logic against fiber `stateData` and the event payload, but signer addresses need to be checked at the validation layer — before the expensive guard execution. The validation layer doesn't run JLVM.
+
+For **Phase 2**, we could expose the transaction signer address as a JLVM context variable (e.g., `$signer`) so guards can do fine-grained per-role authorization. That's out of scope here.
+
+### Q4: What's the minimal change to allow counterparty transitions?
+
+**Answer**: 3 changes across 3 files:
+
+1. `Updates.CreateStateMachine` — add `participants: Option[Set[Address]]`
+2. `Records.StateMachineFiberRecord` — add `authorizedSigners: Set[Address]`
+3. `FiberRules.L0` — add `updateSignedByOwnerOrParticipant` rule
+4. `FiberValidator.L0Validator.processEvent` — use new rule for transitions
+5. `FiberCombiner.createStateMachineFiber` — populate `authorizedSigners`
+
+`archiveFiber` intentionally keeps the strict `updateSignedByOwners` check — only the **owner** can permanently archive a fiber.
+
+### Q5: How does this interact with the delegation system (PR #90)?
+
+**Answer**: These are complementary, not redundant:
+- **Delegation** (PR #90): Bob gets a `DelegationCredential` that lets him sign *on behalf of* Alice — Bob acts as Alice's relayer.
+- **Multi-party signing**: Bob signs *as himself* as a legitimate authorized participant in the fiber.
+
+The `authorizedSigners` approach is simpler and more appropriate for collaborative state machines. Delegation is better suited for "agent acts on behalf of user" scenarios.
+
+---
+
+## Chosen Design: `participants` Field in CreateStateMachine
+
+### Core Principle
+
+At fiber creation, the creator declares which additional addresses may sign transitions. These are stored as `authorizedSigners` on the fiber record. The ownership check for `TransitionStateMachine` is relaxed to accept either an owner or an authorized signer.
+
+### Backward Compatibility
+
+- `participants` is `Option[Set[Address]]` — defaults to `None` → `Set.empty`
+- When `participants` is empty, behavior is identical to current (only owners can sign transitions)
+- All existing fibers continue to work without modification
+- No migration required
+
+---
+
+## Data Model Changes
+
+### 1. `Updates.CreateStateMachine` — New Field
+
+**File**: `modules/models/src/main/scala/xyz/kd5ujc/schema/Updates.scala`
+
+```scala
+// BEFORE
+@derive(customizableDecoder, customizableEncoder)
+final case class CreateStateMachine(
+  fiberId:       UUID,
+  definition:    StateMachineDefinition,
+  initialData:   JsonLogicValue,
+  parentFiberId: Option[UUID] = None
+) extends StateMachineFiberOp
+    with OttochainMessage
+
+// AFTER
+@derive(customizableDecoder, customizableEncoder)
+final case class CreateStateMachine(
+  fiberId:        UUID,
+  definition:     StateMachineDefinition,
+  initialData:    JsonLogicValue,
+  parentFiberId:  Option[UUID] = None,
+  participants:   Option[Set[Address]] = None  // NEW: additional authorized signers
+) extends StateMachineFiberOp
+    with OttochainMessage
+```
+
+**Note**: `Address` is `io.constellationnetwork.schema.address.Address` — already used throughout the codebase.
+
+### 2. `Records.StateMachineFiberRecord` — New Field
+
+**File**: `modules/models/src/main/scala/xyz/kd5ujc/schema/Records.scala`
+
+```scala
+// BEFORE
+@derive(customizableEncoder, customizableDecoder)
+final case class StateMachineFiberRecord(
+  fiberId:               UUID,
+  creationOrdinal:       SnapshotOrdinal,
+  previousUpdateOrdinal: SnapshotOrdinal,
+  latestUpdateOrdinal:   SnapshotOrdinal,
+  definition:            StateMachineDefinition,
+  currentState:          StateId,
+  stateData:             JsonLogicValue,
+  stateDataHash:         Hash,
+  sequenceNumber:        FiberOrdinal,
+  owners:                Set[Address],
+  status:                FiberStatus,
+  lastReceipt:           Option[EventReceipt] = None,
+  parentFiberId:         Option[UUID] = None,
+  childFiberIds:         Set[UUID] = Set.empty
+) extends FiberRecord
+
+// AFTER
+@derive(customizableEncoder, customizableDecoder)
+final case class StateMachineFiberRecord(
+  fiberId:               UUID,
+  creationOrdinal:       SnapshotOrdinal,
+  previousUpdateOrdinal: SnapshotOrdinal,
+  latestUpdateOrdinal:   SnapshotOrdinal,
+  definition:            StateMachineDefinition,
+  currentState:          StateId,
+  stateData:             JsonLogicValue,
+  stateDataHash:         Hash,
+  sequenceNumber:        FiberOrdinal,
+  owners:                Set[Address],
+  status:                FiberStatus,
+  lastReceipt:           Option[EventReceipt] = None,
+  parentFiberId:         Option[UUID] = None,
+  childFiberIds:         Set[UUID] = Set.empty,
+  authorizedSigners:     Set[Address] = Set.empty  // NEW: additional transition signers
+) extends FiberRecord
+```
+
+**Key distinction**:
+- `owners`: Can sign **any** operation (transition + archive). Derived from `CreateStateMachine` proofs.
+- `authorizedSigners`: Can sign **transitions only** (not archive). Declared in `CreateStateMachine.participants`.
+
+### 3. Proto Schema Update
+
+**File**: `modules/proto/src/main/protobuf/records.proto`
+
+```protobuf
+message StateMachineFiberRecord {
+  // ... existing fields ...
+  repeated string authorized_signers = 15;  // NEW — wallet address strings
+}
+```
+
+---
+
+## New Validation Rule
+
+### `FiberRules.L0.updateSignedByOwnerOrParticipant`
+
+**File**: `modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/validate/rules/FiberRules.scala`
+
+```scala
+object L0 {
+
+  // ... existing rules unchanged ...
+
+  /**
+   * Validates that the update is signed by an owner OR an authorized participant.
+   *
+   * Used for TransitionStateMachine operations where counterparties are allowed.
+   * Owners: derived from CreateStateMachine signers (can do anything)
+   * AuthorizedSigners: declared in CreateStateMachine.participants (transitions only)
+   *
+   * Note: ArchiveStateMachine still uses updateSignedByOwners (strict — owners only).
+   */
+  def updateSignedByOwnerOrParticipant[F[_]: Async: SecurityProvider](
+    cid:    UUID,
+    proofs: NonEmptySet[SignatureProof],
+    state:  CalculatedState
+  ): F[ValidationResult] = (for {
+    record          <- state.getFiberRecord(cid)
+    signerAddresses <- EitherT.liftF(proofs.toList.traverse(_.id.toAddress))
+    signerSet = signerAddresses.toSet
+    
+    // Authorized = owners ∪ authorizedSigners
+    authorizedSet = record match {
+      case sm: Records.StateMachineFiberRecord => sm.owners ++ sm.authorizedSigners
+      case other                               => other.owners
+    }
+    
+    result <- EitherT.cond[F](
+      signerSet.intersect(authorizedSet).nonEmpty,
+      (),
+      Errors.NotSignedByAuthorizedParty: DataApplicationValidationError
+    )
+  } yield result).fold(
+    _.invalidNec[Unit],
+    _.validNec[DataApplicationValidationError]
+  )
+}
+
+object Errors {
+  // ... existing errors unchanged ...
+
+  /** New error for multi-party signing rejection */
+  final case object NotSignedByAuthorizedParty extends DataApplicationValidationError {
+    override val message: String =
+      "Update not signed by any fiber owner or authorized participant"
+  }
+}
+```
+
+**Note**: Keep the existing `Errors.NotSignedByOwner` for backward compatibility (still used by archive validation and the error is still useful for the strict owner-only case). Add `NotSignedByAuthorizedParty` as a distinct error for the relaxed check.
+
+---
+
+## Validator Changes
+
+### `FiberValidator.L0Validator.processEvent`
+
+**File**: `modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/validate/FiberValidator.scala`
+
+```scala
+/** Validates a ProcessFiberEvent update (L0 specific checks) */
+def processEvent(update: TransitionStateMachine): F[ValidationResult] =
+  for {
+    fiberActive   <- FiberRules.L0.fiberIsActive(update.fiberId, state.calculated)
+    // CHANGED: was updateSignedByOwners, now allows authorized participants too
+    signedOk      <- FiberRules.L0.updateSignedByOwnerOrParticipant(update.fiberId, proofs, state.calculated)
+    transitionOk  <- FiberRules.L0.transitionExists(update.fiberId, update.eventName, state.calculated)
+  } yield List(fiberActive, signedOk, transitionOk).combineAll
+
+/** Validates an ArchiveFiber update (L0 specific checks) — UNCHANGED */
+def archiveFiber(update: ArchiveStateMachine): F[ValidationResult] =
+  for {
+    fiberActive   <- FiberRules.L0.fiberIsActive(update.fiberId, state.calculated)
+    signedByOwner <- FiberRules.L0.updateSignedByOwners(update.fiberId, proofs, state.calculated)
+    // ^ STRICT — only owners can archive, not participants
+  } yield List(fiberActive, signedByOwner).combineAll
+```
+
+---
+
+## Combiner Changes
+
+### `FiberCombiner.createStateMachineFiber`
+
+**File**: `modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/combine/FiberCombiner.scala`
+
+```scala
+def createStateMachineFiber(
+  update: Signed[Updates.CreateStateMachine]
+): CombineResult[F] = for {
+  currentOrdinal  <- ctx.getCurrentOrdinal
+  owners          <- update.proofs.toList.traverse(_.id.toAddress).map(Set.from)
+  initialDataHash <- update.initialData.computeDigest
+
+  // NEW: participants become authorized signers on the fiber record
+  authorizedSigners = update.participants.getOrElse(Set.empty)
+
+  record = Records.StateMachineFiberRecord(
+    fiberId = update.fiberId,
+    creationOrdinal = currentOrdinal,
+    previousUpdateOrdinal = currentOrdinal,
+    latestUpdateOrdinal = currentOrdinal,
+    definition = update.definition,
+    currentState = update.definition.initialState,
+    stateData = update.initialData,
+    stateDataHash = initialDataHash,
+    sequenceNumber = FiberOrdinal.MinValue,
+    owners = owners,
+    status = FiberStatus.Active,
+    parentFiberId = update.parentFiberId,
+    authorizedSigners = authorizedSigners  // NEW
+  )
+
+  result <- current.withRecord[F](update.fiberId, record)
+} yield result
+```
+
+---
+
+## TDD Test Cases
+
+Write these tests in `modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/MultiPartySigningSuite.scala` using the `weaver` + `TestFixture` + `ParticipantRegistry` patterns from existing suites.
+
+**Reference patterns**: `ValidatorSuite.scala`, `SpawnMachinesSuite.scala`
+
+### Group 1: Backward Compatibility (3 tests)
+
+**T1.1 — Existing single-owner fiber still works**
+```
+setup: Create fiber with Alice as signer, no participants declared
+action: Alice signs TransitionStateMachine("advance", ...)
+expect: ValidationResult.Valid ✓
+```
+
+**T1.2 — Non-owner without participants still rejected**
+```
+setup: Create fiber with Alice as signer, no participants declared
+action: Bob signs TransitionStateMachine("advance", ...)
+expect: ValidationResult.Invalid(NotSignedByAuthorizedParty) ✓
+```
+
+**T1.3 — Archive still requires owner even with participants**
+```
+setup: Create fiber with Alice as signer, Bob as participant
+action: Bob signs ArchiveStateMachine(...)
+expect: ValidationResult.Invalid(NotSignedByOwner) ✓
+   — Bob can transition but cannot archive
+```
+
+### Group 2: Multi-Party Transition Signing (4 tests)
+
+**T2.1 — Authorized participant can trigger transition**
+```
+setup: Alice creates fiber with participants = Set(Bob.address)
+action: Bob signs TransitionStateMachine("accept", ...)
+expect: ValidationResult.Valid ✓
+```
+
+**T2.2 — Multiple participants declared, any one can transition**
+```
+setup: Alice creates fiber with participants = Set(Bob, Charlie, Dave)
+action: Charlie signs TransitionStateMachine("vote", ...)
+expect: ValidationResult.Valid ✓
+```
+
+**T2.3 — Non-participant still rejected even with participants present**
+```
+setup: Alice creates fiber with participants = Set(Bob.address)
+action: Charlie (not in participants) signs TransitionStateMachine(...)
+expect: ValidationResult.Invalid(NotSignedByAuthorizedParty) ✓
+```
+
+**T2.4 — Owner can still transition even with participants set**
+```
+setup: Alice creates fiber with participants = Set(Bob.address)
+action: Alice (owner) signs TransitionStateMachine("advance", ...)
+expect: ValidationResult.Valid ✓
+   — adding participants doesn't remove owner rights
+```
+
+### Group 3: CreateStateMachine Encoding (2 tests)
+
+**T3.1 — participants field serializes/deserializes correctly**
+```
+setup: CreateStateMachine with participants = Some(Set(Alice.address, Bob.address))
+action: encode to JSON, decode back
+expect: participants field round-trips correctly
+   — verify Set ordering is stable (sorted by address)
+```
+
+**T3.2 — Omitted participants field defaults to empty**
+```
+setup: CreateStateMachine without participants field (legacy format)
+action: decode from JSON {"fiberId":..., "definition":..., "initialData":...}
+expect: participants = None (and fiber record authorizedSigners = Set.empty)
+   — backward compatible deserialization
+```
+
+### Group 4: FiberRecord Encoding (2 tests)
+
+**T4.1 — authorizedSigners field persists in FiberRecord**
+```
+setup: Create fiber with Bob as participant, advance state
+action: read StateMachineFiberRecord from CalculatedState
+expect: record.authorizedSigners = Set(Bob.address) ✓
+```
+
+**T4.2 — Legacy FiberRecord without authorizedSigners decodes correctly**
+```
+setup: JSON FiberRecord without authorizedSigners field (legacy snapshot)
+action: decode
+expect: authorizedSigners = Set.empty (no crash, backward compat) ✓
+```
+
+### Group 5: Full Round-Trip Integration (2 tests)
+
+**T5.1 — Two-party contract lifecycle**
+```
+scenario:
+  1. Alice creates contract fiber with participants = Set(Bob)
+  2. Bob signs "accept" transition → Valid ✓
+  3. Alice signs "release" transition → Valid ✓
+  4. Charlie signs anything → Invalid ✓
+  5. Bob tries to archive → Invalid (NotSignedByOwner) ✓
+  6. Alice archives → Valid ✓
+```
+
+**T5.2 — Owner-also-participant: no double-counting issues**
+```
+setup: Alice creates fiber with participants = Set(Alice.address)
+   — Alice is both owner and in participants list
+action: Alice signs TransitionStateMachine
+expect: Valid ✓ (no error from union of owners + authorizedSigners)
+```
+
+### Group 6: Combiner Integration (2 tests)
+
+**T6.1 — participants populate authorizedSigners on created record**
+```
+setup: Alice creates fiber with participants = Some(Set(Bob.address, Charlie.address))
+action: run through full Combiner.combine pipeline
+expect: retrieved FiberRecord.authorizedSigners == Set(Bob.address, Charlie.address) ✓
+```
+
+**T6.2 — No participants → authorizedSigners empty, validation unchanged**
+```
+setup: Alice creates fiber without participants
+action: Bob tries to transition, run through L0 validation
+expect: NotSignedByAuthorizedParty (same as legacy NotSignedByOwner behavior) ✓
+```
+
+---
+
+## Implementation Plan
+
+### Phase 1 (this spec): Static Participants at Creation Time
+
+| Step | File | Change |
+|------|------|--------|
+| 1 | `Updates.scala` | Add `participants: Option[Set[Address]]` to `CreateStateMachine` |
+| 2 | `Records.scala` | Add `authorizedSigners: Set[Address]` to `StateMachineFiberRecord` |
+| 3 | `FiberRules.scala` | Add `updateSignedByOwnerOrParticipant` + `NotSignedByAuthorizedParty` error |
+| 4 | `FiberValidator.scala` | Use new rule in `processEvent` |
+| 5 | `FiberCombiner.scala` | Populate `authorizedSigners` from `update.participants` |
+| 6 | `records.proto` | Add `authorized_signers` field (repeated string, field 15) |
+
+**Target release**: v0.8.0 (breaking change: new field on FiberRecord, proto schema update)
+
+### Phase 2 (future): Dynamic Participant Management
+
+Two approaches for future consideration:
+
+**Option A: `AddAuthorizedSigner` / `RemoveAuthorizedSigner` OttochainMessage**
+```scala
+// New message variants
+case class AddAuthorizedSigner(fiberId: UUID, signer: Address, targetSeq: FiberOrdinal)
+case class RemoveAuthorizedSigner(fiberId: UUID, signer: Address, targetSeq: FiberOrdinal)
+```
+- Only owners can add/remove
+- Useful for: auction bidder reveals, DAO member additions
+
+**Option B: JLVM `$signers` context variable**
+```jsonc
+// Guard that checks transition-specific signer:
+{
+  "in": [{"var": "$signer"}, {"var": "state.approvedParties"}]
+}
+```
+- State-data-driven authorization
+- More powerful but requires guard evaluation before rejection
+- Requires redesigning validation order
+
+**Recommendation**: Phase 2 starts when integration tests (Epic C) are green and James approves the direction.
+
+---
+
+## Acceptance Criteria (James Review)
+
+- [ ] **Design approved**: James agrees with the `participants` field approach vs alternatives
+- [ ] **Backward compat confirmed**: No migration needed for existing fibers or snapshots
+- [ ] **Scope confirmed**: Phase 1 = static participants only; dynamic management = Phase 2
+- [ ] **Error naming approved**: `NotSignedByAuthorizedParty` vs reusing `NotSignedByOwner`
+- [ ] **Proto field number confirmed**: field 15 for `authorized_signers` in `StateMachineFiberRecord`
+
+---
+
+## Open Questions for James
+
+1. **Should participants be validated at CreateStateMachine time?** e.g., reject if `participants` contains an address that is also in `owners` (redundant)? Or silently allow duplicates (union is idempotent)?
+
+2. **Archive permission**: Should authorized participants EVER be able to archive a fiber? (Current spec: no — only owners can archive.) Use case: Bob created a delegation on Alice's behalf, Alice is unavailable, Bob needs to clean up.
+
+3. **Participant limit**: Should we impose a `MaxParticipants` limit (e.g., 10) similar to `MaxStates`? Prevents griefing via enormous participant sets.
+
+4. **Bridge API**: When clients submit `CreateStateMachine` via the bridge, does the bridge need a new `participants` field in its request body? Or is this a future concern?
+
+---
+
+## Files to Change
+
+```
+scasplte2/ottochain
+├── modules/models/src/main/scala/xyz/kd5ujc/schema/
+│   ├── Updates.scala                    # Add participants field
+│   └── Records.scala                   # Add authorizedSigners field
+├── modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/
+│   ├── validate/rules/FiberRules.scala  # New rule + new error
+│   ├── validate/FiberValidator.scala    # Use new rule in processEvent
+│   └── combine/FiberCombiner.scala     # Populate authorizedSigners
+├── modules/proto/src/main/protobuf/
+│   └── records.proto                   # Add authorized_signers field
+└── modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/
+    └── MultiPartySigningSuite.scala    # NEW — 15 TDD tests (write BEFORE implementing)
+```
+
+No changes needed in:
+- `FiberEngine.scala` — evaluation layer unchanged
+- `Validator.scala` — routes to validators, not affected
+- DL1/ML0 layers — no Tessellation changes needed
+- `ottochain-services` — bridge changes are Epic B (client-side signing)
+- `ottochain-sdk` — SDK changes are Epic B (build/submit endpoints)
+
+---
+
+## Why NOT These Alternatives
+
+| Alternative | Why Rejected |
+|-------------|--------------|
+| **Co-ownership** (all participants become owners) | Participants gain archive rights — dangerous. Semantic mismatch. |
+| **Guard-level signer check** (`$signer` JLVM var) | Requires evaluation pass before rejection; more complex; Phase 2 |
+| **Extend delegation system** (everyone gets a credential) | Over-engineered for simple 2-party case; delegation = relaying, not participating |
+| **Tessellation fork** (modify DL1 signer validation) | Never — would break all metagraphs, requires Constellation approval |
+| **Bridge-side proxy signing** (bridge holds all keys) | Security anti-pattern; defeats the purpose of client-side signing |

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1,0 +1,829 @@
+openapi: 3.0.3
+info:
+  title: OttoChain Metagraph API
+  description: |
+    API for interacting with OttoChain metagraph on Constellation Network.
+    
+    ## Layers & Ports
+    | Layer | Port | Description |
+    |-------|------|-------------|
+    | GL0   | 9000 | Global L0 — DAG consensus |
+    | GL1   | 9100 | Global L1 — DAG transaction batching |
+    | ML0   | 9200 | Metagraph L0 — OttoChain snapshots |
+    | CL1   | 9300 | Currency L1 — token transactions |
+    | DL1   | 9400 | Data L1 — data transaction validation |
+  version: 1.0.0
+  contact:
+    name: OttoChain
+    url: https://github.com/scasplte2/ottochain
+  license:
+    name: MIT
+
+servers:
+  - url: http://localhost:9200
+    description: Local ML0 (Metagraph L0)
+  - url: http://localhost:9400
+    description: Local DL1 (Data L1)
+
+tags:
+  - name: Node
+    description: Node status and health
+  - name: Cluster
+    description: Cluster management
+  - name: Snapshots
+    description: Metagraph snapshots
+  - name: StateMachines
+    description: OttoChain state machines (fibers)
+  - name: Currency
+    description: Token operations
+
+paths:
+  # ===== Node Endpoints =====
+  /node/info:
+    get:
+      tags: [Node]
+      summary: Get node information
+      operationId: getNodeInfo
+      responses:
+        '200':
+          description: Node information
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NodeInfo'
+
+  /node/state:
+    get:
+      tags: [Node]
+      summary: Get node state
+      operationId: getNodeState
+      responses:
+        '200':
+          description: Current node state
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NodeState'
+
+  /node/health:
+    get:
+      tags: [Node]
+      summary: Health check
+      operationId: getHealth
+      responses:
+        '200':
+          description: Node is healthy
+        '503':
+          description: Node is unhealthy
+
+  /node/session:
+    get:
+      tags: [Node]
+      summary: Get current session ID
+      operationId: getNodeSession
+      responses:
+        '200':
+          description: Current session
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  session:
+                    type: string
+
+  /metrics:
+    get:
+      tags: [Node]
+      summary: Prometheus metrics
+      operationId: getMetrics
+      responses:
+        '200':
+          description: Prometheus metrics
+          content:
+            text/plain:
+              schema:
+                type: string
+
+  # ===== Cluster Endpoints =====
+  /cluster/info:
+    get:
+      tags: [Cluster]
+      summary: Get cluster info
+      operationId: getClusterInfo
+      responses:
+        '200':
+          description: Cluster peer list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ClusterPeer'
+
+  /cluster/session:
+    get:
+      tags: [Cluster]
+      summary: Get cluster session
+      operationId: getClusterSession
+      responses:
+        '200':
+          description: Current cluster session
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ClusterSession'
+
+  /cluster/peers:
+    get:
+      tags: [Cluster]
+      summary: Get peer details
+      operationId: getClusterPeers
+      responses:
+        '200':
+          description: Detailed peer information
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ClusterPeer'
+
+  /cluster/join:
+    post:
+      tags: [Cluster]
+      summary: Join cluster
+      operationId: joinCluster
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/JoinRequest'
+      responses:
+        '200':
+          description: Successfully joined
+        '400':
+          description: Invalid request
+
+  /cluster/leave:
+    post:
+      tags: [Cluster]
+      summary: Leave cluster
+      operationId: leaveCluster
+      responses:
+        '200':
+          description: Successfully left cluster
+
+  # ===== Snapshot Endpoints (ML0) =====
+  /snapshots/latest:
+    get:
+      tags: [Snapshots]
+      summary: Get latest snapshot
+      operationId: getLatestSnapshot
+      responses:
+        '200':
+          description: Latest metagraph snapshot
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Snapshot'
+
+  /snapshots/latest/ordinal:
+    get:
+      tags: [Snapshots]
+      summary: Get latest ordinal
+      operationId: getLatestOrdinal
+      responses:
+        '200':
+          description: Latest snapshot ordinal
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SnapshotOrdinal'
+
+  /snapshots/{ordinal}:
+    get:
+      tags: [Snapshots]
+      summary: Get snapshot by ordinal
+      operationId: getSnapshotByOrdinal
+      parameters:
+        - name: ordinal
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: Snapshot at ordinal
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Snapshot'
+        '404':
+          description: Snapshot not found
+
+  /snapshots/latest/metadata:
+    get:
+      tags: [Snapshots]
+      summary: Get latest snapshot metadata
+      operationId: getLatestSnapshotMetadata
+      responses:
+        '200':
+          description: Snapshot metadata
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SnapshotMetadata'
+
+  /snapshots/latest/combined:
+    get:
+      tags: [Snapshots]
+      summary: Get latest combined snapshot
+      operationId: getLatestCombinedSnapshot
+      responses:
+        '200':
+          description: Combined snapshot with full state
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CombinedSnapshot'
+
+  /snapshots/{hash}:
+    get:
+      tags: [Snapshots]
+      summary: Get snapshot by hash
+      operationId: getSnapshotByHash
+      parameters:
+        - name: hash
+          in: path
+          required: true
+          schema:
+            $ref: '#/components/schemas/HashValue'
+      responses:
+        '200':
+          description: Snapshot
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Snapshot'
+        '404':
+          description: Snapshot not found
+
+  # ===== OttoChain Custom Endpoints =====
+  /v1/state-machines:
+    get:
+      tags: [StateMachines]
+      summary: List all state machines
+      operationId: listStateMachines
+      responses:
+        '200':
+          description: List of state machine fiber records
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/StateMachineFiberRecord'
+
+  /v1/state-machines/{fiberId}:
+    get:
+      tags: [StateMachines]
+      summary: Get state machine by fiber ID
+      operationId: getStateMachine
+      parameters:
+        - name: fiberId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: State machine fiber record
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StateMachineFiberRecord'
+        '404':
+          description: State machine not found
+
+  /v1/checkpoint:
+    get:
+      tags: [StateMachines]
+      summary: Get latest checkpoint
+      operationId: getCheckpoint
+      responses:
+        '200':
+          description: Latest on-chain state checkpoint
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OnChainState'
+
+  # ===== Currency Endpoints =====
+  /currency/{address}/balance:
+    get:
+      tags: [Currency]
+      summary: Get token balance
+      operationId: getBalance
+      parameters:
+        - name: address
+          in: path
+          required: true
+          schema:
+            $ref: '#/components/schemas/Address'
+      responses:
+        '200':
+          description: Token balance
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Balance'
+
+  /currency/total-supply:
+    get:
+      tags: [Currency]
+      summary: Get total token supply
+      operationId: getTotalSupply
+      responses:
+        '200':
+          description: Total supply
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TokenSupply'
+
+  /currency/last-reference/{address}:
+    get:
+      tags: [Currency]
+      summary: Get last transaction reference for address
+      operationId: getLastReference
+      parameters:
+        - name: address
+          in: path
+          required: true
+          schema:
+            $ref: '#/components/schemas/Address'
+      responses:
+        '200':
+          description: Last reference
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TransactionReference'
+
+  # ===== Transaction Endpoints (CL1) =====
+  /transactions:
+    post:
+      tags: [Currency]
+      summary: Submit currency transaction
+      operationId: submitTransaction
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SignedTransaction'
+      responses:
+        '200':
+          description: Transaction accepted
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TransactionResponse'
+        '400':
+          description: Invalid transaction
+
+  /transactions/{hash}:
+    get:
+      tags: [Currency]
+      summary: Get pending transaction by hash
+      operationId: getTransaction
+      parameters:
+        - name: hash
+          in: path
+          required: true
+          schema:
+            $ref: '#/components/schemas/HashValue'
+      responses:
+        '200':
+          description: Transaction details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TransactionInfo'
+        '404':
+          description: Transaction not found
+
+  # ===== Data L1 Endpoints =====
+  /data:
+    post:
+      tags: [StateMachines]
+      summary: Submit data transaction
+      operationId: submitDataTransaction
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DataTransaction'
+      responses:
+        '200':
+          description: Transaction accepted
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TransactionResponse'
+        '400':
+          description: Invalid transaction
+
+components:
+  schemas:
+    # ===== Common Types (from ottochain.v1.common) =====
+    Address:
+      type: string
+      pattern: '^DAG[0-9A-Za-z]{37}$'
+      description: Constellation DAG address
+      example: "DAG4o41NzhfX6DyYBTTXu6sJa6awm36abJpv89jB"
+
+    HashValue:
+      type: string
+      pattern: '^[a-f0-9]{64}$'
+      description: 256-bit hash value
+      example: "a1b2c3d4e5f6789012345678901234567890123456789012345678901234abcd"
+
+    SnapshotOrdinal:
+      type: object
+      properties:
+        value:
+          type: integer
+          format: int64
+      required: [value]
+
+    FiberOrdinal:
+      type: object
+      properties:
+        value:
+          type: integer
+          format: int64
+      required: [value]
+
+    StateId:
+      type: object
+      properties:
+        value:
+          type: string
+      required: [value]
+
+    # ===== Node Types =====
+    NodeInfo:
+      type: object
+      properties:
+        state:
+          $ref: '#/components/schemas/NodeState'
+        version:
+          type: string
+        host:
+          type: string
+        publicPort:
+          type: integer
+        p2pPort:
+          type: integer
+        id:
+          type: string
+          description: Node peer ID
+        session:
+          type: string
+
+    NodeState:
+      type: string
+      enum:
+        - Initial
+        - ReadyToJoin
+        - LoadingGenesis
+        - GenesisReady
+        - RollbackInProgress
+        - RollbackDone
+        - StartingSession
+        - SessionStarted
+        - WaitingForDownload
+        - DownloadInProgress
+        - Observing
+        - WaitingForObserving
+        - WaitingForReady
+        - Ready
+        - Leaving
+        - Offline
+
+    # ===== Cluster Types =====
+    ClusterPeer:
+      type: object
+      properties:
+        id:
+          type: string
+        ip:
+          type: string
+        publicPort:
+          type: integer
+        p2pPort:
+          type: integer
+        session:
+          type: string
+        state:
+          $ref: '#/components/schemas/NodeState'
+
+    ClusterSession:
+      type: object
+      properties:
+        token:
+          type: string
+
+    JoinRequest:
+      type: object
+      properties:
+        id:
+          type: string
+          description: Peer ID to join
+        ip:
+          type: string
+        p2pPort:
+          type: integer
+      required: [id, ip, p2pPort]
+
+    # ===== Snapshot Types =====
+    Snapshot:
+      type: object
+      properties:
+        ordinal:
+          $ref: '#/components/schemas/SnapshotOrdinal'
+        hash:
+          $ref: '#/components/schemas/HashValue'
+        lastSnapshotHash:
+          $ref: '#/components/schemas/HashValue'
+        timestamp:
+          type: string
+          format: date-time
+        blocks:
+          type: array
+          items:
+            type: object
+        tips:
+          type: object
+
+    SnapshotMetadata:
+      type: object
+      properties:
+        ordinal:
+          $ref: '#/components/schemas/SnapshotOrdinal'
+        hash:
+          $ref: '#/components/schemas/HashValue'
+        timestamp:
+          type: string
+          format: date-time
+        size:
+          type: integer
+
+    CombinedSnapshot:
+      type: object
+      properties:
+        snapshot:
+          $ref: '#/components/schemas/Snapshot'
+        state:
+          type: object
+          description: Full calculated state
+
+    # ===== OttoChain State Machine Types (from ottochain.v1.records) =====
+    StateMachineFiberRecord:
+      type: object
+      description: On-chain state machine fiber record
+      properties:
+        fiberId:
+          type: string
+          description: Unique fiber identifier
+        creationOrdinal:
+          $ref: '#/components/schemas/SnapshotOrdinal'
+        previousUpdateOrdinal:
+          $ref: '#/components/schemas/SnapshotOrdinal'
+        latestUpdateOrdinal:
+          $ref: '#/components/schemas/SnapshotOrdinal'
+        definition:
+          $ref: '#/components/schemas/StateMachineDefinition'
+        currentState:
+          $ref: '#/components/schemas/StateId'
+        stateData:
+          type: object
+          description: Current state data (JSON)
+        stateDataHash:
+          $ref: '#/components/schemas/HashValue'
+        sequenceNumber:
+          $ref: '#/components/schemas/FiberOrdinal'
+        owners:
+          type: array
+          items:
+            $ref: '#/components/schemas/Address'
+        status:
+          $ref: '#/components/schemas/FiberStatus'
+        lastReceipt:
+          $ref: '#/components/schemas/EventReceipt'
+        parentFiberId:
+          type: string
+        childFiberIds:
+          type: array
+          items:
+            type: string
+
+    StateMachineDefinition:
+      type: object
+      description: State machine definition (from ottochain.v1.fiber)
+      properties:
+        states:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/StateDefinition'
+        initialState:
+          $ref: '#/components/schemas/StateId'
+        version:
+          type: string
+
+    StateDefinition:
+      type: object
+      properties:
+        transitions:
+          type: array
+          items:
+            $ref: '#/components/schemas/TransitionDefinition'
+        onEnter:
+          type: object
+        onExit:
+          type: object
+
+    TransitionDefinition:
+      type: object
+      properties:
+        event:
+          type: string
+        target:
+          $ref: '#/components/schemas/StateId'
+        guard:
+          type: object
+          description: JSON Logic guard condition
+        actions:
+          type: array
+          items:
+            type: object
+
+    FiberStatus:
+      type: string
+      enum:
+        - FIBER_STATUS_UNSPECIFIED
+        - ACTIVE
+        - COMPLETED
+        - SUSPENDED
+        - DEACTIVATED
+        - MIGRATING
+        - PENDING_VERIFICATION
+      description: Current fiber status
+
+    EventReceipt:
+      type: object
+      properties:
+        eventHash:
+          $ref: '#/components/schemas/HashValue'
+        success:
+          type: boolean
+        resultData:
+          type: object
+        errorMessage:
+          type: string
+
+    OnChainState:
+      type: object
+      description: Complete on-chain state checkpoint
+      properties:
+        fiberCommits:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/FiberCommit'
+        latestLogs:
+          type: object
+          additionalProperties:
+            type: array
+            items:
+              $ref: '#/components/schemas/FiberLogEntry'
+
+    FiberCommit:
+      type: object
+      properties:
+        recordHash:
+          $ref: '#/components/schemas/HashValue'
+        stateDataHash:
+          $ref: '#/components/schemas/HashValue'
+        sequenceNumber:
+          $ref: '#/components/schemas/FiberOrdinal'
+
+    FiberLogEntry:
+      type: object
+      properties:
+        ordinal:
+          $ref: '#/components/schemas/FiberOrdinal'
+        eventType:
+          type: string
+        data:
+          type: object
+        timestamp:
+          type: string
+          format: date-time
+
+    # ===== Currency Types =====
+    Balance:
+      type: object
+      properties:
+        balance:
+          type: integer
+          format: int64
+        ordinal:
+          $ref: '#/components/schemas/SnapshotOrdinal'
+
+    TokenSupply:
+      type: object
+      properties:
+        total:
+          type: integer
+          format: int64
+
+    TransactionReference:
+      type: object
+      properties:
+        ordinal:
+          type: integer
+          format: int64
+        hash:
+          $ref: '#/components/schemas/HashValue'
+
+    SignedTransaction:
+      type: object
+      properties:
+        value:
+          $ref: '#/components/schemas/Transaction'
+        proofs:
+          type: array
+          items:
+            $ref: '#/components/schemas/Proof'
+      required: [value, proofs]
+
+    Transaction:
+      type: object
+      properties:
+        source:
+          $ref: '#/components/schemas/Address'
+        destination:
+          $ref: '#/components/schemas/Address'
+        amount:
+          type: integer
+          format: int64
+        fee:
+          type: integer
+          format: int64
+        parent:
+          $ref: '#/components/schemas/TransactionReference'
+        salt:
+          type: integer
+          format: int64
+
+    TransactionInfo:
+      type: object
+      properties:
+        transaction:
+          $ref: '#/components/schemas/SignedTransaction'
+        hash:
+          $ref: '#/components/schemas/HashValue'
+        status:
+          type: string
+          enum: [Pending, Accepted, Rejected]
+
+    # ===== Transaction Types =====
+    DataTransaction:
+      type: object
+      properties:
+        value:
+          type: object
+          description: Transaction payload
+        proofs:
+          type: array
+          items:
+            $ref: '#/components/schemas/Proof'
+
+    Proof:
+      type: object
+      properties:
+        id:
+          type: string
+        signature:
+          type: string
+
+    TransactionResponse:
+      type: object
+      properties:
+        hash:
+          $ref: '#/components/schemas/HashValue'

--- a/e2e-test/examples/approval-workflow/definition.json
+++ b/e2e-test/examples/approval-workflow/definition.json
@@ -1,50 +1,101 @@
 {
   "states": {
     "draft": {
-      "id": { "value": "draft" },
+      "id": "draft",
       "isFinal": false,
       "metadata": null
     },
     "submitted": {
-      "id": { "value": "submitted" },
+      "id": "submitted",
       "isFinal": false,
       "metadata": null
     },
     "approved": {
-      "id": { "value": "approved" },
+      "id": "approved",
       "isFinal": true,
       "metadata": null
     },
     "rejected": {
-      "id": { "value": "rejected" },
+      "id": "rejected",
       "isFinal": true,
       "metadata": null
     }
   },
-  "initialState": { "value": "draft" },
+  "initialState": "draft",
   "transitions": [
     {
-      "from": { "value": "draft" },
-      "to": { "value": "submitted" },
+      "from": "draft",
+      "to": "submitted",
       "eventName": "submit",
-      "guard": { "==": [1, 1] },
-      "effect": { "merge": [{ "var": "state" }, { "submittedAt": { "var": "event.timestamp" } }] },
+      "guard": {
+        "==": [
+          1,
+          1
+        ]
+      },
+      "effect": {
+        "merge": [
+          {
+            "var": "state"
+          },
+          {
+            "submittedAt": {
+              "var": "event.timestamp"
+            }
+          }
+        ]
+      },
       "dependencies": []
     },
     {
-      "from": { "value": "submitted" },
-      "to": { "value": "approved" },
+      "from": "submitted",
+      "to": "approved",
       "eventName": "approve",
-      "guard": { "==": [1, 1] },
-      "effect": { "merge": [{ "var": "state" }, { "approvedBy": { "var": "event.approver" } }] },
+      "guard": {
+        "==": [
+          1,
+          1
+        ]
+      },
+      "effect": {
+        "merge": [
+          {
+            "var": "state"
+          },
+          {
+            "approvedBy": {
+              "var": "event.approver"
+            }
+          }
+        ]
+      },
       "dependencies": []
     },
     {
-      "from": { "value": "submitted" },
-      "to": { "value": "rejected" },
+      "from": "submitted",
+      "to": "rejected",
       "eventName": "reject",
-      "guard": { "==": [1, 1] },
-      "effect": { "merge": [{ "var": "state" }, { "rejectedBy": { "var": "event.approver" }, "reason": { "var": "event.reason" } }] },
+      "guard": {
+        "==": [
+          1,
+          1
+        ]
+      },
+      "effect": {
+        "merge": [
+          {
+            "var": "state"
+          },
+          {
+            "rejectedBy": {
+              "var": "event.approver"
+            },
+            "reason": {
+              "var": "event.reason"
+            }
+          }
+        ]
+      },
       "dependencies": []
     }
   ],

--- a/e2e-test/examples/counter-script/definition.json
+++ b/e2e-test/examples/counter-script/definition.json
@@ -1,22 +1,81 @@
 {
   "scriptProgram": {
     "if": [
-      { "==": [{ "var": "method" }, "increment"] },
-      { "merge": [{ "var": "state" }, { "value": { "+": [{ "var": "state.value" }, 1] } }] },
-      { "if": [
-        { "==": [{ "var": "method" }, "decrement"] },
-        { "merge": [{ "var": "state" }, { "value": { "-": [{ "var": "state.value" }, 1] } }] },
-        { "if": [
-          { "==": [{ "var": "method" }, "reset"] },
-          { "value": 0 },
-          { "var": "state" }
-        ]}
-      ]}
+      {
+        "==": [
+          {
+            "var": "method"
+          },
+          "increment"
+        ]
+      },
+      {
+        "merge": [
+          {
+            "var": "state"
+          },
+          {
+            "value": {
+              "+": [
+                {
+                  "var": "state.value"
+                },
+                1
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "if": [
+          {
+            "==": [
+              {
+                "var": "method"
+              },
+              "decrement"
+            ]
+          },
+          {
+            "merge": [
+              {
+                "var": "state"
+              },
+              {
+                "value": {
+                  "-": [
+                    {
+                      "var": "state.value"
+                    },
+                    1
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "if": [
+              {
+                "==": [
+                  {
+                    "var": "method"
+                  },
+                  "reset"
+                ]
+              },
+              {
+                "value": 0
+              },
+              {
+                "var": "state"
+              }
+            ]
+          }
+        ]
+      }
     ]
   },
-  "initialState": {
-    "value": 0
-  },
+  "initialState": {"value": 0},
   "accessControl": {
     "Public": {}
   }

--- a/e2e-test/examples/simple-order/definition.json
+++ b/e2e-test/examples/simple-order/definition.json
@@ -1,63 +1,125 @@
 {
   "states": {
     "pending": {
-      "id": { "value": "pending" },
+      "id": "pending",
       "isFinal": false,
       "metadata": null
     },
     "confirmed": {
-      "id": { "value": "confirmed" },
+      "id": "confirmed",
       "isFinal": false,
       "metadata": null
     },
     "shipped": {
-      "id": { "value": "shipped" },
+      "id": "shipped",
       "isFinal": false,
       "metadata": null
     },
     "delivered": {
-      "id": { "value": "delivered" },
+      "id": "delivered",
       "isFinal": true,
       "metadata": null
     },
     "cancelled": {
-      "id": { "value": "cancelled" },
+      "id": "cancelled",
       "isFinal": true,
       "metadata": null
     }
   },
-  "initialState": { "value": "pending" },
+  "initialState": "pending",
   "transitions": [
     {
-      "from": { "value": "pending" },
-      "to": { "value": "confirmed" },
+      "from": "pending",
+      "to": "confirmed",
       "eventName": "confirm",
-      "guard": { "==": [1, 1] },
-      "effect": { "merge": [{ "var": "state" }, { "var": "event" }] },
+      "guard": {
+        "==": [
+          1,
+          1
+        ]
+      },
+      "effect": {
+        "merge": [
+          {
+            "var": "state"
+          },
+          {
+            "var": "event"
+          }
+        ]
+      },
       "dependencies": []
     },
     {
-      "from": { "value": "pending" },
-      "to": { "value": "cancelled" },
+      "from": "pending",
+      "to": "cancelled",
       "eventName": "cancel",
-      "guard": { "==": [1, 1] },
-      "effect": { "merge": [{ "var": "state" }, { "cancelReason": { "var": "event.reason" } }] },
+      "guard": {
+        "==": [
+          1,
+          1
+        ]
+      },
+      "effect": {
+        "merge": [
+          {
+            "var": "state"
+          },
+          {
+            "cancelReason": {
+              "var": "event.reason"
+            }
+          }
+        ]
+      },
       "dependencies": []
     },
     {
-      "from": { "value": "confirmed" },
-      "to": { "value": "shipped" },
+      "from": "confirmed",
+      "to": "shipped",
       "eventName": "ship",
-      "guard": { "==": [1, 1] },
-      "effect": { "merge": [{ "var": "state" }, { "trackingNumber": { "var": "event.trackingNumber" } }] },
+      "guard": {
+        "==": [
+          1,
+          1
+        ]
+      },
+      "effect": {
+        "merge": [
+          {
+            "var": "state"
+          },
+          {
+            "trackingNumber": {
+              "var": "event.trackingNumber"
+            }
+          }
+        ]
+      },
       "dependencies": []
     },
     {
-      "from": { "value": "shipped" },
-      "to": { "value": "delivered" },
+      "from": "shipped",
+      "to": "delivered",
       "eventName": "deliver",
-      "guard": { "==": [1, 1] },
-      "effect": { "merge": [{ "var": "state" }, { "deliveredAt": { "var": "event.timestamp" } }] },
+      "guard": {
+        "==": [
+          1,
+          1
+        ]
+      },
+      "effect": {
+        "merge": [
+          {
+            "var": "state"
+          },
+          {
+            "deliveredAt": {
+              "var": "event.timestamp"
+            }
+          }
+        ]
+      },
       "dependencies": []
     }
   ],

--- a/e2e-test/examples/tictactoe/archive/event-move.json
+++ b/e2e-test/examples/tictactoe/archive/event-move.json
@@ -1,5 +1,5 @@
 {
-  "eventType": { "value": "make_move" },
+  "eventType": "make_move",
   "payload": {
     "player": "X",
     "cell": 0

--- a/e2e-test/examples/tictactoe/archive/event-reset.json
+++ b/e2e-test/examples/tictactoe/archive/event-reset.json
@@ -1,5 +1,5 @@
 {
-  "eventType": { "value": "reset_board" },
+  "eventType": "reset_board",
   "payload": {},
   "idempotencyKey": null
 }

--- a/e2e-test/examples/tictactoe/archive/event-start-game.json
+++ b/e2e-test/examples/tictactoe/archive/event-start-game.json
@@ -1,5 +1,5 @@
 {
-  "eventType": { "value": "start_game" },
+  "eventType": "start_game",
   "payload": {
     "playerX": "PLACEHOLDER",
     "playerO": "PLACEHOLDER",

--- a/e2e-test/examples/tictactoe/archive/sm-definition.json
+++ b/e2e-test/examples/tictactoe/archive/sm-definition.json
@@ -1,162 +1,308 @@
 {
   "states": {
     "setup": {
-      "id": {"value": "setup"},
+      "id": "setup",
       "isFinal": false,
       "metadata": null
     },
     "playing": {
-      "id": {"value": "playing"},
+      "id": "playing",
       "isFinal": false,
       "metadata": null
     },
     "finished": {
-      "id": {"value": "finished"},
+      "id": "finished",
       "isFinal": true,
       "metadata": null
     },
     "cancelled": {
-      "id": {"value": "cancelled"},
+      "id": "cancelled",
       "isFinal": true,
       "metadata": null
     }
   },
-  "initialState": {"value": "setup"},
+  "initialState": "setup",
   "transitions": [
     {
-      "from": {"value": "setup"},
-      "to": {"value": "playing"},
-      "eventType": {"value": "start_game"},
+      "from": "setup",
+      "to": "playing",
+      "eventType": {
+        "value": "start_game"
+      },
       "guard": {
         "and": [
-          {"!!": [{"var": "event.playerX"}]},
-          {"!!": [{"var": "event.playerO"}]},
-          {"!!": [{"var": "event.gameId"}]}
+          {
+            "!!": [
+              {
+                "var": "event.playerX"
+              }
+            ]
+          },
+          {
+            "!!": [
+              {
+                "var": "event.playerO"
+              }
+            ]
+          },
+          {
+            "!!": [
+              {
+                "var": "event.gameId"
+              }
+            ]
+          }
         ]
       },
       "effect": {
         "_oracleCall": {
-          "fiberId": {"var": "state.oracleFiberId"},
+          "fiberId": {
+            "var": "state.oracleFiberId"
+          },
           "method": "initialize",
           "args": {
-            "playerX": {"var": "event.playerX"},
-            "playerO": {"var": "event.playerO"},
-            "gameId": {"var": "event.gameId"}
+            "playerX": {
+              "var": "event.playerX"
+            },
+            "playerO": {
+              "var": "event.playerO"
+            },
+            "gameId": {
+              "var": "event.gameId"
+            }
           }
         },
-        "gameId": {"var": "event.gameId"},
-        "playerX": {"var": "event.playerX"},
-        "playerO": {"var": "event.playerO"},
+        "gameId": {
+          "var": "event.gameId"
+        },
+        "playerX": {
+          "var": "event.playerX"
+        },
+        "playerO": {
+          "var": "event.playerO"
+        },
         "status": "initialized"
       },
       "dependencies": []
     },
     {
-      "from": {"value": "playing"},
-      "to": {"value": "playing"},
-      "eventType": {"value": "make_move"},
-      "guard": {
-        "===": [{"var": "scriptOracles.11111111-1111-1111-1111-111111111111.state.status"}, "InProgress"]
+      "from": "playing",
+      "to": "playing",
+      "eventType": {
+        "value": "make_move"
       },
-      "effect": {
-        "_oracleCall": {
-          "fiberId": {"var": "state.oracleFiberId"},
-          "method": "makeMove",
-          "args": {
-            "player": {"var": "event.player"},
-            "cell": {"var": "event.cell"}
-          }
-        },
-        "lastMove": {
-          "player": {"var": "event.player"},
-          "cell": {"var": "event.cell"}
-        }
-      },
-      "dependencies": ["11111111-1111-1111-1111-111111111111"]
-    },
-    {
-      "from": {"value": "playing"},
-      "to": {"value": "finished"},
-      "eventType": {"value": "make_move"},
       "guard": {
-        "or": [
-          {"===": [{"var": "scriptOracles.11111111-1111-1111-1111-111111111111.state.status"}, "Won"]},
-          {"===": [{"var": "scriptOracles.11111111-1111-1111-1111-111111111111.state.status"}, "Draw"]}
+        "===": [
+          {
+            "var": "scriptOracles.11111111-1111-1111-1111-111111111111.state.status"
+          },
+          "InProgress"
         ]
       },
       "effect": {
         "_oracleCall": {
-          "fiberId": {"var": "state.oracleFiberId"},
+          "fiberId": {
+            "var": "state.oracleFiberId"
+          },
           "method": "makeMove",
           "args": {
-            "player": {"var": "event.player"},
-            "cell": {"var": "event.cell"}
+            "player": {
+              "var": "event.player"
+            },
+            "cell": {
+              "var": "event.cell"
+            }
           }
         },
-        "finalStatus": {"var": "scriptOracles.11111111-1111-1111-1111-111111111111.state.status"},
-        "winner": {"var": "scriptOracles.11111111-1111-1111-1111-111111111111.state.winner"},
-        "finalBoard": {"var": "scriptOracles.11111111-1111-1111-1111-111111111111.state.board"},
+        "lastMove": {
+          "player": {
+            "var": "event.player"
+          },
+          "cell": {
+            "var": "event.cell"
+          }
+        }
+      },
+      "dependencies": [
+        "11111111-1111-1111-1111-111111111111"
+      ]
+    },
+    {
+      "from": "playing",
+      "to": "finished",
+      "eventType": {
+        "value": "make_move"
+      },
+      "guard": {
+        "or": [
+          {
+            "===": [
+              {
+                "var": "scriptOracles.11111111-1111-1111-1111-111111111111.state.status"
+              },
+              "Won"
+            ]
+          },
+          {
+            "===": [
+              {
+                "var": "scriptOracles.11111111-1111-1111-1111-111111111111.state.status"
+              },
+              "Draw"
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "_oracleCall": {
+          "fiberId": {
+            "var": "state.oracleFiberId"
+          },
+          "method": "makeMove",
+          "args": {
+            "player": {
+              "var": "event.player"
+            },
+            "cell": {
+              "var": "event.cell"
+            }
+          }
+        },
+        "finalStatus": {
+          "var": "scriptOracles.11111111-1111-1111-1111-111111111111.state.status"
+        },
+        "winner": {
+          "var": "scriptOracles.11111111-1111-1111-1111-111111111111.state.winner"
+        },
+        "finalBoard": {
+          "var": "scriptOracles.11111111-1111-1111-1111-111111111111.state.board"
+        },
         "_outputs": [
           {
             "outputType": "game_completed",
             "data": {
-              "gameId": {"var": "state.gameId"},
-              "winner": {"var": "scriptOracles.11111111-1111-1111-1111-111111111111.state.winner"},
-              "status": {"var": "scriptOracles.11111111-1111-1111-1111-111111111111.state.status"},
-              "moveCount": {"var": "scriptOracles.11111111-1111-1111-1111-111111111111.state.moveCount"}
+              "gameId": {
+                "var": "state.gameId"
+              },
+              "winner": {
+                "var": "scriptOracles.11111111-1111-1111-1111-111111111111.state.winner"
+              },
+              "status": {
+                "var": "scriptOracles.11111111-1111-1111-1111-111111111111.state.status"
+              },
+              "moveCount": {
+                "var": "scriptOracles.11111111-1111-1111-1111-111111111111.state.moveCount"
+              }
             }
           }
         ]
       },
-      "dependencies": ["11111111-1111-1111-1111-111111111111"]
+      "dependencies": [
+        "11111111-1111-1111-1111-111111111111"
+      ]
     },
     {
-      "from": {"value": "playing"},
-      "to": {"value": "playing"},
-      "eventType": {"value": "reset_board"},
+      "from": "playing",
+      "to": "playing",
+      "eventType": {
+        "value": "reset_board"
+      },
       "guard": {
         "or": [
-          {"===": [{"var": "scriptOracles.11111111-1111-1111-1111-111111111111.state.status"}, "Won"]},
-          {"===": [{"var": "scriptOracles.11111111-1111-1111-1111-111111111111.state.status"}, "Draw"]}
+          {
+            "===": [
+              {
+                "var": "scriptOracles.11111111-1111-1111-1111-111111111111.state.status"
+              },
+              "Won"
+            ]
+          },
+          {
+            "===": [
+              {
+                "var": "scriptOracles.11111111-1111-1111-1111-111111111111.state.status"
+              },
+              "Draw"
+            ]
+          }
         ]
       },
       "effect": {
         "_oracleCall": {
-          "fiberId": {"var": "state.oracleFiberId"},
+          "fiberId": {
+            "var": "state.oracleFiberId"
+          },
           "method": "resetGame",
           "args": {}
         },
-        "roundCount": {"+": [{"var": "state.roundCount"}, 1]}
+        "roundCount": {
+          "+": [
+            {
+              "var": "state.roundCount"
+            },
+            1
+          ]
+        }
       },
-      "dependencies": ["11111111-1111-1111-1111-111111111111"]
+      "dependencies": [
+        "11111111-1111-1111-1111-111111111111"
+      ]
     },
     {
-      "from": {"value": "playing"},
-      "to": {"value": "cancelled"},
-      "eventType": {"value": "cancel_game"},
-      "guard": {"==": [1, 1]},
+      "from": "playing",
+      "to": "cancelled",
+      "eventType": {
+        "value": "cancel_game"
+      },
+      "guard": {
+        "==": [
+          1,
+          1
+        ]
+      },
       "effect": {
         "_oracleCall": {
-          "fiberId": {"var": "state.oracleFiberId"},
+          "fiberId": {
+            "var": "state.oracleFiberId"
+          },
           "method": "cancelGame",
           "args": {
-            "requestedBy": {"var": "event.requestedBy"},
-            "reason": {"var": "event.reason"}
+            "requestedBy": {
+              "var": "event.requestedBy"
+            },
+            "reason": {
+              "var": "event.reason"
+            }
           }
         },
-        "cancelledBy": {"var": "event.requestedBy"},
-        "cancelReason": {"var": "event.reason"}
+        "cancelledBy": {
+          "var": "event.requestedBy"
+        },
+        "cancelReason": {
+          "var": "event.reason"
+        }
       },
       "dependencies": []
     },
     {
-      "from": {"value": "setup"},
-      "to": {"value": "cancelled"},
-      "eventType": {"value": "cancel_game"},
-      "guard": {"==": [1, 1]},
+      "from": "setup",
+      "to": "cancelled",
+      "eventType": {
+        "value": "cancel_game"
+      },
+      "guard": {
+        "==": [
+          1,
+          1
+        ]
+      },
       "effect": {
-        "cancelledBy": {"var": "event.requestedBy"},
-        "cancelReason": {"var": "event.reason"}
+        "cancelledBy": {
+          "var": "event.requestedBy"
+        },
+        "cancelReason": {
+          "var": "event.reason"
+        }
       },
       "dependencies": []
     }

--- a/e2e-test/examples/tictactoe/sm-definition.ts
+++ b/e2e-test/examples/tictactoe/sm-definition.ts
@@ -16,32 +16,32 @@ export default (context: Record<string, unknown>) => {
   return {
     states: {
       setup: {
-        id: { value: 'setup' },
+        id: 'setup',
         isFinal: false,
         metadata: null,
       },
       playing: {
-        id: { value: 'playing' },
+        id: 'playing',
         isFinal: false,
         metadata: null,
       },
       finished: {
-        id: { value: 'finished' },
+        id: 'finished',
         isFinal: true,
         metadata: null,
       },
       cancelled: {
-        id: { value: 'cancelled' },
+        id: 'cancelled',
         isFinal: true,
         metadata: null,
       },
     },
-    initialState: { value: 'setup' },
+    initialState: 'setup',
     transitions: [
       // setup -> playing (start_game)
       {
-        from: { value: 'setup' },
-        to: { value: 'playing' },
+        from: 'setup',
+        to: 'playing',
         eventName: 'start_game',
         guard: {
           and: [
@@ -70,8 +70,8 @@ export default (context: Record<string, unknown>) => {
 
       // playing -> playing (make_move, game continues)
       {
-        from: { value: 'playing' },
-        to: { value: 'playing' },
+        from: 'playing',
+        to: 'playing',
         eventName: 'make_move',
         guard: {
           '===': [{ var: `scripts.${oracleFiberId}.state.status` }, 'InProgress'],
@@ -95,8 +95,8 @@ export default (context: Record<string, unknown>) => {
 
       // playing -> finished (make_move, game ends with win/draw)
       {
-        from: { value: 'playing' },
-        to: { value: 'finished' },
+        from: 'playing',
+        to: 'finished',
         eventName: 'make_move',
         guard: {
           or: [
@@ -133,8 +133,8 @@ export default (context: Record<string, unknown>) => {
 
       // playing -> playing (reset_board, start new round)
       {
-        from: { value: 'playing' },
-        to: { value: 'playing' },
+        from: 'playing',
+        to: 'playing',
         eventName: 'reset_board',
         guard: {
           or: [
@@ -155,8 +155,8 @@ export default (context: Record<string, unknown>) => {
 
       // playing -> cancelled (cancel_game)
       {
-        from: { value: 'playing' },
-        to: { value: 'cancelled' },
+        from: 'playing',
+        to: 'cancelled',
         eventName: 'cancel_game',
         guard: { '==': [1, 1] },
         effect: {
@@ -176,8 +176,8 @@ export default (context: Record<string, unknown>) => {
 
       // setup -> cancelled (cancel_game before start)
       {
-        from: { value: 'setup' },
-        to: { value: 'cancelled' },
+        from: 'setup',
+        to: 'cancelled',
         eventName: 'cancel_game',
         guard: { '==': [1, 1] },
         effect: {

--- a/e2e-test/examples/token-escrow/definition.json
+++ b/e2e-test/examples/token-escrow/definition.json
@@ -1,50 +1,97 @@
 {
   "states": {
     "pending": {
-      "id": { "value": "pending" },
+      "id": "pending",
       "isFinal": false,
       "metadata": null
     },
     "funded": {
-      "id": { "value": "funded" },
+      "id": "funded",
       "isFinal": false,
       "metadata": null
     },
     "released": {
-      "id": { "value": "released" },
+      "id": "released",
       "isFinal": true,
       "metadata": null
     },
     "refunded": {
-      "id": { "value": "refunded" },
+      "id": "refunded",
       "isFinal": true,
       "metadata": null
     }
   },
-  "initialState": { "value": "pending" },
+  "initialState": "pending",
   "transitions": [
     {
-      "from": { "value": "pending" },
-      "to": { "value": "funded" },
+      "from": "pending",
+      "to": "funded",
       "eventName": "fund",
-      "guard": { "==": [1, 1] },
-      "effect": { "merge": [{ "var": "state" }, { "depositor": { "var": "event.depositor" }, "amount": { "var": "event.amount" } }] },
+      "guard": {
+        "==": [
+          1,
+          1
+        ]
+      },
+      "effect": {
+        "merge": [
+          {
+            "var": "state"
+          },
+          {
+            "depositor": {
+              "var": "event.depositor"
+            },
+            "amount": {
+              "var": "event.amount"
+            }
+          }
+        ]
+      },
       "dependencies": []
     },
     {
-      "from": { "value": "funded" },
-      "to": { "value": "released" },
+      "from": "funded",
+      "to": "released",
       "eventName": "release",
-      "guard": { "==": [1, 1] },
-      "effect": { "merge": [{ "var": "state" }, { "beneficiary": { "var": "event.beneficiary" } }] },
+      "guard": {
+        "==": [
+          1,
+          1
+        ]
+      },
+      "effect": {
+        "merge": [
+          {
+            "var": "state"
+          },
+          {
+            "beneficiary": {
+              "var": "event.beneficiary"
+            }
+          }
+        ]
+      },
       "dependencies": []
     },
     {
-      "from": { "value": "funded" },
-      "to": { "value": "refunded" },
+      "from": "funded",
+      "to": "refunded",
       "eventName": "refund",
-      "guard": { "==": [1, 1] },
-      "effect": { "merge": [{ "var": "state" }, {}] },
+      "guard": {
+        "==": [
+          1,
+          1
+        ]
+      },
+      "effect": {
+        "merge": [
+          {
+            "var": "state"
+          },
+          {}
+        ]
+      },
       "dependencies": []
     }
   ],

--- a/e2e-test/examples/voting/definition.json
+++ b/e2e-test/examples/voting/definition.json
@@ -1,25 +1,60 @@
 {
   "states": {
-    "pending": { "id": { "value": "pending" }, "isFinal": false, "metadata": null },
-    "voting": { "id": { "value": "voting" }, "isFinal": false, "metadata": null },
-    "completed": { "id": { "value": "completed" }, "isFinal": true, "metadata": null }
+    "pending": {
+      "id": "pending",
+      "isFinal": false,
+      "metadata": null
+    },
+    "voting": {
+      "id": "voting",
+      "isFinal": false,
+      "metadata": null
+    },
+    "completed": {
+      "id": "completed",
+      "isFinal": true,
+      "metadata": null
+    }
   },
-  "initialState": { "value": "pending" },
+  "initialState": "pending",
   "transitions": [
     {
-      "from": { "value": "pending" },
-      "to": { "value": "voting" },
+      "from": "pending",
+      "to": "voting",
       "eventName": "startVoting",
-      "guard": { "==": [1, 1] },
-      "effect": { "merge": [{ "var": "state" }, { "candidates": { "var": "event.candidates" } }] },
+      "guard": {
+        "==": [
+          1,
+          1
+        ]
+      },
+      "effect": {
+        "merge": [
+          {
+            "var": "state"
+          },
+          {
+            "candidates": {
+              "var": "event.candidates"
+            }
+          }
+        ]
+      },
       "dependencies": []
     },
     {
-      "from": { "value": "voting" },
-      "to": { "value": "completed" },
+      "from": "voting",
+      "to": "completed",
       "eventName": "endVoting",
-      "guard": { "==": [1, 1] },
-      "effect": { "var": "state" },
+      "guard": {
+        "==": [
+          1,
+          1
+        ]
+      },
+      "effect": {
+        "var": "state"
+      },
       "dependencies": []
     }
   ],

--- a/e2e-test/package-lock.json
+++ b/e2e-test/package-lock.json
@@ -31,14 +31,21 @@
         "js-sha512": "^0.9.0"
       },
       "devDependencies": {
+        "@bufbuild/buf": "^1.65.0",
+        "@bufbuild/protobuf": "^2.11.0",
+        "@bufbuild/protoc-gen-es": "^2.11.0",
+        "@protobuf-ts/plugin": "^2.11.1",
+        "@protobuf-ts/runtime": "^2.11.1",
         "@types/jest": "^29.5.0",
         "@types/node": "^20.0.0",
         "@typescript-eslint/eslint-plugin": "^7.0.0",
         "@typescript-eslint/parser": "^7.0.0",
         "eslint": "^8.0.0",
+        "grpc-tools": "^1.13.1",
         "jest": "^29.0.0",
         "prettier": "^3.0.0",
         "ts-jest": "^29.0.0",
+        "ts-proto": "^2.11.2",
         "typescript": "^5.0.0"
       },
       "engines": {
@@ -495,9 +502,9 @@
       "link": true
     },
     "node_modules/@types/node": {
-      "version": "22.19.7",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.7.tgz",
-      "integrity": "sha512-MciR4AKGHWl7xwxkBa6xUGxQJ4VBOmPTF7sL+iGzuahOFaO0jHCsuEfS80pan1ef4gWId1oWOweIhrDEYLuaOw==",
+      "version": "22.19.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.9.tgz",
+      "integrity": "sha512-PD03/U8g1F9T9MI+1OBisaIARhSzeidsUjQaf51fOxrfjeiKN9bLVO06lHuHYjxdnqLWJijJHfqXPSJri2EM2A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -583,9 +590,9 @@
       }
     },
     "node_modules/get-tsconfig": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.1.tgz",
-      "integrity": "sha512-EoY1N2xCn44xU6750Sx7OjOIT59FkmstNc3X6y5xpz7D5cBtZRe/3pSlTkDJgqsOk3WwZPkWfonhhUJfttQo3w==",
+      "version": "4.13.3",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.3.tgz",
+      "integrity": "sha512-vp8Cj/+9Q/ibZUrq1rhy8mCTQpCk31A3uu9wc1C50yAb3x2pFHOsGdAZQ7jD86ARayyxZUViYeIztW+GE8dcrg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/e2e-test/package-lock.json
+++ b/e2e-test/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@ottochain/sdk": "file:../sdk",
+        "@ottochain/sdk": "github:ottobot-ai/ottochain-sdk#main",
         "commander": "13.1.0",
         "dotenv": "^16.4.7"
       },
@@ -19,40 +19,25 @@
         "typescript": "^5.7.0"
       }
     },
-    "../sdk": {
-      "name": "@ottochain/sdk",
-      "version": "0.1.0",
+    "node_modules/@bufbuild/protobuf": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.11.0.tgz",
+      "integrity": "sha512-sBXGT13cpmPR5BMgHE6UEEfEaShh5Ror6rfN3yEK5si7QVrtZg8LEPQb0VVhiLRUslD2yLnXtnRzG035J/mZXQ==",
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
+    },
+    "node_modules/@constellation-network/metagraph-sdk": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@constellation-network/metagraph-sdk/-/metagraph-sdk-0.2.0.tgz",
+      "integrity": "sha512-QpQwk3JW0fsP/sc/ke12TYEKUkFdEmOhcNLY3C41vncb6Pjxc+PoAJsNbp18BfXsjphZXeOL83aps6XRA07OPQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@stardust-collective/dag4": "^2.6.0",
-        "@stardust-collective/dag4-keystore": "^2.6.0",
-        "canonicalize": "^2.1.0",
-        "js-sha256": "^0.11.1",
-        "js-sha512": "^0.9.0"
-      },
-      "devDependencies": {
-        "@bufbuild/buf": "^1.65.0",
-        "@bufbuild/protobuf": "^2.11.0",
-        "@bufbuild/protoc-gen-es": "^2.11.0",
-        "@protobuf-ts/plugin": "^2.11.1",
-        "@protobuf-ts/runtime": "^2.11.1",
-        "@types/jest": "^29.5.0",
-        "@types/node": "^20.0.0",
-        "@typescript-eslint/eslint-plugin": "^7.0.0",
-        "@typescript-eslint/parser": "^7.0.0",
-        "eslint": "^8.0.0",
-        "grpc-tools": "^1.13.1",
-        "jest": "^29.0.0",
-        "prettier": "^3.0.0",
-        "ts-jest": "^29.0.0",
-        "ts-proto": "^2.11.2",
-        "typescript": "^5.0.0"
+        "@noble/curves": "^2.0.1",
+        "@noble/hashes": "^2.0.1",
+        "bs58": "^6.0.0",
+        "canonicalize": "^2.1.0"
       },
       "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "@stardust-collective/dag4": "^2.6.0"
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -497,18 +482,618 @@
         "node": ">=18"
       }
     },
+    "node_modules/@noble/curves": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.0.1.tgz",
+      "integrity": "sha512-vs1Az2OOTBiP4q0pwjW5aF0xp9n4MxVrmkFBxc6EKZc6ddYx5gaZiAsZoq0uRRXWbi3AT/sBqn05eRPtn1JCPw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.0.1"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.0.1.tgz",
+      "integrity": "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/secp256k1": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.7.2.tgz",
+      "integrity": "sha512-/qzwYl5eFLH8OWIecQWM31qld2g1NfjgylK+TNhqtaUKP37Nm+Y+z30Fjhw0Ct8p9yCQEm2N3W/AckdIb3SMcQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/@ottochain/sdk": {
-      "resolved": "../sdk",
-      "link": true
+      "version": "1.4.2",
+      "resolved": "git+ssh://git@github.com/ottobot-ai/ottochain-sdk.git#16918418c96d2ebcc73b6cb9a5e6b63554a3694c",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@bufbuild/protobuf": "^2.11.0",
+        "@constellation-network/metagraph-sdk": "^0.2.0",
+        "@stardust-collective/dag4": "^2.6.0",
+        "@stardust-collective/dag4-keystore": "^2.6.0",
+        "canonicalize": "^2.1.0",
+        "js-sha256": "^0.11.1",
+        "js-sha512": "^0.9.0",
+        "zod": "^3.22.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@stardust-collective/dag4": "^2.6.0"
+      }
+    },
+    "node_modules/@stardust-collective/dag4": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/@stardust-collective/dag4/-/dag4-2.8.1.tgz",
+      "integrity": "sha512-qjDWtpLA0yl1cJ2bHRZIDnrEGOccNLFqln6+u3bnX0LLi0uFVuzCiaj66zq57NOU2tKOLJ72YD7wBARhWrCZVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@stardust-collective/dag4-core": "2.8.1",
+        "@stardust-collective/dag4-keystore": "2.8.1",
+        "@stardust-collective/dag4-network": "2.8.1",
+        "@stardust-collective/dag4-wallet": "2.8.1",
+        "cross-fetch": "^3.1.5"
+      }
+    },
+    "node_modules/@stardust-collective/dag4-core": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/@stardust-collective/dag4-core/-/dag4-core-2.8.1.tgz",
+      "integrity": "sha512-D+OJ7liXpIZsZRYPNNyHCnBWPH5kDXnOhUyH5OszEGqVX4zmiFDDvxm8SKT18yx9Nq7+AwFqtZ+a4qtqyQ9ohQ==",
+      "license": "MIT"
+    },
+    "node_modules/@stardust-collective/dag4-keystore": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/@stardust-collective/dag4-keystore/-/dag4-keystore-2.8.1.tgz",
+      "integrity": "sha512-0M2I3pqXpgbvsP3MBQq7gzNAwbKyvb7q4PBEDeaGLEzpJ5QTqON3+xR2ONxxSPqdaFAYW0/Tmp/saD7eLprHUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/secp256k1": "^1.6.3",
+        "bignumber.js": "^9.0.1",
+        "bip39": "^3.0.2",
+        "blakejs": "^1.1.0",
+        "bn.js": "^5.1.3",
+        "brotli-wasm": "^2.0.0",
+        "bs58": "^4.0.1",
+        "buffer": "^5.6.0",
+        "create-hash": "^1.2.0",
+        "create-hmac": "^1.1.7",
+        "elliptic": "^6.5.3",
+        "eth-lib": "^0.1.29",
+        "ethereum-cryptography": "^0.1.3",
+        "ethereumjs-wallet": "^1.0.1",
+        "js-sha256": "^0.9.0",
+        "js-sha512": "^0.8.0",
+        "pbkdf2": "^3.0.9",
+        "randombytes": "^2.1.0",
+        "stream-browserify": "^3.0.0",
+        "uuid": "^3.4.0"
+      }
+    },
+    "node_modules/@stardust-collective/dag4-keystore/node_modules/base-x": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.11.tgz",
+      "integrity": "sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/@stardust-collective/dag4-keystore/node_modules/bs58": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
+      "integrity": "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==",
+      "license": "MIT",
+      "dependencies": {
+        "base-x": "^3.0.2"
+      }
+    },
+    "node_modules/@stardust-collective/dag4-keystore/node_modules/js-sha256": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.9.0.tgz",
+      "integrity": "sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA==",
+      "license": "MIT"
+    },
+    "node_modules/@stardust-collective/dag4-keystore/node_modules/js-sha512": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/js-sha512/-/js-sha512-0.8.0.tgz",
+      "integrity": "sha512-PWsmefG6Jkodqt+ePTvBZCSMFgN7Clckjd0O7su3I0+BW2QWUTJNzjktHsztGLhncP2h8mcF9V9Y2Ha59pAViQ==",
+      "license": "MIT"
+    },
+    "node_modules/@stardust-collective/dag4-network": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/@stardust-collective/dag4-network/-/dag4-network-2.8.1.tgz",
+      "integrity": "sha512-CEl3uFd5d80JCsBv4Ct4bo6gbbZ1nFBide2zDedj95R0/q9GnieYJUCMUZBPaZZDHwHv5jnf26laqOYNO6y56w==",
+      "license": "MIT",
+      "dependencies": {
+        "@stardust-collective/dag4-core": "2.8.1",
+        "bignumber.js": "^9.0.1",
+        "rxjs": "^6.6.3",
+        "zod": "^3.24.2"
+      }
+    },
+    "node_modules/@stardust-collective/dag4-wallet": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/@stardust-collective/dag4-wallet/-/dag4-wallet-2.8.1.tgz",
+      "integrity": "sha512-JlNX8cGaYAER5zPa/qan5bkQ0N1Pj+Aa01qKOJbC5ml/5GDrtIsdDCkoqbGoOFJIDsu5oj8qbLooCsXw2tdsBA==",
+      "license": "MIT",
+      "dependencies": {
+        "@stardust-collective/dag4-core": "2.8.1",
+        "@stardust-collective/dag4-keystore": "2.8.1",
+        "@stardust-collective/dag4-network": "2.8.1",
+        "bignumber.js": "^9.0.1",
+        "rimraf": "^3.0.2",
+        "zod": "^3.24.2"
+      }
+    },
+    "node_modules/@types/bn.js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.2.0.tgz",
+      "integrity": "sha512-DLbJ1BPqxvQhIGbeu8VbUC1DiAiahHtAYvA0ZEAa4P31F7IaArc8z3C3BRQdWX4mtLQuABG4yzp76ZrS02Ui1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/node": {
       "version": "22.19.9",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.9.tgz",
       "integrity": "sha512-PD03/U8g1F9T9MI+1OBisaIARhSzeidsUjQaf51fOxrfjeiKN9bLVO06lHuHYjxdnqLWJijJHfqXPSJri2EM2A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/pbkdf2": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@types/pbkdf2/-/pbkdf2-3.1.2.tgz",
+      "integrity": "sha512-uRwJqmiXmh9++aSu1VNEn3iIxWOhd8AHXNSdlaLfdAAdSTY9jYVeGWnzejM3dvrkbqE3/hyQkQQ29IFATEGlew==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/secp256k1": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@types/secp256k1/-/secp256k1-4.0.7.tgz",
+      "integrity": "sha512-Rcvjl6vARGAKRO6jHeKMatGrvOMGrR/AR11N1x2LqintPCyDZ7NBhrh238Z2VZc7aM7KIwnFpFQ7fnfK4H/9Qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/aes-js": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.1.2.tgz",
+      "integrity": "sha512-e5pEa2kBnBOgR4Y/p20pskXI74UEz7de8ZGVo58asOtvSVG5YAbJeELPZxOmt+Bnz3rX753YKhfIn4X4l1PPRQ==",
+      "license": "MIT"
+    },
+    "node_modules/ajv": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/asn1": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
+    "node_modules/assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/async-limiter": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
+      "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
+      "license": "MIT"
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/aws4": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.13.2.tgz",
+      "integrity": "sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==",
+      "license": "MIT"
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT"
+    },
+    "node_modules/base-x": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-5.0.1.tgz",
+      "integrity": "sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg==",
+      "license": "MIT"
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tweetnacl": "^0.14.3"
+      }
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/bip39": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/bip39/-/bip39-3.1.0.tgz",
+      "integrity": "sha512-c9kiwdk45Do5GL0vJMe7tS95VjCii65mYAH7DfWl3uW8AVzXKQVUm64i3hzVybBDMp9r7j9iNxR85+ul8MdN/A==",
+      "license": "ISC",
+      "dependencies": {
+        "@noble/hashes": "^1.2.0"
+      }
+    },
+    "node_modules/bip39/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/blakejs": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.2.1.tgz",
+      "integrity": "sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ==",
+      "license": "MIT"
+    },
+    "node_modules/bn.js": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.3.tgz",
+      "integrity": "sha512-EAcmnPkxpntVL+DS7bO1zhcZNvCkxqtkd0ZY53h06GNQ3DEkkGZ/gKgmDv6DdZQGj9BgfSPKtJJ7Dp1GPP8f7w==",
+      "license": "MIT"
+    },
+    "node_modules/body-parser": {
+      "version": "1.20.4",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
+      "integrity": "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "~1.2.0",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "on-finished": "~2.4.1",
+        "qs": "~6.14.0",
+        "raw-body": "~2.5.3",
+        "type-is": "~1.6.18",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/brorand": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+      "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==",
+      "license": "MIT"
+    },
+    "node_modules/brotli-wasm": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brotli-wasm/-/brotli-wasm-2.0.1.tgz",
+      "integrity": "sha512-+3USgYsC7bzb5yU0/p2HnnynZl0ak0E6uoIm4UW4Aby/8s8HFCq6NCfrrf1E9c3O8OCSzq3oYO1tUVqIi61Nww==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/browserify-aes": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-xor": "^1.0.3",
+        "cipher-base": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.3",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/bs58": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-6.0.0.tgz",
+      "integrity": "sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw==",
+      "license": "MIT",
+      "dependencies": {
+        "base-x": "^5.0.0"
+      }
+    },
+    "node_modules/bs58check": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.2.tgz",
+      "integrity": "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==",
+      "license": "MIT",
+      "dependencies": {
+        "bs58": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "safe-buffer": "^5.1.2"
+      }
+    },
+    "node_modules/bs58check/node_modules/base-x": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.11.tgz",
+      "integrity": "sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/bs58check/node_modules/bs58": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
+      "integrity": "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==",
+      "license": "MIT",
+      "dependencies": {
+        "base-x": "^3.0.2"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/buffer-to-arraybuffer": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/buffer-to-arraybuffer/-/buffer-to-arraybuffer-0.0.5.tgz",
+      "integrity": "sha512-3dthu5CYiVB1DEJp61FtApNnNndTckcqe4pFcLdvHtrpG+kcyekCJKg4MRiDcFW7A6AODnXB9U4dwQiCW5kzJQ==",
+      "license": "MIT"
+    },
+    "node_modules/buffer-xor": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
+      "integrity": "sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ==",
+      "license": "MIT"
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
+      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.0",
+        "es-define-property": "^1.0.0",
+        "get-intrinsic": "^1.2.4",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/canonicalize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/canonicalize/-/canonicalize-2.1.0.tgz",
+      "integrity": "sha512-F705O3xrsUtgt98j7leetNhTWPe+5S72rlL5O4jA1pKqBVQ/dT1O1D6PFxmSXvc0SUOinWS57DKx0I3CHrXJHQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "canonicalize": "bin/canonicalize.js"
+      }
+    },
+    "node_modules/caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/cipher-base": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.7.tgz",
+      "integrity": "sha512-Mz9QMT5fJe7bKI7MH31UilT5cEK5EHHRCccw/YRFsRY47AuNgaV6HY3rscp0/I4Q+tTW/5zoqpSeRRI54TkDWA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.4",
+        "safe-buffer": "^5.2.1",
+        "to-buffer": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/commander": {
@@ -520,6 +1105,199 @@
         "node": ">=18"
       }
     },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "license": "MIT"
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "license": "MIT"
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
+      "license": "MIT"
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/create-hash": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
+      "license": "MIT",
+      "dependencies": {
+        "cipher-base": "^1.0.1",
+        "inherits": "^2.0.1",
+        "md5.js": "^1.3.4",
+        "ripemd160": "^2.0.1",
+        "sha.js": "^2.4.0"
+      }
+    },
+    "node_modules/create-hmac": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
+      "license": "MIT",
+      "dependencies": {
+        "cipher-base": "^1.0.3",
+        "create-hash": "^1.1.0",
+        "inherits": "^2.0.1",
+        "ripemd160": "^2.0.0",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
+      }
+    },
+    "node_modules/cross-fetch": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.2.0.tgz",
+      "integrity": "sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "node-fetch": "^2.7.0"
+      }
+    },
+    "node_modules/dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
+      "license": "MIT",
+      "dependencies": {
+        "assert-plus": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/decode-uri-component": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
+      "integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/decompress-response": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
+      "integrity": "sha512-BzRPQuY1ip+qDonAOz42gRm/pg9F768C+npV/4JOsxRC2sq+Rlk+Q4ZCAsOhnIaMrgarILY+RMUIvMmmX1qAEA==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dom-walk": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
+      "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w=="
+    },
     "node_modules/dotenv": {
       "version": "16.6.1",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
@@ -530,6 +1308,96 @@
       },
       "funding": {
         "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ecc-jsbn": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==",
+      "license": "MIT",
+      "dependencies": {
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/elliptic": {
+      "version": "6.6.1",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz",
+      "integrity": "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==",
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.11.9",
+        "brorand": "^1.1.0",
+        "hash.js": "^1.0.0",
+        "hmac-drbg": "^1.0.1",
+        "inherits": "^2.0.4",
+        "minimalistic-assert": "^1.0.1",
+        "minimalistic-crypto-utils": "^1.0.1"
+      }
+    },
+    "node_modules/elliptic/node_modules/bn.js": {
+      "version": "4.12.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/esbuild": {
@@ -574,6 +1442,269 @@
         "@esbuild/win32-x64": "0.27.2"
       }
     },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eth-lib": {
+      "version": "0.1.29",
+      "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.1.29.tgz",
+      "integrity": "sha512-bfttrr3/7gG4E02HoWTDUcDDslN003OlOoBxk9virpAZQ1ja/jDgwkWB8QfJF7ojuEowrqy+lzp9VcJG7/k5bQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.11.6",
+        "elliptic": "^6.4.0",
+        "nano-json-stream-parser": "^0.1.2",
+        "servify": "^0.1.12",
+        "ws": "^3.0.0",
+        "xhr-request-promise": "^0.1.2"
+      }
+    },
+    "node_modules/eth-lib/node_modules/bn.js": {
+      "version": "4.12.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
+      "license": "MIT"
+    },
+    "node_modules/ethereum-cryptography": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
+      "integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/pbkdf2": "^3.0.0",
+        "@types/secp256k1": "^4.0.1",
+        "blakejs": "^1.1.0",
+        "browserify-aes": "^1.2.0",
+        "bs58check": "^2.1.2",
+        "create-hash": "^1.2.0",
+        "create-hmac": "^1.1.7",
+        "hash.js": "^1.1.7",
+        "keccak": "^3.0.0",
+        "pbkdf2": "^3.0.17",
+        "randombytes": "^2.1.0",
+        "safe-buffer": "^5.1.2",
+        "scrypt-js": "^3.0.0",
+        "secp256k1": "^4.0.1",
+        "setimmediate": "^1.0.5"
+      }
+    },
+    "node_modules/ethereumjs-util": {
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.1.5.tgz",
+      "integrity": "sha512-SDl5kKrQAudFBUe5OJM9Ac6WmMyYmXX/6sTmLZ3ffG2eY6ZIGBes3pEDxNN6V72WyOw4CPD5RomKdsa8DAAwLg==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "@types/bn.js": "^5.1.0",
+        "bn.js": "^5.1.2",
+        "create-hash": "^1.1.2",
+        "ethereum-cryptography": "^0.1.3",
+        "rlp": "^2.2.4"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/ethereumjs-wallet": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/ethereumjs-wallet/-/ethereumjs-wallet-1.0.2.tgz",
+      "integrity": "sha512-CCWV4RESJgRdHIvFciVQFnCHfqyhXWchTPlkfp28Qc53ufs+doi5I/cV2+xeK9+qEo25XCWfP9MiL+WEPAZfdA==",
+      "deprecated": "New package name format for new versions: @ethereumjs/wallet. Please update.",
+      "license": "MIT",
+      "dependencies": {
+        "aes-js": "^3.1.2",
+        "bs58check": "^2.1.2",
+        "ethereum-cryptography": "^0.1.3",
+        "ethereumjs-util": "^7.1.2",
+        "randombytes": "^2.1.0",
+        "scrypt-js": "^3.0.1",
+        "utf8": "^3.0.0",
+        "uuid": "^8.3.2"
+      }
+    },
+    "node_modules/ethereumjs-wallet/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/evp_bytestokey": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
+      "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
+      "license": "MIT",
+      "dependencies": {
+        "md5.js": "^1.3.4",
+        "safe-buffer": "^5.1.1"
+      }
+    },
+    "node_modules/express": {
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
+      "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "~1.20.3",
+        "content-disposition": "~0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "~0.7.1",
+        "cookie-signature": "~1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.3.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "~0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "~6.14.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "~0.19.0",
+        "serve-static": "~1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "~2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
+    "node_modules/extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==",
+      "engines": [
+        "node >=0.6.0"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "license": "MIT"
+    },
+    "node_modules/finalhandler": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
+      "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "~2.0.2",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/for-each": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 0.12"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "license": "ISC"
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -589,6 +1720,52 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/get-tsconfig": {
       "version": "4.13.3",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.3.tgz",
@@ -602,6 +1779,879 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
+    "node_modules/getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
+      "license": "MIT",
+      "dependencies": {
+        "assert-plus": "^1.0.0"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/global": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/global/-/global-4.4.0.tgz",
+      "integrity": "sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==",
+      "license": "MIT",
+      "dependencies": {
+        "min-document": "^2.19.0",
+        "process": "^0.11.10"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/har-validator": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
+      "deprecated": "this library is no longer supported",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.12.3",
+        "har-schema": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hash-base": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.2.tgz",
+      "integrity": "sha512-Bb33KbowVTIj5s7Ked1OsqHUeCpz//tPwR+E2zJgJKo9Z5XolZ9b6bdUgjmYlwnWhoOQKoTd1TYToZGn5mAYOg==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.4",
+        "readable-stream": "^2.3.8",
+        "safe-buffer": "^5.2.1",
+        "to-buffer": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/hash-base/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
+    "node_modules/hash-base/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/hash-base/node_modules/readable-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/hash-base/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/hash-base/node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/hash.js": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.1"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hmac-drbg": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+      "integrity": "sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==",
+      "license": "MIT",
+      "dependencies": {
+        "hash.js": "^1.0.3",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.1"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/http-signature": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
+      },
+      "engines": {
+        "node": ">=0.8",
+        "npm": ">=1.3.7"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-function": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.2.tgz",
+      "integrity": "sha512-lw7DUp0aWXYg+CBCN+JKkcE0Q2RayZnSvnZBlwgxHBQhqt5pZNVy4Ri7H9GmmXkdu7LUthszM+Tor1u/2iBcpQ==",
+      "license": "MIT"
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
+      "license": "MIT"
+    },
+    "node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "license": "MIT"
+    },
+    "node_modules/isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
+      "license": "MIT"
+    },
+    "node_modules/js-sha256": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.11.1.tgz",
+      "integrity": "sha512-o6WSo/LUvY2uC4j7mO50a2ms7E/EAdbP0swigLV+nzHKTTaYnaLIWJ02VdXrsJX0vGedDESQnLsOekr94ryfjg==",
+      "license": "MIT"
+    },
+    "node_modules/js-sha512": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/js-sha512/-/js-sha512-0.9.0.tgz",
+      "integrity": "sha512-mirki9WS/SUahm+1TbAPkqvbCiCfOAAsyXeHxK1UkullnJVVqoJG2pL9ObvT05CN+tM7fxhfYm0NbXn+1hWoZg==",
+      "license": "MIT"
+    },
+    "node_modules/jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "license": "(AFL-2.1 OR BSD-3-Clause)"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "license": "MIT"
+    },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "license": "ISC"
+    },
+    "node_modules/jsprim": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
+      "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
+      "license": "MIT",
+      "dependencies": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.4.0",
+        "verror": "1.10.0"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
+    "node_modules/keccak": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.4.tgz",
+      "integrity": "sha512-3vKuW0jV8J3XNTzvfyicFR5qvxrSAGl7KIhvgOu5cmWwM7tZRj3fMbj/pfIf4be7aznbc+prBWGjywox/g2Y6Q==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^2.0.0",
+        "node-gyp-build": "^4.2.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/md5.js": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
+      "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
+      "license": "MIT",
+      "dependencies": {
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.1.2"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-response": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/min-document": {
+      "version": "2.19.2",
+      "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.2.tgz",
+      "integrity": "sha512-8S5I8db/uZN8r9HSLFVWPdJCvYOejMcEC82VIzNUc6Zkklf/d1gg2psfE79/vyhWOj4+J8MtwmoOz3TmvaGu5A==",
+      "license": "MIT",
+      "dependencies": {
+        "dom-walk": "^0.1.0"
+      }
+    },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "license": "ISC"
+    },
+    "node_modules/minimalistic-crypto-utils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+      "integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==",
+      "license": "MIT"
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/nano-json-stream-parser": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/nano-json-stream-parser/-/nano-json-stream-parser-0.1.2.tgz",
+      "integrity": "sha512-9MqxMH/BSJC7dnLsEMPyfN5Dvoo49IsPFYMcHw3Bcfc2kN0lpHRBSzlMSVx4HGyJ7s9B31CyBTVehWJoQ8Ctew==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
+      "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA==",
+      "license": "MIT"
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
+    },
+    "node_modules/oauth-sign": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parse-headers": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.6.tgz",
+      "integrity": "sha512-Tz11t3uKztEW5FEVZnj1ox8GKblWn+PvHY9TmJV5Mll2uHEwRdR/5Li1OlXoECjLYkApdhWy44ocONwXLiKO5A==",
+      "license": "MIT"
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
+      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+      "license": "MIT"
+    },
+    "node_modules/pbkdf2": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.5.tgz",
+      "integrity": "sha512-Q3CG/cYvCO1ye4QKkuH7EXxs3VC/rI1/trd+qX2+PolbaKG0H+bgcZzrTt96mMyRtejk+JMCiLUn3y29W8qmFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "create-hash": "^1.2.0",
+        "create-hmac": "^1.1.7",
+        "ripemd160": "^2.0.3",
+        "safe-buffer": "^5.2.1",
+        "sha.js": "^2.4.12",
+        "to-buffer": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
+      "license": "MIT"
+    },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/psl": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/lupomontero"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.14.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
+      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/query-string": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
+      "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
+      "license": "MIT",
+      "dependencies": {
+        "decode-uri-component": "^0.2.0",
+        "object-assign": "^4.1.0",
+        "strict-uri-encode": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/request": {
+      "version": "2.88.2",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+      "deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.3",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.5.0",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.3.2"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/request/node_modules/qs": {
+      "version": "6.5.5",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.5.tgz",
+      "integrity": "sha512-mzR4sElr1bfCaPJe7m8ilJ6ZXdDaGoObcYR0ZHSsktM/Lt21MVHj5De30GQH2eiZ1qGRTO7LCAzQsUeXTNexWQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
@@ -611,6 +2661,444 @@
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
+    },
+    "node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/ripemd160": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.3.tgz",
+      "integrity": "sha512-5Di9UC0+8h1L6ZD2d7awM7E/T4uA1fJRlx6zk/NvdCCVEoAnFqvHmCuNeIKoCeIixBX/q8uM+6ycDvF8woqosA==",
+      "license": "MIT",
+      "dependencies": {
+        "hash-base": "^3.1.2",
+        "inherits": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/rlp": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/rlp/-/rlp-2.2.7.tgz",
+      "integrity": "sha512-d5gdPmgQ0Z+AklL2NVXr/IoSjNZFfTVvQWzL/AM2AOcSzYP2xjlb0AC8YyCLc41MSNf6P6QVtjgPdmVtzb+4lQ==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "bn.js": "^5.2.0"
+      },
+      "bin": {
+        "rlp": "bin/rlp"
+      }
+    },
+    "node_modules/rxjs": {
+      "version": "6.6.7",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+      "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^1.9.0"
+      },
+      "engines": {
+        "npm": ">=2.0.0"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/scrypt-js": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
+      "integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA==",
+      "license": "MIT"
+    },
+    "node_modules/secp256k1": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.4.tgz",
+      "integrity": "sha512-6JfvwvjUOn8F/jUoBY2Q1v5WY5XS+rj8qSe0v8Y4ezH4InLgTEeOOPQsRll9OV429Pvo6BCHGavIyJfr3TAhsw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "elliptic": "^6.5.7",
+        "node-addon-api": "^5.0.0",
+        "node-gyp-build": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/secp256k1/node_modules/node-addon-api": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-5.1.0.tgz",
+      "integrity": "sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
+      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.1",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "~2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "~2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/serve-static": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
+      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "~0.19.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/servify": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/servify/-/servify-0.1.12.tgz",
+      "integrity": "sha512-/xE6GvsKKqyo1BAY+KxOWXcLpPsUUyji7Qg3bVD7hh1eRze5bR1uYiuDA/k3Gof1s9BTzQZEJK8sNcNGFIzeWw==",
+      "license": "MIT",
+      "dependencies": {
+        "body-parser": "^1.16.0",
+        "cors": "^2.8.1",
+        "express": "^4.14.0",
+        "request": "^2.79.0",
+        "xhr": "^2.3.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "license": "MIT"
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/sha.js": {
+      "version": "2.4.12",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.12.tgz",
+      "integrity": "sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==",
+      "license": "(MIT AND BSD-3-Clause)",
+      "dependencies": {
+        "inherits": "^2.0.4",
+        "safe-buffer": "^5.2.1",
+        "to-buffer": "^1.2.0"
+      },
+      "bin": {
+        "sha.js": "bin.js"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-2.8.2.tgz",
+      "integrity": "sha512-Ijd/rV5o+mSBBs4F/x9oDPtTx9Zb6X9brmnXvMW4J7IR15ngi9q5xxqWBKU744jTZiaXtxaPL7uHG6vtN8kUkw==",
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^3.3.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
+    "node_modules/sshpk": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.18.0.tgz",
+      "integrity": "sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==",
+      "license": "MIT",
+      "dependencies": {
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
+      },
+      "bin": {
+        "sshpk-conv": "bin/sshpk-conv",
+        "sshpk-sign": "bin/sshpk-sign",
+        "sshpk-verify": "bin/sshpk-verify"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/stream-browserify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-3.0.0.tgz",
+      "integrity": "sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "~2.0.4",
+        "readable-stream": "^3.5.0"
+      }
+    },
+    "node_modules/strict-uri-encode": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
+      "integrity": "sha512-R3f198pcvnB+5IpnBlRkphuE9n46WyVl8I39W/ZUTZLz4nqSP/oLYUrcnJrw462Ds8he4YKMov2efsTIw1BDGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/timed-out": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
+      "integrity": "sha512-G7r3AhovYtr5YKOWQkta8RKAPb+J9IsO4uVmzjl8AZwfhs8UcUwTiD6gcJYSgOtzyjvQKrKYn41syHbUWMkafA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/to-buffer": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.2.tgz",
+      "integrity": "sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==",
+      "license": "MIT",
+      "dependencies": {
+        "isarray": "^2.0.5",
+        "safe-buffer": "^5.2.1",
+        "typed-array-buffer": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "psl": "^1.1.28",
+        "punycode": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
     },
     "node_modules/tsx": {
       "version": "4.21.0",
@@ -632,6 +3120,51 @@
         "fsevents": "~2.3.3"
       }
     },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
+      "license": "Unlicense"
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/typed-array-buffer": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+      "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -646,12 +3179,209 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/ultron": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
+      "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og==",
+      "license": "MIT"
+    },
     "node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/url-set-query": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/url-set-query/-/url-set-query-1.0.0.tgz",
+      "integrity": "sha512-3AChu4NiXquPfeckE5R5cGdiHCMWJx1dwCWOmWIL4KHAziJNOFIYJlpGFeKDvwLPHovZRCxK3cYlwzqI9Vp+Gg==",
+      "license": "MIT"
+    },
+    "node_modules/utf8": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/utf8/-/utf8-3.0.0.tgz",
+      "integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ==",
+      "license": "MIT"
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "license": "MIT",
+      "bin": {
+        "uuid": "bin/uuid"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==",
+      "engines": [
+        "node >=0.6.0"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.20",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
+      "integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
+      "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
+      "license": "MIT",
+      "dependencies": {
+        "async-limiter": "~1.0.0",
+        "safe-buffer": "~5.1.0",
+        "ultron": "~1.1.0"
+      }
+    },
+    "node_modules/ws/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/xhr": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/xhr/-/xhr-2.6.0.tgz",
+      "integrity": "sha512-/eCGLb5rxjx5e3mF1A7s+pLlR6CGyqWN91fv1JgER5mVWg1MZmlhBvy9kjcsOdRk8RrIujotWyJamfyrp+WIcA==",
+      "license": "MIT",
+      "dependencies": {
+        "global": "~4.4.0",
+        "is-function": "^1.0.1",
+        "parse-headers": "^2.0.0",
+        "xtend": "^4.0.0"
+      }
+    },
+    "node_modules/xhr-request": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/xhr-request/-/xhr-request-1.1.0.tgz",
+      "integrity": "sha512-Y7qzEaR3FDtL3fP30k9wO/e+FBnBByZeybKOhASsGP30NIkRAAkKD/sCnLvgEfAIEC1rcmK7YG8f4oEnIrrWzA==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-to-arraybuffer": "^0.0.5",
+        "object-assign": "^4.1.1",
+        "query-string": "^5.0.1",
+        "simple-get": "^2.7.0",
+        "timed-out": "^4.0.1",
+        "url-set-query": "^1.0.0",
+        "xhr": "^2.0.4"
+      }
+    },
+    "node_modules/xhr-request-promise": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/xhr-request-promise/-/xhr-request-promise-0.1.3.tgz",
+      "integrity": "sha512-YUBytBsuwgitWtdRzXDDkWAXzhdGB8bYm0sSzMPZT7Z2MBjMSTHFsyCT1yCRATY+XC69DUrQraRAEgcoCRaIPg==",
+      "license": "MIT",
+      "dependencies": {
+        "xhr-request": "^1.1.0"
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
     }
   }
 }

--- a/e2e-test/package-lock.json
+++ b/e2e-test/package-lock.json
@@ -522,9 +522,9 @@
       "license": "MIT"
     },
     "node_modules/@ottochain/sdk": {
-      "version": "1.4.2",
-      "resolved": "git+ssh://git@github.com/ottobot-ai/ottochain-sdk.git#36ca07bf744cc581fbe12df9b3bb9e71af815d43",
-      "integrity": "sha512-Ix95mnlnoxlEjbBKLlF+A3hv71kYZjtY26/LAuvxsrQB34LYKek7NCMWjFGT8XQGT9fpW08RAA5iZHBEM2y3dA==",
+      "version": "1.5.0",
+      "resolved": "git+ssh://git@github.com/ottobot-ai/ottochain-sdk.git#9aa0af4c23d395f403b19cf3ff9cd8faf7e90305",
+      "integrity": "sha512-VjQRHQ5nFvKL70GvSxU/ODUPBhSrF4Zvj1ejha1Y14mHKpJcDeDEB3FN8Ku8lxCTHHc/R0n7Ix2d/Mpwv9ykzQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@bufbuild/protobuf": "^2.11.0",

--- a/e2e-test/package-lock.json
+++ b/e2e-test/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@ottochain/sdk": "github:ottobot-ai/ottochain-sdk#main",
+        "@ottochain/sdk": "github:ottobot-ai/ottochain-sdk#fix/normalize-processevent-fields",
         "commander": "13.1.0",
         "dotenv": "^16.4.7"
       },
@@ -523,8 +523,7 @@
     },
     "node_modules/@ottochain/sdk": {
       "version": "1.5.0",
-      "resolved": "git+ssh://git@github.com/ottobot-ai/ottochain-sdk.git#9aa0af4c23d395f403b19cf3ff9cd8faf7e90305",
-      "integrity": "sha512-VjQRHQ5nFvKL70GvSxU/ODUPBhSrF4Zvj1ejha1Y14mHKpJcDeDEB3FN8Ku8lxCTHHc/R0n7Ix2d/Mpwv9ykzQ==",
+      "resolved": "git+ssh://git@github.com/ottobot-ai/ottochain-sdk.git#e62a56910a20929b5ddde091d41518a3092ad4df",
       "license": "Apache-2.0",
       "dependencies": {
         "@bufbuild/protobuf": "^2.11.0",

--- a/e2e-test/package-lock.json
+++ b/e2e-test/package-lock.json
@@ -523,7 +523,8 @@
     },
     "node_modules/@ottochain/sdk": {
       "version": "1.4.2",
-      "resolved": "git+ssh://git@github.com/ottobot-ai/ottochain-sdk.git#7f7e2b26e2a6770a58ddcfef3a517b7ac84a09d9",
+      "resolved": "git+ssh://git@github.com/ottobot-ai/ottochain-sdk.git#36ca07bf744cc581fbe12df9b3bb9e71af815d43",
+      "integrity": "sha512-Ix95mnlnoxlEjbBKLlF+A3hv71kYZjtY26/LAuvxsrQB34LYKek7NCMWjFGT8XQGT9fpW08RAA5iZHBEM2y3dA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@bufbuild/protobuf": "^2.11.0",

--- a/e2e-test/package-lock.json
+++ b/e2e-test/package-lock.json
@@ -41,9 +41,9 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.2.tgz",
-      "integrity": "sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.4.tgz",
+      "integrity": "sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==",
       "cpu": [
         "ppc64"
       ],
@@ -58,9 +58,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.2.tgz",
-      "integrity": "sha512-DVNI8jlPa7Ujbr1yjU2PfUSRtAUZPG9I1RwW4F4xFB1Imiu2on0ADiI/c3td+KmDtVKNbi+nffGDQMfcIMkwIA==",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.4.tgz",
+      "integrity": "sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==",
       "cpu": [
         "arm"
       ],
@@ -75,9 +75,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.2.tgz",
-      "integrity": "sha512-pvz8ZZ7ot/RBphf8fv60ljmaoydPU12VuXHImtAs0XhLLw+EXBi2BLe3OYSBslR4rryHvweW5gmkKFwTiFy6KA==",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.4.tgz",
+      "integrity": "sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==",
       "cpu": [
         "arm64"
       ],
@@ -92,9 +92,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.2.tgz",
-      "integrity": "sha512-z8Ank4Byh4TJJOh4wpz8g2vDy75zFL0TlZlkUkEwYXuPSgX8yzep596n6mT7905kA9uHZsf/o2OJZubl2l3M7A==",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.4.tgz",
+      "integrity": "sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==",
       "cpu": [
         "x64"
       ],
@@ -109,9 +109,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.2.tgz",
-      "integrity": "sha512-davCD2Zc80nzDVRwXTcQP/28fiJbcOwvdolL0sOiOsbwBa72kegmVU0Wrh1MYrbuCL98Omp5dVhQFWRKR2ZAlg==",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.4.tgz",
+      "integrity": "sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==",
       "cpu": [
         "arm64"
       ],
@@ -126,9 +126,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.2.tgz",
-      "integrity": "sha512-ZxtijOmlQCBWGwbVmwOF/UCzuGIbUkqB1faQRf5akQmxRJ1ujusWsb3CVfk/9iZKr2L5SMU5wPBi1UWbvL+VQA==",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.4.tgz",
+      "integrity": "sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==",
       "cpu": [
         "x64"
       ],
@@ -143,9 +143,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.2.tgz",
-      "integrity": "sha512-lS/9CN+rgqQ9czogxlMcBMGd+l8Q3Nj1MFQwBZJyoEKI50XGxwuzznYdwcav6lpOGv5BqaZXqvBSiB/kJ5op+g==",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==",
       "cpu": [
         "arm64"
       ],
@@ -160,9 +160,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.2.tgz",
-      "integrity": "sha512-tAfqtNYb4YgPnJlEFu4c212HYjQWSO/w/h/lQaBK7RbwGIkBOuNKQI9tqWzx7Wtp7bTPaGC6MJvWI608P3wXYA==",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.4.tgz",
+      "integrity": "sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==",
       "cpu": [
         "x64"
       ],
@@ -177,9 +177,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.2.tgz",
-      "integrity": "sha512-vWfq4GaIMP9AIe4yj1ZUW18RDhx6EPQKjwe7n8BbIecFtCQG4CfHGaHuh7fdfq+y3LIA2vGS/o9ZBGVxIDi9hw==",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.4.tgz",
+      "integrity": "sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==",
       "cpu": [
         "arm"
       ],
@@ -194,9 +194,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.2.tgz",
-      "integrity": "sha512-hYxN8pr66NsCCiRFkHUAsxylNOcAQaxSSkHMMjcpx0si13t1LHFphxJZUiGwojB1a/Hd5OiPIqDdXONia6bhTw==",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.4.tgz",
+      "integrity": "sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==",
       "cpu": [
         "arm64"
       ],
@@ -211,9 +211,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.2.tgz",
-      "integrity": "sha512-MJt5BRRSScPDwG2hLelYhAAKh9imjHK5+NE/tvnRLbIqUWa+0E9N4WNMjmp/kXXPHZGqPLxggwVhz7QP8CTR8w==",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.4.tgz",
+      "integrity": "sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==",
       "cpu": [
         "ia32"
       ],
@@ -228,9 +228,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.2.tgz",
-      "integrity": "sha512-lugyF1atnAT463aO6KPshVCJK5NgRnU4yb3FUumyVz+cGvZbontBgzeGFO1nF+dPueHD367a2ZXe1NtUkAjOtg==",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.4.tgz",
+      "integrity": "sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==",
       "cpu": [
         "loong64"
       ],
@@ -245,9 +245,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.2.tgz",
-      "integrity": "sha512-nlP2I6ArEBewvJ2gjrrkESEZkB5mIoaTswuqNFRv/WYd+ATtUpe9Y09RnJvgvdag7he0OWgEZWhviS1OTOKixw==",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.4.tgz",
+      "integrity": "sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==",
       "cpu": [
         "mips64el"
       ],
@@ -262,9 +262,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.2.tgz",
-      "integrity": "sha512-C92gnpey7tUQONqg1n6dKVbx3vphKtTHJaNG2Ok9lGwbZil6DrfyecMsp9CrmXGQJmZ7iiVXvvZH6Ml5hL6XdQ==",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.4.tgz",
+      "integrity": "sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==",
       "cpu": [
         "ppc64"
       ],
@@ -279,9 +279,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.2.tgz",
-      "integrity": "sha512-B5BOmojNtUyN8AXlK0QJyvjEZkWwy/FKvakkTDCziX95AowLZKR6aCDhG7LeF7uMCXEJqwa8Bejz5LTPYm8AvA==",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.4.tgz",
+      "integrity": "sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==",
       "cpu": [
         "riscv64"
       ],
@@ -296,9 +296,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.2.tgz",
-      "integrity": "sha512-p4bm9+wsPwup5Z8f4EpfN63qNagQ47Ua2znaqGH6bqLlmJ4bx97Y9JdqxgGZ6Y8xVTixUnEkoKSHcpRlDnNr5w==",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.4.tgz",
+      "integrity": "sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==",
       "cpu": [
         "s390x"
       ],
@@ -313,9 +313,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.2.tgz",
-      "integrity": "sha512-uwp2Tip5aPmH+NRUwTcfLb+W32WXjpFejTIOWZFw/v7/KnpCDKG66u4DLcurQpiYTiYwQ9B7KOeMJvLCu/OvbA==",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.4.tgz",
+      "integrity": "sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==",
       "cpu": [
         "x64"
       ],
@@ -330,9 +330,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.2.tgz",
-      "integrity": "sha512-Kj6DiBlwXrPsCRDeRvGAUb/LNrBASrfqAIok+xB0LxK8CHqxZ037viF13ugfsIpePH93mX7xfJp97cyDuTZ3cw==",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==",
       "cpu": [
         "arm64"
       ],
@@ -347,9 +347,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.2.tgz",
-      "integrity": "sha512-HwGDZ0VLVBY3Y+Nw0JexZy9o/nUAWq9MlV7cahpaXKW6TOzfVno3y3/M8Ga8u8Yr7GldLOov27xiCnqRZf0tCA==",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.4.tgz",
+      "integrity": "sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==",
       "cpu": [
         "x64"
       ],
@@ -364,9 +364,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.2.tgz",
-      "integrity": "sha512-DNIHH2BPQ5551A7oSHD0CKbwIA/Ox7+78/AWkbS5QoRzaqlev2uFayfSxq68EkonB+IKjiuxBFoV8ESJy8bOHA==",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==",
       "cpu": [
         "arm64"
       ],
@@ -381,9 +381,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.2.tgz",
-      "integrity": "sha512-/it7w9Nb7+0KFIzjalNJVR5bOzA9Vay+yIPLVHfIQYG/j+j9VTH84aNB8ExGKPU4AzfaEvN9/V4HV+F+vo8OEg==",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.4.tgz",
+      "integrity": "sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==",
       "cpu": [
         "x64"
       ],
@@ -398,9 +398,9 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.2.tgz",
-      "integrity": "sha512-LRBbCmiU51IXfeXk59csuX/aSaToeG7w48nMwA6049Y4J4+VbWALAuXcs+qcD04rHDuSCSRKdmY63sruDS5qag==",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.4.tgz",
+      "integrity": "sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==",
       "cpu": [
         "arm64"
       ],
@@ -415,9 +415,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.2.tgz",
-      "integrity": "sha512-kMtx1yqJHTmqaqHPAzKCAkDaKsffmXkPHThSfRwZGyuqyIeBvf08KSsYXl+abf5HDAPMJIPnbBfXvP2ZC2TfHg==",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.4.tgz",
+      "integrity": "sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==",
       "cpu": [
         "x64"
       ],
@@ -432,9 +432,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.2.tgz",
-      "integrity": "sha512-Yaf78O/B3Kkh+nKABUF++bvJv5Ijoy9AN1ww904rOXZFLWVc5OLOfL56W+C8F9xn5JQZa3UX6m+IktJnIb1Jjg==",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.4.tgz",
+      "integrity": "sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==",
       "cpu": [
         "arm64"
       ],
@@ -449,9 +449,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.2.tgz",
-      "integrity": "sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ==",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.4.tgz",
+      "integrity": "sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==",
       "cpu": [
         "ia32"
       ],
@@ -466,9 +466,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.2.tgz",
-      "integrity": "sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ==",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.4.tgz",
+      "integrity": "sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==",
       "cpu": [
         "x64"
       ],
@@ -523,7 +523,7 @@
     },
     "node_modules/@ottochain/sdk": {
       "version": "1.4.2",
-      "resolved": "git+ssh://git@github.com/ottobot-ai/ottochain-sdk.git#16918418c96d2ebcc73b6cb9a5e6b63554a3694c",
+      "resolved": "git+ssh://git@github.com/ottobot-ai/ottochain-sdk.git#7f7e2b26e2a6770a58ddcfef3a517b7ac84a09d9",
       "license": "Apache-2.0",
       "dependencies": {
         "@bufbuild/protobuf": "^2.11.0",
@@ -655,9 +655,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "22.19.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.9.tgz",
-      "integrity": "sha512-PD03/U8g1F9T9MI+1OBisaIARhSzeidsUjQaf51fOxrfjeiKN9bLVO06lHuHYjxdnqLWJijJHfqXPSJri2EM2A==",
+      "version": "22.19.15",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
+      "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -1401,9 +1401,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.2.tgz",
-      "integrity": "sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.4.tgz",
+      "integrity": "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -1414,32 +1414,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.27.2",
-        "@esbuild/android-arm": "0.27.2",
-        "@esbuild/android-arm64": "0.27.2",
-        "@esbuild/android-x64": "0.27.2",
-        "@esbuild/darwin-arm64": "0.27.2",
-        "@esbuild/darwin-x64": "0.27.2",
-        "@esbuild/freebsd-arm64": "0.27.2",
-        "@esbuild/freebsd-x64": "0.27.2",
-        "@esbuild/linux-arm": "0.27.2",
-        "@esbuild/linux-arm64": "0.27.2",
-        "@esbuild/linux-ia32": "0.27.2",
-        "@esbuild/linux-loong64": "0.27.2",
-        "@esbuild/linux-mips64el": "0.27.2",
-        "@esbuild/linux-ppc64": "0.27.2",
-        "@esbuild/linux-riscv64": "0.27.2",
-        "@esbuild/linux-s390x": "0.27.2",
-        "@esbuild/linux-x64": "0.27.2",
-        "@esbuild/netbsd-arm64": "0.27.2",
-        "@esbuild/netbsd-x64": "0.27.2",
-        "@esbuild/openbsd-arm64": "0.27.2",
-        "@esbuild/openbsd-x64": "0.27.2",
-        "@esbuild/openharmony-arm64": "0.27.2",
-        "@esbuild/sunos-x64": "0.27.2",
-        "@esbuild/win32-arm64": "0.27.2",
-        "@esbuild/win32-ia32": "0.27.2",
-        "@esbuild/win32-x64": "0.27.2"
+        "@esbuild/aix-ppc64": "0.27.4",
+        "@esbuild/android-arm": "0.27.4",
+        "@esbuild/android-arm64": "0.27.4",
+        "@esbuild/android-x64": "0.27.4",
+        "@esbuild/darwin-arm64": "0.27.4",
+        "@esbuild/darwin-x64": "0.27.4",
+        "@esbuild/freebsd-arm64": "0.27.4",
+        "@esbuild/freebsd-x64": "0.27.4",
+        "@esbuild/linux-arm": "0.27.4",
+        "@esbuild/linux-arm64": "0.27.4",
+        "@esbuild/linux-ia32": "0.27.4",
+        "@esbuild/linux-loong64": "0.27.4",
+        "@esbuild/linux-mips64el": "0.27.4",
+        "@esbuild/linux-ppc64": "0.27.4",
+        "@esbuild/linux-riscv64": "0.27.4",
+        "@esbuild/linux-s390x": "0.27.4",
+        "@esbuild/linux-x64": "0.27.4",
+        "@esbuild/netbsd-arm64": "0.27.4",
+        "@esbuild/netbsd-x64": "0.27.4",
+        "@esbuild/openbsd-arm64": "0.27.4",
+        "@esbuild/openbsd-x64": "0.27.4",
+        "@esbuild/openharmony-arm64": "0.27.4",
+        "@esbuild/sunos-x64": "0.27.4",
+        "@esbuild/win32-arm64": "0.27.4",
+        "@esbuild/win32-ia32": "0.27.4",
+        "@esbuild/win32-x64": "0.27.4"
       }
     },
     "node_modules/escape-html": {
@@ -1767,9 +1767,9 @@
       }
     },
     "node_modules/get-tsconfig": {
-      "version": "4.13.3",
-      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.3.tgz",
-      "integrity": "sha512-vp8Cj/+9Q/ibZUrq1rhy8mCTQpCk31A3uu9wc1C50yAb3x2pFHOsGdAZQ7jD86ARayyxZUViYeIztW+GE8dcrg==",
+      "version": "4.13.6",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
+      "integrity": "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/e2e-test/package.json
+++ b/e2e-test/package.json
@@ -14,7 +14,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@ottochain/sdk": "file:../sdk",
+    "@ottochain/sdk": "github:ottobot-ai/ottochain-sdk#main",
     "commander": "13.1.0",
     "dotenv": "^16.4.7"
   },

--- a/e2e-test/package.json
+++ b/e2e-test/package.json
@@ -19,8 +19,8 @@
     "dotenv": "^16.4.7"
   },
   "devDependencies": {
+    "@types/node": "^22.0.0",
     "tsx": "^4.19.0",
-    "typescript": "^5.7.0",
-    "@types/node": "^22.0.0"
+    "typescript": "^5.7.0"
   }
 }

--- a/e2e-test/package.json
+++ b/e2e-test/package.json
@@ -14,7 +14,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@ottochain/sdk": "github:ottobot-ai/ottochain-sdk#main",
+    "@ottochain/sdk": "github:ottobot-ai/ottochain-sdk#fix/normalize-processevent-fields",
     "commander": "13.1.0",
     "dotenv": "^16.4.7"
   },

--- a/e2e-test/patches/v4.0.0-rc.2-java21-deps.patch
+++ b/e2e-test/patches/v4.0.0-rc.2-java21-deps.patch
@@ -1,0 +1,77 @@
+diff --git a/docker/bin/install_dependencies.sh b/docker/bin/install_dependencies.sh
+--- a/docker/bin/install_dependencies.sh
++++ b/docker/bin/install_dependencies.sh
+@@ -22,29 +22,28 @@ check_java_home() {
+     
+ }
+ 
+-# Check and install Java 11
++# Check and install Java 21
+ check_java() {
+-  echo "Checking for Java 11..."
++  echo "Checking for Java 21..."
+   if command -v java >/dev/null 2>&1; then
+     java_version=$(java -version 2>&1 | awk -F '"' '/version/ {print $2}')
+     echo "Found Java version: $java_version"
+-    if [[ "$java_version" == 11* ]] || [[ "$java_version" == 1.11* ]]; then
+-      echo "✅ Java 11 is installed."
++    if [[ "$java_version" == 21* ]]; then
++      echo "✅ Java 21 is installed."
+       return 0
+     else
+-      echo "⚠️ Java is installed but not version 11. Will attempt to install Java 11."
++      echo "⚠️ Java is installed but not version 21. Will attempt to install Java 21."
+     fi
+   else
+-    echo "⚠️ Java not found. Will attempt to install Java 11."
++    echo "⚠️ Java not found. Will attempt to install Java 21."
+   fi
+ 
+-  
+   case "$(uname)" in
+     Linux)
+       if command -v apt >/dev/null 2>&1; then
+-        echo "Installing Java 11 using apt..."
+-        sudo apt install -y openjdk-11-jdk
++        echo "Installing Java 21 using apt..."
++        sudo apt install -y openjdk-21-jdk
+       elif command -v yum >/dev/null 2>&1; then
+-        echo "Installing Java 11 using yum..."
+-        sudo yum install -y java-11-openjdk-devel
++        echo "Installing Java 21 using yum..."
++        sudo yum install -y java-21-openjdk-devel
+       else
+-        echo "⚠️ Unsupported Linux distribution. Please install Java 11 manually."
++        echo "⚠️ Unsupported Linux distribution. Please install Java 21 manually."
+         return 1
+       fi
+       ;;
+     Darwin)
+       if command -v brew >/dev/null 2>&1; then
+-        echo "Installing Java 11 using Homebrew..."
+-        brew tap adoptopenjdk/openjdk
+-        brew install --cask adoptopenjdk11
++        echo "Installing Java 21 using Homebrew..."
++        brew install openjdk@21
+       else
+-        echo "⚠️ Homebrew not found. Please install Java 11 manually."
++        echo "⚠️ Homebrew not found. Please install Java 21 manually."
+         return 1
+       fi
+       ;;
+     MINGW*|MSYS*|CYGWIN*)
+-      echo "On Windows, please install Java 11 manually from https://adoptopenjdk.net/"
++      echo "On Windows, please install Java 21 manually from https://adoptium.net/"
+       return 1
+       ;;
+     *)
+-      echo "⚠️ Unsupported OS: $(uname). Please install Java 11 manually."
++      echo "⚠️ Unsupported OS: $(uname). Please install Java 21 manually."
+       return 1
+       ;;
+   esac
+ 
+-  echo "✅ Java 11 installation complete."
++  echo "✅ Java 21 installation complete."
+   return 0
+ }

--- a/e2e-test/pnpm-lock.yaml
+++ b/e2e-test/pnpm-lock.yaml
@@ -1,0 +1,2293 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@ottochain/sdk':
+        specifier: file:../sdk
+        version: file:../sdk(@stardust-collective/dag4@2.8.1)
+      commander:
+        specifier: 13.1.0
+        version: 13.1.0
+      dotenv:
+        specifier: ^16.4.7
+        version: 16.6.1
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.8
+      tsx:
+        specifier: ^4.19.0
+        version: 4.21.0
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+
+packages:
+
+  '@esbuild/aix-ppc64@0.27.2':
+    resolution: {integrity: sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.27.2':
+    resolution: {integrity: sha512-pvz8ZZ7ot/RBphf8fv60ljmaoydPU12VuXHImtAs0XhLLw+EXBi2BLe3OYSBslR4rryHvweW5gmkKFwTiFy6KA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.2':
+    resolution: {integrity: sha512-DVNI8jlPa7Ujbr1yjU2PfUSRtAUZPG9I1RwW4F4xFB1Imiu2on0ADiI/c3td+KmDtVKNbi+nffGDQMfcIMkwIA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.2':
+    resolution: {integrity: sha512-z8Ank4Byh4TJJOh4wpz8g2vDy75zFL0TlZlkUkEwYXuPSgX8yzep596n6mT7905kA9uHZsf/o2OJZubl2l3M7A==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.27.2':
+    resolution: {integrity: sha512-davCD2Zc80nzDVRwXTcQP/28fiJbcOwvdolL0sOiOsbwBa72kegmVU0Wrh1MYrbuCL98Omp5dVhQFWRKR2ZAlg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.2':
+    resolution: {integrity: sha512-ZxtijOmlQCBWGwbVmwOF/UCzuGIbUkqB1faQRf5akQmxRJ1ujusWsb3CVfk/9iZKr2L5SMU5wPBi1UWbvL+VQA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.27.2':
+    resolution: {integrity: sha512-lS/9CN+rgqQ9czogxlMcBMGd+l8Q3Nj1MFQwBZJyoEKI50XGxwuzznYdwcav6lpOGv5BqaZXqvBSiB/kJ5op+g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.2':
+    resolution: {integrity: sha512-tAfqtNYb4YgPnJlEFu4c212HYjQWSO/w/h/lQaBK7RbwGIkBOuNKQI9tqWzx7Wtp7bTPaGC6MJvWI608P3wXYA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.27.2':
+    resolution: {integrity: sha512-hYxN8pr66NsCCiRFkHUAsxylNOcAQaxSSkHMMjcpx0si13t1LHFphxJZUiGwojB1a/Hd5OiPIqDdXONia6bhTw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.2':
+    resolution: {integrity: sha512-vWfq4GaIMP9AIe4yj1ZUW18RDhx6EPQKjwe7n8BbIecFtCQG4CfHGaHuh7fdfq+y3LIA2vGS/o9ZBGVxIDi9hw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.27.2':
+    resolution: {integrity: sha512-MJt5BRRSScPDwG2hLelYhAAKh9imjHK5+NE/tvnRLbIqUWa+0E9N4WNMjmp/kXXPHZGqPLxggwVhz7QP8CTR8w==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.2':
+    resolution: {integrity: sha512-lugyF1atnAT463aO6KPshVCJK5NgRnU4yb3FUumyVz+cGvZbontBgzeGFO1nF+dPueHD367a2ZXe1NtUkAjOtg==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.27.2':
+    resolution: {integrity: sha512-nlP2I6ArEBewvJ2gjrrkESEZkB5mIoaTswuqNFRv/WYd+ATtUpe9Y09RnJvgvdag7he0OWgEZWhviS1OTOKixw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.2':
+    resolution: {integrity: sha512-C92gnpey7tUQONqg1n6dKVbx3vphKtTHJaNG2Ok9lGwbZil6DrfyecMsp9CrmXGQJmZ7iiVXvvZH6Ml5hL6XdQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.27.2':
+    resolution: {integrity: sha512-B5BOmojNtUyN8AXlK0QJyvjEZkWwy/FKvakkTDCziX95AowLZKR6aCDhG7LeF7uMCXEJqwa8Bejz5LTPYm8AvA==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.2':
+    resolution: {integrity: sha512-p4bm9+wsPwup5Z8f4EpfN63qNagQ47Ua2znaqGH6bqLlmJ4bx97Y9JdqxgGZ6Y8xVTixUnEkoKSHcpRlDnNr5w==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.27.2':
+    resolution: {integrity: sha512-uwp2Tip5aPmH+NRUwTcfLb+W32WXjpFejTIOWZFw/v7/KnpCDKG66u4DLcurQpiYTiYwQ9B7KOeMJvLCu/OvbA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.27.2':
+    resolution: {integrity: sha512-Kj6DiBlwXrPsCRDeRvGAUb/LNrBASrfqAIok+xB0LxK8CHqxZ037viF13ugfsIpePH93mX7xfJp97cyDuTZ3cw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.2':
+    resolution: {integrity: sha512-HwGDZ0VLVBY3Y+Nw0JexZy9o/nUAWq9MlV7cahpaXKW6TOzfVno3y3/M8Ga8u8Yr7GldLOov27xiCnqRZf0tCA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.27.2':
+    resolution: {integrity: sha512-DNIHH2BPQ5551A7oSHD0CKbwIA/Ox7+78/AWkbS5QoRzaqlev2uFayfSxq68EkonB+IKjiuxBFoV8ESJy8bOHA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.2':
+    resolution: {integrity: sha512-/it7w9Nb7+0KFIzjalNJVR5bOzA9Vay+yIPLVHfIQYG/j+j9VTH84aNB8ExGKPU4AzfaEvN9/V4HV+F+vo8OEg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.27.2':
+    resolution: {integrity: sha512-LRBbCmiU51IXfeXk59csuX/aSaToeG7w48nMwA6049Y4J4+VbWALAuXcs+qcD04rHDuSCSRKdmY63sruDS5qag==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.27.2':
+    resolution: {integrity: sha512-kMtx1yqJHTmqaqHPAzKCAkDaKsffmXkPHThSfRwZGyuqyIeBvf08KSsYXl+abf5HDAPMJIPnbBfXvP2ZC2TfHg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.27.2':
+    resolution: {integrity: sha512-Yaf78O/B3Kkh+nKABUF++bvJv5Ijoy9AN1ww904rOXZFLWVc5OLOfL56W+C8F9xn5JQZa3UX6m+IktJnIb1Jjg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.27.2':
+    resolution: {integrity: sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.2':
+    resolution: {integrity: sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@noble/hashes@1.8.0':
+    resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
+    engines: {node: ^14.21.3 || >=16}
+
+  '@noble/secp256k1@1.7.2':
+    resolution: {integrity: sha512-/qzwYl5eFLH8OWIecQWM31qld2g1NfjgylK+TNhqtaUKP37Nm+Y+z30Fjhw0Ct8p9yCQEm2N3W/AckdIb3SMcQ==}
+
+  '@ottochain/sdk@file:../sdk':
+    resolution: {directory: ../sdk, type: directory}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      '@stardust-collective/dag4': ^2.6.0
+
+  '@stardust-collective/dag4-core@2.8.1':
+    resolution: {integrity: sha512-D+OJ7liXpIZsZRYPNNyHCnBWPH5kDXnOhUyH5OszEGqVX4zmiFDDvxm8SKT18yx9Nq7+AwFqtZ+a4qtqyQ9ohQ==}
+
+  '@stardust-collective/dag4-keystore@2.8.1':
+    resolution: {integrity: sha512-0M2I3pqXpgbvsP3MBQq7gzNAwbKyvb7q4PBEDeaGLEzpJ5QTqON3+xR2ONxxSPqdaFAYW0/Tmp/saD7eLprHUw==}
+
+  '@stardust-collective/dag4-network@2.8.1':
+    resolution: {integrity: sha512-CEl3uFd5d80JCsBv4Ct4bo6gbbZ1nFBide2zDedj95R0/q9GnieYJUCMUZBPaZZDHwHv5jnf26laqOYNO6y56w==}
+
+  '@stardust-collective/dag4-wallet@2.8.1':
+    resolution: {integrity: sha512-JlNX8cGaYAER5zPa/qan5bkQ0N1Pj+Aa01qKOJbC5ml/5GDrtIsdDCkoqbGoOFJIDsu5oj8qbLooCsXw2tdsBA==}
+
+  '@stardust-collective/dag4@2.8.1':
+    resolution: {integrity: sha512-qjDWtpLA0yl1cJ2bHRZIDnrEGOccNLFqln6+u3bnX0LLi0uFVuzCiaj66zq57NOU2tKOLJ72YD7wBARhWrCZVQ==}
+
+  '@types/bn.js@5.2.0':
+    resolution: {integrity: sha512-DLbJ1BPqxvQhIGbeu8VbUC1DiAiahHtAYvA0ZEAa4P31F7IaArc8z3C3BRQdWX4mtLQuABG4yzp76ZrS02Ui1Q==}
+
+  '@types/node@22.19.8':
+    resolution: {integrity: sha512-ebO/Yl+EAvVe8DnMfi+iaAyIqYdK0q/q0y0rw82INWEKJOBe6b/P3YWE8NW7oOlF/nXFNrHwhARrN/hdgDkraA==}
+
+  '@types/pbkdf2@3.1.2':
+    resolution: {integrity: sha512-uRwJqmiXmh9++aSu1VNEn3iIxWOhd8AHXNSdlaLfdAAdSTY9jYVeGWnzejM3dvrkbqE3/hyQkQQ29IFATEGlew==}
+
+  '@types/secp256k1@4.0.7':
+    resolution: {integrity: sha512-Rcvjl6vARGAKRO6jHeKMatGrvOMGrR/AR11N1x2LqintPCyDZ7NBhrh238Z2VZc7aM7KIwnFpFQ7fnfK4H/9Qw==}
+
+  accepts@1.3.8:
+    resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
+    engines: {node: '>= 0.6'}
+
+  aes-js@3.1.2:
+    resolution: {integrity: sha512-e5pEa2kBnBOgR4Y/p20pskXI74UEz7de8ZGVo58asOtvSVG5YAbJeELPZxOmt+Bnz3rX753YKhfIn4X4l1PPRQ==}
+
+  ajv@6.12.6:
+    resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
+
+  array-flatten@1.1.1:
+    resolution: {integrity: sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==}
+
+  asn1@0.2.6:
+    resolution: {integrity: sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==}
+
+  assert-plus@1.0.0:
+    resolution: {integrity: sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==}
+    engines: {node: '>=0.8'}
+
+  async-limiter@1.0.1:
+    resolution: {integrity: sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==}
+
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
+  available-typed-arrays@1.0.7:
+    resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
+    engines: {node: '>= 0.4'}
+
+  aws-sign2@0.7.0:
+    resolution: {integrity: sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==}
+
+  aws4@1.13.2:
+    resolution: {integrity: sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==}
+
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  base-x@3.0.11:
+    resolution: {integrity: sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA==}
+
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
+  bcrypt-pbkdf@1.0.2:
+    resolution: {integrity: sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==}
+
+  bignumber.js@9.3.1:
+    resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
+
+  bip39@3.1.0:
+    resolution: {integrity: sha512-c9kiwdk45Do5GL0vJMe7tS95VjCii65mYAH7DfWl3uW8AVzXKQVUm64i3hzVybBDMp9r7j9iNxR85+ul8MdN/A==}
+
+  blakejs@1.2.1:
+    resolution: {integrity: sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ==}
+
+  bn.js@4.12.2:
+    resolution: {integrity: sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw==}
+
+  bn.js@5.2.2:
+    resolution: {integrity: sha512-v2YAxEmKaBLahNwE1mjp4WON6huMNeuDvagFZW+ASCuA/ku0bXR9hSMw0XpiqMoA3+rmnyck/tPRSFQkoC9Cuw==}
+
+  body-parser@1.20.4:
+    resolution: {integrity: sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==}
+    engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
+
+  brace-expansion@1.1.12:
+    resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
+
+  brorand@1.1.0:
+    resolution: {integrity: sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==}
+
+  brotli-wasm@2.0.1:
+    resolution: {integrity: sha512-+3USgYsC7bzb5yU0/p2HnnynZl0ak0E6uoIm4UW4Aby/8s8HFCq6NCfrrf1E9c3O8OCSzq3oYO1tUVqIi61Nww==}
+
+  browserify-aes@1.2.0:
+    resolution: {integrity: sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==}
+
+  bs58@4.0.1:
+    resolution: {integrity: sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==}
+
+  bs58check@2.1.2:
+    resolution: {integrity: sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==}
+
+  buffer-to-arraybuffer@0.0.5:
+    resolution: {integrity: sha512-3dthu5CYiVB1DEJp61FtApNnNndTckcqe4pFcLdvHtrpG+kcyekCJKg4MRiDcFW7A6AODnXB9U4dwQiCW5kzJQ==}
+
+  buffer-xor@1.0.3:
+    resolution: {integrity: sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ==}
+
+  buffer@5.7.1:
+    resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
+
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bind@1.0.8:
+    resolution: {integrity: sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
+    engines: {node: '>= 0.4'}
+
+  canonicalize@2.1.0:
+    resolution: {integrity: sha512-F705O3xrsUtgt98j7leetNhTWPe+5S72rlL5O4jA1pKqBVQ/dT1O1D6PFxmSXvc0SUOinWS57DKx0I3CHrXJHQ==}
+    hasBin: true
+
+  caseless@0.12.0:
+    resolution: {integrity: sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==}
+
+  cipher-base@1.0.7:
+    resolution: {integrity: sha512-Mz9QMT5fJe7bKI7MH31UilT5cEK5EHHRCccw/YRFsRY47AuNgaV6HY3rscp0/I4Q+tTW/5zoqpSeRRI54TkDWA==}
+    engines: {node: '>= 0.10'}
+
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
+
+  commander@13.1.0:
+    resolution: {integrity: sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==}
+    engines: {node: '>=18'}
+
+  concat-map@0.0.1:
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  content-disposition@0.5.4:
+    resolution: {integrity: sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==}
+    engines: {node: '>= 0.6'}
+
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+
+  cookie-signature@1.0.7:
+    resolution: {integrity: sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
+
+  core-util-is@1.0.2:
+    resolution: {integrity: sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==}
+
+  core-util-is@1.0.3:
+    resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
+
+  create-hash@1.2.0:
+    resolution: {integrity: sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==}
+
+  create-hmac@1.1.7:
+    resolution: {integrity: sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==}
+
+  cross-fetch@3.2.0:
+    resolution: {integrity: sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==}
+
+  dashdash@1.14.1:
+    resolution: {integrity: sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==}
+    engines: {node: '>=0.10'}
+
+  debug@2.6.9:
+    resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  decode-uri-component@0.2.2:
+    resolution: {integrity: sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==}
+    engines: {node: '>=0.10'}
+
+  decompress-response@3.3.0:
+    resolution: {integrity: sha512-BzRPQuY1ip+qDonAOz42gRm/pg9F768C+npV/4JOsxRC2sq+Rlk+Q4ZCAsOhnIaMrgarILY+RMUIvMmmX1qAEA==}
+    engines: {node: '>=4'}
+
+  define-data-property@1.1.4:
+    resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
+    engines: {node: '>= 0.4'}
+
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
+
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
+
+  destroy@1.2.0:
+    resolution: {integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==}
+    engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
+
+  dom-walk@0.1.2:
+    resolution: {integrity: sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w==}
+
+  dotenv@16.6.1:
+    resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
+    engines: {node: '>=12'}
+
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
+  ecc-jsbn@0.1.2:
+    resolution: {integrity: sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==}
+
+  ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+
+  elliptic@6.6.1:
+    resolution: {integrity: sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==}
+
+  encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
+
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
+  es-object-atoms@1.1.1:
+    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+    engines: {node: '>= 0.4'}
+
+  esbuild@0.27.2:
+    resolution: {integrity: sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
+
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+
+  eth-lib@0.1.29:
+    resolution: {integrity: sha512-bfttrr3/7gG4E02HoWTDUcDDslN003OlOoBxk9virpAZQ1ja/jDgwkWB8QfJF7ojuEowrqy+lzp9VcJG7/k5bQ==}
+
+  ethereum-cryptography@0.1.3:
+    resolution: {integrity: sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==}
+
+  ethereumjs-util@7.1.5:
+    resolution: {integrity: sha512-SDl5kKrQAudFBUe5OJM9Ac6WmMyYmXX/6sTmLZ3ffG2eY6ZIGBes3pEDxNN6V72WyOw4CPD5RomKdsa8DAAwLg==}
+    engines: {node: '>=10.0.0'}
+
+  ethereumjs-wallet@1.0.2:
+    resolution: {integrity: sha512-CCWV4RESJgRdHIvFciVQFnCHfqyhXWchTPlkfp28Qc53ufs+doi5I/cV2+xeK9+qEo25XCWfP9MiL+WEPAZfdA==}
+    deprecated: 'New package name format for new versions: @ethereumjs/wallet. Please update.'
+
+  evp_bytestokey@1.0.3:
+    resolution: {integrity: sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==}
+
+  express@4.22.1:
+    resolution: {integrity: sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==}
+    engines: {node: '>= 0.10.0'}
+
+  extend@3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
+
+  extsprintf@1.3.0:
+    resolution: {integrity: sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==}
+    engines: {'0': node >=0.6.0}
+
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-json-stable-stringify@2.1.0:
+    resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
+
+  finalhandler@1.3.2:
+    resolution: {integrity: sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==}
+    engines: {node: '>= 0.8'}
+
+  for-each@0.3.5:
+    resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
+    engines: {node: '>= 0.4'}
+
+  forever-agent@0.6.1:
+    resolution: {integrity: sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==}
+
+  form-data@2.3.3:
+    resolution: {integrity: sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==}
+    engines: {node: '>= 0.12'}
+
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
+  fresh@0.5.2:
+    resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
+    engines: {node: '>= 0.6'}
+
+  fs.realpath@1.0.0:
+    resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
+
+  get-tsconfig@4.13.1:
+    resolution: {integrity: sha512-EoY1N2xCn44xU6750Sx7OjOIT59FkmstNc3X6y5xpz7D5cBtZRe/3pSlTkDJgqsOk3WwZPkWfonhhUJfttQo3w==}
+
+  getpass@0.1.7:
+    resolution: {integrity: sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==}
+
+  glob@7.2.3:
+    resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+
+  global@4.4.0:
+    resolution: {integrity: sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==}
+
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
+  har-schema@2.0.0:
+    resolution: {integrity: sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==}
+    engines: {node: '>=4'}
+
+  har-validator@5.1.5:
+    resolution: {integrity: sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==}
+    engines: {node: '>=6'}
+    deprecated: this library is no longer supported
+
+  has-property-descriptors@1.0.2:
+    resolution: {integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==}
+
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  has-tostringtag@1.0.2:
+    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
+    engines: {node: '>= 0.4'}
+
+  hash-base@3.1.2:
+    resolution: {integrity: sha512-Bb33KbowVTIj5s7Ked1OsqHUeCpz//tPwR+E2zJgJKo9Z5XolZ9b6bdUgjmYlwnWhoOQKoTd1TYToZGn5mAYOg==}
+    engines: {node: '>= 0.8'}
+
+  hash.js@1.1.7:
+    resolution: {integrity: sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==}
+
+  hasown@2.0.2:
+    resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
+    engines: {node: '>= 0.4'}
+
+  hmac-drbg@1.0.1:
+    resolution: {integrity: sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==}
+
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
+
+  http-signature@1.2.0:
+    resolution: {integrity: sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==}
+    engines: {node: '>=0.8', npm: '>=1.3.7'}
+
+  iconv-lite@0.4.24:
+    resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
+    engines: {node: '>=0.10.0'}
+
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+
+  inflight@1.0.6:
+    resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
+    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
+
+  is-callable@1.2.7:
+    resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
+    engines: {node: '>= 0.4'}
+
+  is-function@1.0.2:
+    resolution: {integrity: sha512-lw7DUp0aWXYg+CBCN+JKkcE0Q2RayZnSvnZBlwgxHBQhqt5pZNVy4Ri7H9GmmXkdu7LUthszM+Tor1u/2iBcpQ==}
+
+  is-typed-array@1.1.15:
+    resolution: {integrity: sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==}
+    engines: {node: '>= 0.4'}
+
+  is-typedarray@1.0.0:
+    resolution: {integrity: sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==}
+
+  isarray@1.0.0:
+    resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
+
+  isarray@2.0.5:
+    resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
+
+  isstream@0.1.2:
+    resolution: {integrity: sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==}
+
+  js-sha256@0.11.1:
+    resolution: {integrity: sha512-o6WSo/LUvY2uC4j7mO50a2ms7E/EAdbP0swigLV+nzHKTTaYnaLIWJ02VdXrsJX0vGedDESQnLsOekr94ryfjg==}
+
+  js-sha256@0.9.0:
+    resolution: {integrity: sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA==}
+
+  js-sha512@0.8.0:
+    resolution: {integrity: sha512-PWsmefG6Jkodqt+ePTvBZCSMFgN7Clckjd0O7su3I0+BW2QWUTJNzjktHsztGLhncP2h8mcF9V9Y2Ha59pAViQ==}
+
+  js-sha512@0.9.0:
+    resolution: {integrity: sha512-mirki9WS/SUahm+1TbAPkqvbCiCfOAAsyXeHxK1UkullnJVVqoJG2pL9ObvT05CN+tM7fxhfYm0NbXn+1hWoZg==}
+
+  jsbn@0.1.1:
+    resolution: {integrity: sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==}
+
+  json-schema-traverse@0.4.1:
+    resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
+  json-schema@0.4.0:
+    resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
+
+  json-stringify-safe@5.0.1:
+    resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
+
+  jsprim@1.4.2:
+    resolution: {integrity: sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==}
+    engines: {node: '>=0.6.0'}
+
+  keccak@3.0.4:
+    resolution: {integrity: sha512-3vKuW0jV8J3XNTzvfyicFR5qvxrSAGl7KIhvgOu5cmWwM7tZRj3fMbj/pfIf4be7aznbc+prBWGjywox/g2Y6Q==}
+    engines: {node: '>=10.0.0'}
+
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
+  md5.js@1.3.5:
+    resolution: {integrity: sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==}
+
+  media-typer@0.3.0:
+    resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
+    engines: {node: '>= 0.6'}
+
+  merge-descriptors@1.0.3:
+    resolution: {integrity: sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==}
+
+  methods@1.1.2:
+    resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}
+    engines: {node: '>= 0.6'}
+
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+
+  mime@1.6.0:
+    resolution: {integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==}
+    engines: {node: '>=4'}
+    hasBin: true
+
+  mimic-response@1.0.1:
+    resolution: {integrity: sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==}
+    engines: {node: '>=4'}
+
+  min-document@2.19.2:
+    resolution: {integrity: sha512-8S5I8db/uZN8r9HSLFVWPdJCvYOejMcEC82VIzNUc6Zkklf/d1gg2psfE79/vyhWOj4+J8MtwmoOz3TmvaGu5A==}
+
+  minimalistic-assert@1.0.1:
+    resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
+
+  minimalistic-crypto-utils@1.0.1:
+    resolution: {integrity: sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==}
+
+  minimatch@3.1.2:
+    resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
+
+  ms@2.0.0:
+    resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  nano-json-stream-parser@0.1.2:
+    resolution: {integrity: sha512-9MqxMH/BSJC7dnLsEMPyfN5Dvoo49IsPFYMcHw3Bcfc2kN0lpHRBSzlMSVx4HGyJ7s9B31CyBTVehWJoQ8Ctew==}
+
+  negotiator@0.6.3:
+    resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
+    engines: {node: '>= 0.6'}
+
+  node-addon-api@2.0.2:
+    resolution: {integrity: sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA==}
+
+  node-addon-api@5.1.0:
+    resolution: {integrity: sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA==}
+
+  node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+
+  node-gyp-build@4.8.4:
+    resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
+    hasBin: true
+
+  oauth-sign@0.9.0:
+    resolution: {integrity: sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==}
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
+
+  on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
+  parse-headers@2.0.6:
+    resolution: {integrity: sha512-Tz11t3uKztEW5FEVZnj1ox8GKblWn+PvHY9TmJV5Mll2uHEwRdR/5Li1OlXoECjLYkApdhWy44ocONwXLiKO5A==}
+
+  parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+
+  path-is-absolute@1.0.1:
+    resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
+    engines: {node: '>=0.10.0'}
+
+  path-to-regexp@0.1.12:
+    resolution: {integrity: sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==}
+
+  pbkdf2@3.1.5:
+    resolution: {integrity: sha512-Q3CG/cYvCO1ye4QKkuH7EXxs3VC/rI1/trd+qX2+PolbaKG0H+bgcZzrTt96mMyRtejk+JMCiLUn3y29W8qmFQ==}
+    engines: {node: '>= 0.10'}
+
+  performance-now@2.1.0:
+    resolution: {integrity: sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==}
+
+  possible-typed-array-names@1.1.0:
+    resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
+    engines: {node: '>= 0.4'}
+
+  process-nextick-args@2.0.1:
+    resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
+
+  process@0.11.10:
+    resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
+    engines: {node: '>= 0.6.0'}
+
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+
+  psl@1.15.0:
+    resolution: {integrity: sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==}
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
+
+  qs@6.14.1:
+    resolution: {integrity: sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==}
+    engines: {node: '>=0.6'}
+
+  qs@6.5.3:
+    resolution: {integrity: sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==}
+    engines: {node: '>=0.6'}
+
+  query-string@5.1.1:
+    resolution: {integrity: sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==}
+    engines: {node: '>=0.10.0'}
+
+  randombytes@2.1.0:
+    resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
+
+  range-parser@1.2.1:
+    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
+    engines: {node: '>= 0.6'}
+
+  raw-body@2.5.3:
+    resolution: {integrity: sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==}
+    engines: {node: '>= 0.8'}
+
+  readable-stream@2.3.8:
+    resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
+
+  readable-stream@3.6.2:
+    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
+    engines: {node: '>= 6'}
+
+  request@2.88.2:
+    resolution: {integrity: sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==}
+    engines: {node: '>= 6'}
+    deprecated: request has been deprecated, see https://github.com/request/request/issues/3142
+
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
+  rimraf@3.0.2:
+    resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
+    deprecated: Rimraf versions prior to v4 are no longer supported
+    hasBin: true
+
+  ripemd160@2.0.3:
+    resolution: {integrity: sha512-5Di9UC0+8h1L6ZD2d7awM7E/T4uA1fJRlx6zk/NvdCCVEoAnFqvHmCuNeIKoCeIixBX/q8uM+6ycDvF8woqosA==}
+    engines: {node: '>= 0.8'}
+
+  rlp@2.2.7:
+    resolution: {integrity: sha512-d5gdPmgQ0Z+AklL2NVXr/IoSjNZFfTVvQWzL/AM2AOcSzYP2xjlb0AC8YyCLc41MSNf6P6QVtjgPdmVtzb+4lQ==}
+    hasBin: true
+
+  rxjs@6.6.7:
+    resolution: {integrity: sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==}
+    engines: {npm: '>=2.0.0'}
+
+  safe-buffer@5.1.2:
+    resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
+
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  scrypt-js@3.0.1:
+    resolution: {integrity: sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA==}
+
+  secp256k1@4.0.4:
+    resolution: {integrity: sha512-6JfvwvjUOn8F/jUoBY2Q1v5WY5XS+rj8qSe0v8Y4ezH4InLgTEeOOPQsRll9OV429Pvo6BCHGavIyJfr3TAhsw==}
+    engines: {node: '>=18.0.0'}
+
+  send@0.19.2:
+    resolution: {integrity: sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==}
+    engines: {node: '>= 0.8.0'}
+
+  serve-static@1.16.3:
+    resolution: {integrity: sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==}
+    engines: {node: '>= 0.8.0'}
+
+  servify@0.1.12:
+    resolution: {integrity: sha512-/xE6GvsKKqyo1BAY+KxOWXcLpPsUUyji7Qg3bVD7hh1eRze5bR1uYiuDA/k3Gof1s9BTzQZEJK8sNcNGFIzeWw==}
+    engines: {node: '>=6'}
+
+  set-function-length@1.2.2:
+    resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
+    engines: {node: '>= 0.4'}
+
+  setimmediate@1.0.5:
+    resolution: {integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==}
+
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
+
+  sha.js@2.4.12:
+    resolution: {integrity: sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==}
+    engines: {node: '>= 0.10'}
+    hasBin: true
+
+  side-channel-list@1.0.0:
+    resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.0:
+    resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
+    engines: {node: '>= 0.4'}
+
+  simple-concat@1.0.1:
+    resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
+
+  simple-get@2.8.2:
+    resolution: {integrity: sha512-Ijd/rV5o+mSBBs4F/x9oDPtTx9Zb6X9brmnXvMW4J7IR15ngi9q5xxqWBKU744jTZiaXtxaPL7uHG6vtN8kUkw==}
+
+  sshpk@1.18.0:
+    resolution: {integrity: sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==}
+    engines: {node: '>=0.10.0'}
+    hasBin: true
+
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
+
+  stream-browserify@3.0.0:
+    resolution: {integrity: sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==}
+
+  strict-uri-encode@1.1.0:
+    resolution: {integrity: sha512-R3f198pcvnB+5IpnBlRkphuE9n46WyVl8I39W/ZUTZLz4nqSP/oLYUrcnJrw462Ds8he4YKMov2efsTIw1BDGQ==}
+    engines: {node: '>=0.10.0'}
+
+  string_decoder@1.1.1:
+    resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
+
+  string_decoder@1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
+
+  timed-out@4.0.1:
+    resolution: {integrity: sha512-G7r3AhovYtr5YKOWQkta8RKAPb+J9IsO4uVmzjl8AZwfhs8UcUwTiD6gcJYSgOtzyjvQKrKYn41syHbUWMkafA==}
+    engines: {node: '>=0.10.0'}
+
+  to-buffer@1.2.2:
+    resolution: {integrity: sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==}
+    engines: {node: '>= 0.4'}
+
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+
+  tough-cookie@2.5.0:
+    resolution: {integrity: sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==}
+    engines: {node: '>=0.8'}
+
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
+  tslib@1.14.1:
+    resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
+
+  tsx@4.21.0:
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
+  tunnel-agent@0.6.0:
+    resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
+
+  tweetnacl@0.14.5:
+    resolution: {integrity: sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==}
+
+  type-is@1.6.18:
+    resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
+    engines: {node: '>= 0.6'}
+
+  typed-array-buffer@1.0.3:
+    resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
+    engines: {node: '>= 0.4'}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  ultron@1.1.1:
+    resolution: {integrity: sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og==}
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
+
+  uri-js@4.4.1:
+    resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  url-set-query@1.0.0:
+    resolution: {integrity: sha512-3AChu4NiXquPfeckE5R5cGdiHCMWJx1dwCWOmWIL4KHAziJNOFIYJlpGFeKDvwLPHovZRCxK3cYlwzqI9Vp+Gg==}
+
+  utf8@3.0.0:
+    resolution: {integrity: sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ==}
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  utils-merge@1.0.1:
+    resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
+    engines: {node: '>= 0.4.0'}
+
+  uuid@3.4.0:
+    resolution: {integrity: sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==}
+    deprecated: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
+    hasBin: true
+
+  uuid@8.3.2:
+    resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    hasBin: true
+
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
+
+  verror@1.10.0:
+    resolution: {integrity: sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==}
+    engines: {'0': node >=0.6.0}
+
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
+
+  which-typed-array@1.1.20:
+    resolution: {integrity: sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==}
+    engines: {node: '>= 0.4'}
+
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  ws@3.3.3:
+    resolution: {integrity: sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: ^5.0.2
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  xhr-request-promise@0.1.3:
+    resolution: {integrity: sha512-YUBytBsuwgitWtdRzXDDkWAXzhdGB8bYm0sSzMPZT7Z2MBjMSTHFsyCT1yCRATY+XC69DUrQraRAEgcoCRaIPg==}
+
+  xhr-request@1.1.0:
+    resolution: {integrity: sha512-Y7qzEaR3FDtL3fP30k9wO/e+FBnBByZeybKOhASsGP30NIkRAAkKD/sCnLvgEfAIEC1rcmK7YG8f4oEnIrrWzA==}
+
+  xhr@2.6.0:
+    resolution: {integrity: sha512-/eCGLb5rxjx5e3mF1A7s+pLlR6CGyqWN91fv1JgER5mVWg1MZmlhBvy9kjcsOdRk8RrIujotWyJamfyrp+WIcA==}
+
+  xtend@4.0.2:
+    resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
+    engines: {node: '>=0.4'}
+
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
+snapshots:
+
+  '@esbuild/aix-ppc64@0.27.2':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/android-arm@0.27.2':
+    optional: true
+
+  '@esbuild/android-x64@0.27.2':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.2':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.2':
+    optional: true
+
+  '@esbuild/linux-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.2':
+    optional: true
+
+  '@esbuild/linux-ia32@0.27.2':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.2':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.27.2':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.2':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.27.2':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.2':
+    optional: true
+
+  '@esbuild/linux-x64@0.27.2':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.2':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.27.2':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.2':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/win32-ia32@0.27.2':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.2':
+    optional: true
+
+  '@noble/hashes@1.8.0': {}
+
+  '@noble/secp256k1@1.7.2': {}
+
+  '@ottochain/sdk@file:../sdk(@stardust-collective/dag4@2.8.1)':
+    dependencies:
+      '@stardust-collective/dag4': 2.8.1
+      '@stardust-collective/dag4-keystore': 2.8.1
+      canonicalize: 2.1.0
+      js-sha256: 0.11.1
+      js-sha512: 0.9.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  '@stardust-collective/dag4-core@2.8.1': {}
+
+  '@stardust-collective/dag4-keystore@2.8.1':
+    dependencies:
+      '@noble/secp256k1': 1.7.2
+      bignumber.js: 9.3.1
+      bip39: 3.1.0
+      blakejs: 1.2.1
+      bn.js: 5.2.2
+      brotli-wasm: 2.0.1
+      bs58: 4.0.1
+      buffer: 5.7.1
+      create-hash: 1.2.0
+      create-hmac: 1.1.7
+      elliptic: 6.6.1
+      eth-lib: 0.1.29
+      ethereum-cryptography: 0.1.3
+      ethereumjs-wallet: 1.0.2
+      js-sha256: 0.9.0
+      js-sha512: 0.8.0
+      pbkdf2: 3.1.5
+      randombytes: 2.1.0
+      stream-browserify: 3.0.0
+      uuid: 3.4.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  '@stardust-collective/dag4-network@2.8.1':
+    dependencies:
+      '@stardust-collective/dag4-core': 2.8.1
+      bignumber.js: 9.3.1
+      rxjs: 6.6.7
+      zod: 3.25.76
+
+  '@stardust-collective/dag4-wallet@2.8.1':
+    dependencies:
+      '@stardust-collective/dag4-core': 2.8.1
+      '@stardust-collective/dag4-keystore': 2.8.1
+      '@stardust-collective/dag4-network': 2.8.1
+      bignumber.js: 9.3.1
+      rimraf: 3.0.2
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  '@stardust-collective/dag4@2.8.1':
+    dependencies:
+      '@stardust-collective/dag4-core': 2.8.1
+      '@stardust-collective/dag4-keystore': 2.8.1
+      '@stardust-collective/dag4-network': 2.8.1
+      '@stardust-collective/dag4-wallet': 2.8.1
+      cross-fetch: 3.2.0
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - supports-color
+      - utf-8-validate
+
+  '@types/bn.js@5.2.0':
+    dependencies:
+      '@types/node': 22.19.8
+
+  '@types/node@22.19.8':
+    dependencies:
+      undici-types: 6.21.0
+
+  '@types/pbkdf2@3.1.2':
+    dependencies:
+      '@types/node': 22.19.8
+
+  '@types/secp256k1@4.0.7':
+    dependencies:
+      '@types/node': 22.19.8
+
+  accepts@1.3.8:
+    dependencies:
+      mime-types: 2.1.35
+      negotiator: 0.6.3
+
+  aes-js@3.1.2: {}
+
+  ajv@6.12.6:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-json-stable-stringify: 2.1.0
+      json-schema-traverse: 0.4.1
+      uri-js: 4.4.1
+
+  array-flatten@1.1.1: {}
+
+  asn1@0.2.6:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  assert-plus@1.0.0: {}
+
+  async-limiter@1.0.1: {}
+
+  asynckit@0.4.0: {}
+
+  available-typed-arrays@1.0.7:
+    dependencies:
+      possible-typed-array-names: 1.1.0
+
+  aws-sign2@0.7.0: {}
+
+  aws4@1.13.2: {}
+
+  balanced-match@1.0.2: {}
+
+  base-x@3.0.11:
+    dependencies:
+      safe-buffer: 5.2.1
+
+  base64-js@1.5.1: {}
+
+  bcrypt-pbkdf@1.0.2:
+    dependencies:
+      tweetnacl: 0.14.5
+
+  bignumber.js@9.3.1: {}
+
+  bip39@3.1.0:
+    dependencies:
+      '@noble/hashes': 1.8.0
+
+  blakejs@1.2.1: {}
+
+  bn.js@4.12.2: {}
+
+  bn.js@5.2.2: {}
+
+  body-parser@1.20.4:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 2.6.9
+      depd: 2.0.0
+      destroy: 1.2.0
+      http-errors: 2.0.1
+      iconv-lite: 0.4.24
+      on-finished: 2.4.1
+      qs: 6.14.1
+      raw-body: 2.5.3
+      type-is: 1.6.18
+      unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  brace-expansion@1.1.12:
+    dependencies:
+      balanced-match: 1.0.2
+      concat-map: 0.0.1
+
+  brorand@1.1.0: {}
+
+  brotli-wasm@2.0.1: {}
+
+  browserify-aes@1.2.0:
+    dependencies:
+      buffer-xor: 1.0.3
+      cipher-base: 1.0.7
+      create-hash: 1.2.0
+      evp_bytestokey: 1.0.3
+      inherits: 2.0.4
+      safe-buffer: 5.2.1
+
+  bs58@4.0.1:
+    dependencies:
+      base-x: 3.0.11
+
+  bs58check@2.1.2:
+    dependencies:
+      bs58: 4.0.1
+      create-hash: 1.2.0
+      safe-buffer: 5.2.1
+
+  buffer-to-arraybuffer@0.0.5: {}
+
+  buffer-xor@1.0.3: {}
+
+  buffer@5.7.1:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+
+  bytes@3.1.2: {}
+
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
+  call-bind@1.0.8:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      get-intrinsic: 1.3.0
+      set-function-length: 1.2.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
+
+  canonicalize@2.1.0: {}
+
+  caseless@0.12.0: {}
+
+  cipher-base@1.0.7:
+    dependencies:
+      inherits: 2.0.4
+      safe-buffer: 5.2.1
+      to-buffer: 1.2.2
+
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
+
+  commander@13.1.0: {}
+
+  concat-map@0.0.1: {}
+
+  content-disposition@0.5.4:
+    dependencies:
+      safe-buffer: 5.2.1
+
+  content-type@1.0.5: {}
+
+  cookie-signature@1.0.7: {}
+
+  cookie@0.7.2: {}
+
+  core-util-is@1.0.2: {}
+
+  core-util-is@1.0.3: {}
+
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
+
+  create-hash@1.2.0:
+    dependencies:
+      cipher-base: 1.0.7
+      inherits: 2.0.4
+      md5.js: 1.3.5
+      ripemd160: 2.0.3
+      sha.js: 2.4.12
+
+  create-hmac@1.1.7:
+    dependencies:
+      cipher-base: 1.0.7
+      create-hash: 1.2.0
+      inherits: 2.0.4
+      ripemd160: 2.0.3
+      safe-buffer: 5.2.1
+      sha.js: 2.4.12
+
+  cross-fetch@3.2.0:
+    dependencies:
+      node-fetch: 2.7.0
+    transitivePeerDependencies:
+      - encoding
+
+  dashdash@1.14.1:
+    dependencies:
+      assert-plus: 1.0.0
+
+  debug@2.6.9:
+    dependencies:
+      ms: 2.0.0
+
+  decode-uri-component@0.2.2: {}
+
+  decompress-response@3.3.0:
+    dependencies:
+      mimic-response: 1.0.1
+
+  define-data-property@1.1.4:
+    dependencies:
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
+  delayed-stream@1.0.0: {}
+
+  depd@2.0.0: {}
+
+  destroy@1.2.0: {}
+
+  dom-walk@0.1.2: {}
+
+  dotenv@16.6.1: {}
+
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
+  ecc-jsbn@0.1.2:
+    dependencies:
+      jsbn: 0.1.1
+      safer-buffer: 2.1.2
+
+  ee-first@1.1.1: {}
+
+  elliptic@6.6.1:
+    dependencies:
+      bn.js: 4.12.2
+      brorand: 1.1.0
+      hash.js: 1.1.7
+      hmac-drbg: 1.0.1
+      inherits: 2.0.4
+      minimalistic-assert: 1.0.1
+      minimalistic-crypto-utils: 1.0.1
+
+  encodeurl@2.0.0: {}
+
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
+  es-object-atoms@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+
+  esbuild@0.27.2:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.2
+      '@esbuild/android-arm': 0.27.2
+      '@esbuild/android-arm64': 0.27.2
+      '@esbuild/android-x64': 0.27.2
+      '@esbuild/darwin-arm64': 0.27.2
+      '@esbuild/darwin-x64': 0.27.2
+      '@esbuild/freebsd-arm64': 0.27.2
+      '@esbuild/freebsd-x64': 0.27.2
+      '@esbuild/linux-arm': 0.27.2
+      '@esbuild/linux-arm64': 0.27.2
+      '@esbuild/linux-ia32': 0.27.2
+      '@esbuild/linux-loong64': 0.27.2
+      '@esbuild/linux-mips64el': 0.27.2
+      '@esbuild/linux-ppc64': 0.27.2
+      '@esbuild/linux-riscv64': 0.27.2
+      '@esbuild/linux-s390x': 0.27.2
+      '@esbuild/linux-x64': 0.27.2
+      '@esbuild/netbsd-arm64': 0.27.2
+      '@esbuild/netbsd-x64': 0.27.2
+      '@esbuild/openbsd-arm64': 0.27.2
+      '@esbuild/openbsd-x64': 0.27.2
+      '@esbuild/openharmony-arm64': 0.27.2
+      '@esbuild/sunos-x64': 0.27.2
+      '@esbuild/win32-arm64': 0.27.2
+      '@esbuild/win32-ia32': 0.27.2
+      '@esbuild/win32-x64': 0.27.2
+
+  escape-html@1.0.3: {}
+
+  etag@1.8.1: {}
+
+  eth-lib@0.1.29:
+    dependencies:
+      bn.js: 4.12.2
+      elliptic: 6.6.1
+      nano-json-stream-parser: 0.1.2
+      servify: 0.1.12
+      ws: 3.3.3
+      xhr-request-promise: 0.1.3
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  ethereum-cryptography@0.1.3:
+    dependencies:
+      '@types/pbkdf2': 3.1.2
+      '@types/secp256k1': 4.0.7
+      blakejs: 1.2.1
+      browserify-aes: 1.2.0
+      bs58check: 2.1.2
+      create-hash: 1.2.0
+      create-hmac: 1.1.7
+      hash.js: 1.1.7
+      keccak: 3.0.4
+      pbkdf2: 3.1.5
+      randombytes: 2.1.0
+      safe-buffer: 5.2.1
+      scrypt-js: 3.0.1
+      secp256k1: 4.0.4
+      setimmediate: 1.0.5
+
+  ethereumjs-util@7.1.5:
+    dependencies:
+      '@types/bn.js': 5.2.0
+      bn.js: 5.2.2
+      create-hash: 1.2.0
+      ethereum-cryptography: 0.1.3
+      rlp: 2.2.7
+
+  ethereumjs-wallet@1.0.2:
+    dependencies:
+      aes-js: 3.1.2
+      bs58check: 2.1.2
+      ethereum-cryptography: 0.1.3
+      ethereumjs-util: 7.1.5
+      randombytes: 2.1.0
+      scrypt-js: 3.0.1
+      utf8: 3.0.0
+      uuid: 8.3.2
+
+  evp_bytestokey@1.0.3:
+    dependencies:
+      md5.js: 1.3.5
+      safe-buffer: 5.2.1
+
+  express@4.22.1:
+    dependencies:
+      accepts: 1.3.8
+      array-flatten: 1.1.1
+      body-parser: 1.20.4
+      content-disposition: 0.5.4
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.0.7
+      debug: 2.6.9
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 1.3.2
+      fresh: 0.5.2
+      http-errors: 2.0.1
+      merge-descriptors: 1.0.3
+      methods: 1.1.2
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      path-to-regexp: 0.1.12
+      proxy-addr: 2.0.7
+      qs: 6.14.1
+      range-parser: 1.2.1
+      safe-buffer: 5.2.1
+      send: 0.19.2
+      serve-static: 1.16.3
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      type-is: 1.6.18
+      utils-merge: 1.0.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  extend@3.0.2: {}
+
+  extsprintf@1.3.0: {}
+
+  fast-deep-equal@3.1.3: {}
+
+  fast-json-stable-stringify@2.1.0: {}
+
+  finalhandler@1.3.2:
+    dependencies:
+      debug: 2.6.9
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+      unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  for-each@0.3.5:
+    dependencies:
+      is-callable: 1.2.7
+
+  forever-agent@0.6.1: {}
+
+  form-data@2.3.3:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      mime-types: 2.1.35
+
+  forwarded@0.2.0: {}
+
+  fresh@0.5.2: {}
+
+  fs.realpath@1.0.0: {}
+
+  fsevents@2.3.3:
+    optional: true
+
+  function-bind@1.1.2: {}
+
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.2
+      math-intrinsics: 1.1.0
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.1
+
+  get-tsconfig@4.13.1:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
+  getpass@0.1.7:
+    dependencies:
+      assert-plus: 1.0.0
+
+  glob@7.2.3:
+    dependencies:
+      fs.realpath: 1.0.0
+      inflight: 1.0.6
+      inherits: 2.0.4
+      minimatch: 3.1.2
+      once: 1.4.0
+      path-is-absolute: 1.0.1
+
+  global@4.4.0:
+    dependencies:
+      min-document: 2.19.2
+      process: 0.11.10
+
+  gopd@1.2.0: {}
+
+  har-schema@2.0.0: {}
+
+  har-validator@5.1.5:
+    dependencies:
+      ajv: 6.12.6
+      har-schema: 2.0.0
+
+  has-property-descriptors@1.0.2:
+    dependencies:
+      es-define-property: 1.0.1
+
+  has-symbols@1.1.0: {}
+
+  has-tostringtag@1.0.2:
+    dependencies:
+      has-symbols: 1.1.0
+
+  hash-base@3.1.2:
+    dependencies:
+      inherits: 2.0.4
+      readable-stream: 2.3.8
+      safe-buffer: 5.2.1
+      to-buffer: 1.2.2
+
+  hash.js@1.1.7:
+    dependencies:
+      inherits: 2.0.4
+      minimalistic-assert: 1.0.1
+
+  hasown@2.0.2:
+    dependencies:
+      function-bind: 1.1.2
+
+  hmac-drbg@1.0.1:
+    dependencies:
+      hash.js: 1.1.7
+      minimalistic-assert: 1.0.1
+      minimalistic-crypto-utils: 1.0.1
+
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
+
+  http-signature@1.2.0:
+    dependencies:
+      assert-plus: 1.0.0
+      jsprim: 1.4.2
+      sshpk: 1.18.0
+
+  iconv-lite@0.4.24:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  ieee754@1.2.1: {}
+
+  inflight@1.0.6:
+    dependencies:
+      once: 1.4.0
+      wrappy: 1.0.2
+
+  inherits@2.0.4: {}
+
+  ipaddr.js@1.9.1: {}
+
+  is-callable@1.2.7: {}
+
+  is-function@1.0.2: {}
+
+  is-typed-array@1.1.15:
+    dependencies:
+      which-typed-array: 1.1.20
+
+  is-typedarray@1.0.0: {}
+
+  isarray@1.0.0: {}
+
+  isarray@2.0.5: {}
+
+  isstream@0.1.2: {}
+
+  js-sha256@0.11.1: {}
+
+  js-sha256@0.9.0: {}
+
+  js-sha512@0.8.0: {}
+
+  js-sha512@0.9.0: {}
+
+  jsbn@0.1.1: {}
+
+  json-schema-traverse@0.4.1: {}
+
+  json-schema@0.4.0: {}
+
+  json-stringify-safe@5.0.1: {}
+
+  jsprim@1.4.2:
+    dependencies:
+      assert-plus: 1.0.0
+      extsprintf: 1.3.0
+      json-schema: 0.4.0
+      verror: 1.10.0
+
+  keccak@3.0.4:
+    dependencies:
+      node-addon-api: 2.0.2
+      node-gyp-build: 4.8.4
+      readable-stream: 3.6.2
+
+  math-intrinsics@1.1.0: {}
+
+  md5.js@1.3.5:
+    dependencies:
+      hash-base: 3.1.2
+      inherits: 2.0.4
+      safe-buffer: 5.2.1
+
+  media-typer@0.3.0: {}
+
+  merge-descriptors@1.0.3: {}
+
+  methods@1.1.2: {}
+
+  mime-db@1.52.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
+
+  mime@1.6.0: {}
+
+  mimic-response@1.0.1: {}
+
+  min-document@2.19.2:
+    dependencies:
+      dom-walk: 0.1.2
+
+  minimalistic-assert@1.0.1: {}
+
+  minimalistic-crypto-utils@1.0.1: {}
+
+  minimatch@3.1.2:
+    dependencies:
+      brace-expansion: 1.1.12
+
+  ms@2.0.0: {}
+
+  ms@2.1.3: {}
+
+  nano-json-stream-parser@0.1.2: {}
+
+  negotiator@0.6.3: {}
+
+  node-addon-api@2.0.2: {}
+
+  node-addon-api@5.1.0: {}
+
+  node-fetch@2.7.0:
+    dependencies:
+      whatwg-url: 5.0.0
+
+  node-gyp-build@4.8.4: {}
+
+  oauth-sign@0.9.0: {}
+
+  object-assign@4.1.1: {}
+
+  object-inspect@1.13.4: {}
+
+  on-finished@2.4.1:
+    dependencies:
+      ee-first: 1.1.1
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
+
+  parse-headers@2.0.6: {}
+
+  parseurl@1.3.3: {}
+
+  path-is-absolute@1.0.1: {}
+
+  path-to-regexp@0.1.12: {}
+
+  pbkdf2@3.1.5:
+    dependencies:
+      create-hash: 1.2.0
+      create-hmac: 1.1.7
+      ripemd160: 2.0.3
+      safe-buffer: 5.2.1
+      sha.js: 2.4.12
+      to-buffer: 1.2.2
+
+  performance-now@2.1.0: {}
+
+  possible-typed-array-names@1.1.0: {}
+
+  process-nextick-args@2.0.1: {}
+
+  process@0.11.10: {}
+
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+
+  psl@1.15.0:
+    dependencies:
+      punycode: 2.3.1
+
+  punycode@2.3.1: {}
+
+  qs@6.14.1:
+    dependencies:
+      side-channel: 1.1.0
+
+  qs@6.5.3: {}
+
+  query-string@5.1.1:
+    dependencies:
+      decode-uri-component: 0.2.2
+      object-assign: 4.1.1
+      strict-uri-encode: 1.1.0
+
+  randombytes@2.1.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
+  range-parser@1.2.1: {}
+
+  raw-body@2.5.3:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.4.24
+      unpipe: 1.0.0
+
+  readable-stream@2.3.8:
+    dependencies:
+      core-util-is: 1.0.3
+      inherits: 2.0.4
+      isarray: 1.0.0
+      process-nextick-args: 2.0.1
+      safe-buffer: 5.1.2
+      string_decoder: 1.1.1
+      util-deprecate: 1.0.2
+
+  readable-stream@3.6.2:
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.3.0
+      util-deprecate: 1.0.2
+
+  request@2.88.2:
+    dependencies:
+      aws-sign2: 0.7.0
+      aws4: 1.13.2
+      caseless: 0.12.0
+      combined-stream: 1.0.8
+      extend: 3.0.2
+      forever-agent: 0.6.1
+      form-data: 2.3.3
+      har-validator: 5.1.5
+      http-signature: 1.2.0
+      is-typedarray: 1.0.0
+      isstream: 0.1.2
+      json-stringify-safe: 5.0.1
+      mime-types: 2.1.35
+      oauth-sign: 0.9.0
+      performance-now: 2.1.0
+      qs: 6.5.3
+      safe-buffer: 5.2.1
+      tough-cookie: 2.5.0
+      tunnel-agent: 0.6.0
+      uuid: 3.4.0
+
+  resolve-pkg-maps@1.0.0: {}
+
+  rimraf@3.0.2:
+    dependencies:
+      glob: 7.2.3
+
+  ripemd160@2.0.3:
+    dependencies:
+      hash-base: 3.1.2
+      inherits: 2.0.4
+
+  rlp@2.2.7:
+    dependencies:
+      bn.js: 5.2.2
+
+  rxjs@6.6.7:
+    dependencies:
+      tslib: 1.14.1
+
+  safe-buffer@5.1.2: {}
+
+  safe-buffer@5.2.1: {}
+
+  safer-buffer@2.1.2: {}
+
+  scrypt-js@3.0.1: {}
+
+  secp256k1@4.0.4:
+    dependencies:
+      elliptic: 6.6.1
+      node-addon-api: 5.1.0
+      node-gyp-build: 4.8.4
+
+  send@0.19.2:
+    dependencies:
+      debug: 2.6.9
+      depd: 2.0.0
+      destroy: 1.2.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 0.5.2
+      http-errors: 2.0.1
+      mime: 1.6.0
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-static@1.16.3:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 0.19.2
+    transitivePeerDependencies:
+      - supports-color
+
+  servify@0.1.12:
+    dependencies:
+      body-parser: 1.20.4
+      cors: 2.8.6
+      express: 4.22.1
+      request: 2.88.2
+      xhr: 2.6.0
+    transitivePeerDependencies:
+      - supports-color
+
+  set-function-length@1.2.2:
+    dependencies:
+      define-data-property: 1.1.4
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+      get-intrinsic: 1.3.0
+      gopd: 1.2.0
+      has-property-descriptors: 1.0.2
+
+  setimmediate@1.0.5: {}
+
+  setprototypeof@1.2.0: {}
+
+  sha.js@2.4.12:
+    dependencies:
+      inherits: 2.0.4
+      safe-buffer: 5.2.1
+      to-buffer: 1.2.2
+
+  side-channel-list@1.0.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+
+  side-channel@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.0
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
+
+  simple-concat@1.0.1: {}
+
+  simple-get@2.8.2:
+    dependencies:
+      decompress-response: 3.3.0
+      once: 1.4.0
+      simple-concat: 1.0.1
+
+  sshpk@1.18.0:
+    dependencies:
+      asn1: 0.2.6
+      assert-plus: 1.0.0
+      bcrypt-pbkdf: 1.0.2
+      dashdash: 1.14.1
+      ecc-jsbn: 0.1.2
+      getpass: 0.1.7
+      jsbn: 0.1.1
+      safer-buffer: 2.1.2
+      tweetnacl: 0.14.5
+
+  statuses@2.0.2: {}
+
+  stream-browserify@3.0.0:
+    dependencies:
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+
+  strict-uri-encode@1.1.0: {}
+
+  string_decoder@1.1.1:
+    dependencies:
+      safe-buffer: 5.1.2
+
+  string_decoder@1.3.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
+  timed-out@4.0.1: {}
+
+  to-buffer@1.2.2:
+    dependencies:
+      isarray: 2.0.5
+      safe-buffer: 5.2.1
+      typed-array-buffer: 1.0.3
+
+  toidentifier@1.0.1: {}
+
+  tough-cookie@2.5.0:
+    dependencies:
+      psl: 1.15.0
+      punycode: 2.3.1
+
+  tr46@0.0.3: {}
+
+  tslib@1.14.1: {}
+
+  tsx@4.21.0:
+    dependencies:
+      esbuild: 0.27.2
+      get-tsconfig: 4.13.1
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  tunnel-agent@0.6.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
+  tweetnacl@0.14.5: {}
+
+  type-is@1.6.18:
+    dependencies:
+      media-typer: 0.3.0
+      mime-types: 2.1.35
+
+  typed-array-buffer@1.0.3:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      is-typed-array: 1.1.15
+
+  typescript@5.9.3: {}
+
+  ultron@1.1.1: {}
+
+  undici-types@6.21.0: {}
+
+  unpipe@1.0.0: {}
+
+  uri-js@4.4.1:
+    dependencies:
+      punycode: 2.3.1
+
+  url-set-query@1.0.0: {}
+
+  utf8@3.0.0: {}
+
+  util-deprecate@1.0.2: {}
+
+  utils-merge@1.0.1: {}
+
+  uuid@3.4.0: {}
+
+  uuid@8.3.2: {}
+
+  vary@1.1.2: {}
+
+  verror@1.10.0:
+    dependencies:
+      assert-plus: 1.0.0
+      core-util-is: 1.0.2
+      extsprintf: 1.3.0
+
+  webidl-conversions@3.0.1: {}
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
+
+  which-typed-array@1.1.20:
+    dependencies:
+      available-typed-arrays: 1.0.7
+      call-bind: 1.0.8
+      call-bound: 1.0.4
+      for-each: 0.3.5
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-tostringtag: 1.0.2
+
+  wrappy@1.0.2: {}
+
+  ws@3.3.3:
+    dependencies:
+      async-limiter: 1.0.1
+      safe-buffer: 5.1.2
+      ultron: 1.1.1
+
+  xhr-request-promise@0.1.3:
+    dependencies:
+      xhr-request: 1.1.0
+
+  xhr-request@1.1.0:
+    dependencies:
+      buffer-to-arraybuffer: 0.0.5
+      object-assign: 4.1.1
+      query-string: 5.1.1
+      simple-get: 2.8.2
+      timed-out: 4.0.1
+      url-set-query: 1.0.0
+      xhr: 2.6.0
+
+  xhr@2.6.0:
+    dependencies:
+      global: 4.4.0
+      is-function: 1.0.2
+      parse-headers: 2.0.6
+      xtend: 4.0.2
+
+  xtend@4.0.2: {}
+
+  zod@3.25.76: {}

--- a/modules/data_l1/src/main/resources/dag-l1.conf
+++ b/modules/data_l1/src/main/resources/dag-l1.conf
@@ -1,0 +1,34 @@
+state-after-joining = Ready
+
+# Custom: Single-node consensus for dev/test deployments
+consensus {
+  peers-count = 1
+  tips-count = 1
+  timeout = 45 seconds
+  pull-txs-count = 100
+}
+
+data-consensus {
+  peers-count = 1
+  timeout = 10 seconds
+  max-data-updates-to-dequeue = 50
+}
+
+swap {
+  peers-count = 1
+  timeout = 10 seconds
+  max-allow-spends-to-dequeue = 50
+}
+
+token-lock {
+  peers-count = 1
+  timeout = 10 seconds
+  max-token-locks-to-dequeue = 50
+}
+
+transaction-limit {
+  base-balance = 100000000
+  time-trigger-interval = 43 seconds
+  time-to-wait-for-base-balance = 20 hours
+  min-fee-without-limit = 200000
+}

--- a/modules/models/src/main/scala/xyz/kd5ujc/schema/Records.scala
+++ b/modules/models/src/main/scala/xyz/kd5ujc/schema/Records.scala
@@ -39,7 +39,8 @@ object Records {
     status:                FiberStatus,
     lastReceipt:           Option[EventReceipt] = None,
     parentFiberId:         Option[UUID] = None,
-    childFiberIds:         Set[UUID] = Set.empty
+    childFiberIds:         Set[UUID] = Set.empty,
+    authorizedSigners:     Set[Address] = Set.empty
   ) extends FiberRecord
 
   @derive(encoder, decoder)

--- a/modules/models/src/main/scala/xyz/kd5ujc/schema/Updates.scala
+++ b/modules/models/src/main/scala/xyz/kd5ujc/schema/Updates.scala
@@ -4,6 +4,7 @@ import java.util.UUID
 
 import io.constellationnetwork.currency.dataApplication.DataUpdate
 import io.constellationnetwork.metagraph_sdk.json_logic.{JsonLogicExpression, JsonLogicValue}
+import io.constellationnetwork.schema.address.Address
 
 import xyz.kd5ujc.schema.fiber.{AccessControlPolicy, FiberOrdinal, StateMachineDefinition}
 
@@ -26,7 +27,8 @@ object Updates {
     fiberId:       UUID,
     definition:    StateMachineDefinition,
     initialData:   JsonLogicValue,
-    parentFiberId: Option[UUID] = None
+    parentFiberId: Option[UUID] = None,
+    participants:  Option[Set[Address]] = None
   ) extends StateMachineFiberOp
       with OttochainMessage
 

--- a/modules/models/src/main/scala/xyz/kd5ujc/schema/Updates.scala
+++ b/modules/models/src/main/scala/xyz/kd5ujc/schema/Updates.scala
@@ -11,6 +11,7 @@ import xyz.kd5ujc.schema.fiber.{AccessControlPolicy, FiberOrdinal, StateMachineD
 import derevo.circe.magnolia.{decoder, encoder}
 import derevo.derive
 import io.circe._
+import io.circe.generic.semiauto.deriveEncoder
 import io.circe.syntax.EncoderOps
 
 object Updates {
@@ -22,7 +23,7 @@ object Updates {
 
   sealed trait StateMachineFiberOp
 
-  @derive(decoder, encoder)
+  @derive(decoder)
   final case class CreateStateMachine(
     fiberId:       UUID,
     definition:    StateMachineDefinition,
@@ -31,6 +32,12 @@ object Updates {
     participants:  Option[Set[Address]] = None
   ) extends StateMachineFiberOp
       with OttochainMessage
+
+  object CreateStateMachine {
+
+    implicit val encoder: Encoder[CreateStateMachine] =
+      deriveEncoder[CreateStateMachine].mapJson(_.dropNullValues)
+  }
 
   /**
    * Event to trigger a state machine transition.

--- a/modules/models/src/main/scala/xyz/kd5ujc/schema/Updates.scala
+++ b/modules/models/src/main/scala/xyz/kd5ujc/schema/Updates.scala
@@ -11,7 +11,6 @@ import xyz.kd5ujc.schema.fiber.{AccessControlPolicy, FiberOrdinal, StateMachineD
 import derevo.circe.magnolia.{decoder, encoder}
 import derevo.derive
 import io.circe._
-import io.circe.generic.semiauto.deriveEncoder
 import io.circe.syntax.EncoderOps
 
 object Updates {
@@ -23,7 +22,7 @@ object Updates {
 
   sealed trait StateMachineFiberOp
 
-  @derive(decoder)
+  @derive(decoder, encoder)
   final case class CreateStateMachine(
     fiberId:       UUID,
     definition:    StateMachineDefinition,
@@ -32,12 +31,6 @@ object Updates {
     participants:  Option[Set[Address]] = None
   ) extends StateMachineFiberOp
       with OttochainMessage
-
-  object CreateStateMachine {
-
-    implicit val encoder: Encoder[CreateStateMachine] =
-      deriveEncoder[CreateStateMachine].mapJson(_.dropNullValues)
-  }
 
   /**
    * Event to trigger a state machine transition.

--- a/modules/models/src/main/scala/xyz/kd5ujc/schema/fiber/StateId.scala
+++ b/modules/models/src/main/scala/xyz/kd5ujc/schema/fiber/StateId.scala
@@ -1,7 +1,22 @@
 package xyz.kd5ujc.schema.fiber
 
-import derevo.circe.magnolia.{decoder, encoder, keyDecoder, keyEncoder}
-import derevo.derive
+import io.circe.{Decoder, Encoder, KeyDecoder, KeyEncoder}
 
-@derive(encoder, decoder, keyEncoder, keyDecoder)
 case class StateId(value: String) extends AnyVal
+
+object StateId {
+  // Encode as plain string (canonical wire format)
+  implicit val encoder: Encoder[StateId] = Encoder.encodeString.contramap(_.value)
+
+  // Accept both plain string ("state") and wrapped object ({"value": "state"})
+  // The wrapped format was used in TDD test fixtures; both are valid on input.
+  implicit val decoder: Decoder[StateId] =
+    Decoder.decodeString
+      .map(StateId(_))
+      .or(
+        Decoder.forProduct1("value")(StateId(_))
+      )
+
+  implicit val keyEncoder: KeyEncoder[StateId] = KeyEncoder.encodeKeyString.contramap(_.value)
+  implicit val keyDecoder: KeyDecoder[StateId] = KeyDecoder.decodeKeyString.map(StateId(_))
+}

--- a/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/combine/FiberCombiner.scala
+++ b/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/combine/FiberCombiner.scala
@@ -47,6 +47,9 @@ class FiberCombiner[F[_]: Async: SecurityProvider](
     owners          <- update.proofs.toList.traverse(_.id.toAddress).map(Set.from)
     initialDataHash <- update.initialData.computeDigest
 
+    // participants declared in CreateStateMachine become authorized signers for transitions
+    authorizedSigners = update.participants.getOrElse(Set.empty)
+
     record = Records.StateMachineFiberRecord(
       fiberId = update.fiberId,
       creationOrdinal = currentOrdinal,
@@ -59,7 +62,8 @@ class FiberCombiner[F[_]: Async: SecurityProvider](
       sequenceNumber = FiberOrdinal.MinValue,
       owners = owners,
       status = FiberStatus.Active,
-      parentFiberId = update.parentFiberId
+      parentFiberId = update.parentFiberId,
+      authorizedSigners = authorizedSigners
     )
 
     result <- current.withRecord[F](update.fiberId, record)

--- a/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/validate/FiberValidator.scala
+++ b/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/validate/FiberValidator.scala
@@ -38,6 +38,7 @@ object FiberValidator {
         definitionOk   <- FiberRules.L1.validStateMachineDefinition(update.definition)
         limitsOk       <- FiberRules.L1.definitionWithinLimits(update.definition)
         expressionsOk  <- FiberRules.L1.definitionExpressionsWithinDepthLimits(update.definition)
+        reservedOk     <- FiberRules.L1.noReservedOperatorFieldNames(update.definition)
         initialDataMap <- CommonRules.isMapValue(update.initialData, "initialData")
         initialDataSize <- CommonRules.valueWithinSizeLimit(
           update.initialData,
@@ -50,6 +51,7 @@ object FiberValidator {
         definitionOk,
         limitsOk,
         expressionsOk,
+        reservedOk,
         initialDataMap,
         initialDataSize,
         parentExists

--- a/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/validate/FiberValidator.scala
+++ b/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/validate/FiberValidator.scala
@@ -103,10 +103,11 @@ object FiberValidator {
     /** Validates a ProcessFiberEvent update (L0 specific checks) */
     def processEvent(update: TransitionStateMachine): F[ValidationResult] =
       for {
-        fiberActive   <- FiberRules.L0.fiberIsActive(update.fiberId, state.calculated)
-        signedByOwner <- FiberRules.L0.updateSignedByOwners(update.fiberId, proofs, state.calculated)
-        transitionOk  <- FiberRules.L0.transitionExists(update.fiberId, update.eventName, state.calculated)
-      } yield List(fiberActive, signedByOwner, transitionOk).combineAll
+        fiberActive <- FiberRules.L0.fiberIsActive(update.fiberId, state.calculated)
+        // Relaxed: owners OR authorized participants (declared in CreateStateMachine.participants)
+        signedOk     <- FiberRules.L0.updateSignedByOwnerOrParticipant(update.fiberId, proofs, state.calculated)
+        transitionOk <- FiberRules.L0.transitionExists(update.fiberId, update.eventName, state.calculated)
+      } yield List(fiberActive, signedOk, transitionOk).combineAll
 
     /** Validates an ArchiveFiber update (L0 specific checks) */
     def archiveFiber(update: ArchiveStateMachine): F[ValidationResult] =

--- a/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/validate/rules/FiberRules.scala
+++ b/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/validate/rules/FiberRules.scala
@@ -14,7 +14,7 @@ import io.constellationnetwork.security.SecurityProvider
 import io.constellationnetwork.security.signature.signature.SignatureProof
 
 import xyz.kd5ujc.schema.fiber.{FiberOrdinal, FiberStatus, StateId, StateMachineDefinition}
-import xyz.kd5ujc.schema.{CalculatedState, OnChain}
+import xyz.kd5ujc.schema.{CalculatedState, OnChain, Records}
 import xyz.kd5ujc.shared_data.lifecycle.validate.{Limits, ValidationResult}
 import xyz.kd5ujc.shared_data.syntax.calculatedState._
 
@@ -286,6 +286,37 @@ object FiberRules {
       _.validNec[DataApplicationValidationError]
     )
 
+    /**
+     * Validates that the update is signed by an owner OR an authorized participant.
+     *
+     * Used for TransitionStateMachine operations where counterparties are allowed.
+     * Owners: derived from CreateStateMachine signers (can do anything)
+     * AuthorizedSigners: declared in CreateStateMachine.participants (transitions only)
+     *
+     * Note: ArchiveStateMachine still uses updateSignedByOwners (strict — owners only).
+     */
+    def updateSignedByOwnerOrParticipant[F[_]: Async: SecurityProvider](
+      cid:    UUID,
+      proofs: NonEmptySet[SignatureProof],
+      state:  CalculatedState
+    ): F[ValidationResult] = (for {
+      record          <- state.getFiberRecord(cid)
+      signerAddresses <- EitherT.liftF(proofs.toList.traverse(_.id.toAddress))
+      signerSet = signerAddresses.toSet
+      authorizedSet = record match {
+        case sm: Records.StateMachineFiberRecord => sm.owners ++ sm.authorizedSigners
+        case other                               => other.owners
+      }
+      result <- EitherT.cond[F](
+        signerSet.intersect(authorizedSet).nonEmpty,
+        (),
+        Errors.NotSignedByAuthorizedParty: DataApplicationValidationError
+      )
+    } yield result).fold(
+      _.invalidNec[Unit],
+      _.validNec[DataApplicationValidationError]
+    )
+
     /** Validates that a transition exists for the given state+event combination */
     def transitionExists[F[_]: Monad](
       cid:       UUID,
@@ -408,6 +439,10 @@ object FiberRules {
 
     final case object NotSignedByOwner extends DataApplicationValidationError {
       override val message: String = "Update not signed by any fiber owner"
+    }
+
+    final case object NotSignedByAuthorizedParty extends DataApplicationValidationError {
+      override val message: String = "Update not signed by any fiber owner or authorized participant"
     }
 
     // --- Sequence number errors ---

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/ConcurrentEventsSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/ConcurrentEventsSuite.scala
@@ -200,13 +200,13 @@ object ConcurrentEventsSuite extends SimpleIOSuite {
   private val historyDefinitionJson =
     """|{
        |  "states": {
-       |    "active": { "id": { "value": "active" }, "isFinal": false }
+       |    "ACTIVE": { "id": { "value": "ACTIVE" }, "isFinal": false }
        |  },
-       |  "initialState": { "value": "active" },
+       |  "initialState": { "value": "ACTIVE" },
        |  "transitions": [
        |    {
-       |      "from": { "value": "active" },
-       |      "to": { "value": "active" },
+       |      "from": { "value": "ACTIVE" },
+       |      "to": { "value": "ACTIVE" },
        |      "eventName": "record",
        |      "guard": true,
        |      "effect": {

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/CrossMachineStateMachineSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/CrossMachineStateMachineSuite.scala
@@ -66,13 +66,13 @@ object CrossMachineStateMachineSuite extends SimpleIOSuite {
         buyerfiberId <- UUIDGen.randomUUID[IO]
         buyerDef = StateMachineDefinition(
           states = Map(
-            StateId("pending")   -> State(StateId("pending")),
+            StateId("PENDING")   -> State(StateId("PENDING")),
             StateId("purchased") -> State(StateId("purchased"))
           ),
-          initialState = StateId("pending"),
+          initialState = StateId("PENDING"),
           transitions = List(
             Transition(
-              from = StateId("pending"),
+              from = StateId("PENDING"),
               to = StateId("purchased"),
               eventName = "buy",
               guard = ApplyExpression(
@@ -114,7 +114,7 @@ object CrossMachineStateMachineSuite extends SimpleIOSuite {
           previousUpdateOrdinal = ordinal,
           latestUpdateOrdinal = ordinal,
           definition = buyerDef,
-          currentState = StateId("pending"),
+          currentState = StateId("PENDING"),
           stateData = buyerData,
           stateDataHash = buyerHash,
           sequenceNumber = FiberOrdinal.MinValue,

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/DeterministicExecutionSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/DeterministicExecutionSuite.scala
@@ -42,13 +42,13 @@ object DeterministicExecutionSuite extends SimpleIOSuite with Checkers {
         definition = StateMachineDefinition(
           states = Map(
             StateId("idle")   -> State(StateId("idle")),
-            StateId("active") -> State(StateId("active"))
+            StateId("ACTIVE") -> State(StateId("ACTIVE"))
           ),
           initialState = StateId("idle"),
           transitions = List(
             Transition(
               from = StateId("idle"),
-              to = StateId("active"),
+              to = StateId("ACTIVE"),
               eventName = "activate",
               guard = ConstExpression(BoolValue(true)),
               effect = ConstExpression(MapValue(Map("activated" -> BoolValue(true))))
@@ -97,7 +97,7 @@ object DeterministicExecutionSuite extends SimpleIOSuite with Checkers {
       expect(
         result1 match {
           case TransactionResult.Committed(updatedSMs, _, _, _, _, _) =>
-            updatedSMs.get(fiberId).exists(_.currentState == StateId("active"))
+            updatedSMs.get(fiberId).exists(_.currentState == StateId("ACTIVE"))
           case _ => false
         }
       )
@@ -985,13 +985,13 @@ object DeterministicExecutionSuite extends SimpleIOSuite with Checkers {
         // C triggers A (completes the cycle, with self-transition to allow cycle to continue)
         defC = StateMachineDefinition(
           states = Map(
-            StateId("pending")  -> State(StateId("pending")),
+            StateId("PENDING")  -> State(StateId("PENDING")),
             StateId("finished") -> State(StateId("finished"))
           ),
-          initialState = StateId("pending"),
+          initialState = StateId("PENDING"),
           transitions = List(
             Transition(
-              from = StateId("pending"),
+              from = StateId("PENDING"),
               to = StateId("finished"),
               eventName = "finish",
               guard = ConstExpression(BoolValue(true)),
@@ -1085,7 +1085,7 @@ object DeterministicExecutionSuite extends SimpleIOSuite with Checkers {
           previousUpdateOrdinal = ordinal,
           latestUpdateOrdinal = ordinal,
           definition = defC,
-          currentState = StateId("pending"),
+          currentState = StateId("PENDING"),
           stateData = dataC,
           stateDataHash = hashC,
           sequenceNumber = FiberOrdinal.MinValue,
@@ -1389,7 +1389,7 @@ object DeterministicExecutionSuite extends SimpleIOSuite with Checkers {
         parentDefinition = StateMachineDefinition(
           states = Map(
             StateId("ready")    -> State(StateId("ready")),
-            StateId("active")   -> State(StateId("active")),
+            StateId("ACTIVE")   -> State(StateId("ACTIVE")),
             StateId("callback") -> State(StateId("callback"))
           ),
           initialState = StateId("ready"),
@@ -1397,7 +1397,7 @@ object DeterministicExecutionSuite extends SimpleIOSuite with Checkers {
             // Start transition triggers child
             Transition(
               from = StateId("ready"),
-              to = StateId("active"),
+              to = StateId("ACTIVE"),
               eventName = "start",
               guard = ConstExpression(BoolValue(true)),
               effect = ConstExpression(
@@ -1421,7 +1421,7 @@ object DeterministicExecutionSuite extends SimpleIOSuite with Checkers {
             ),
             // Callback from child triggers child again - creates cycle!
             Transition(
-              from = StateId("active"),
+              from = StateId("ACTIVE"),
               to = StateId("callback"),
               eventName = "child_callback",
               guard = ConstExpression(BoolValue(true)),
@@ -1447,7 +1447,7 @@ object DeterministicExecutionSuite extends SimpleIOSuite with Checkers {
             // Handle callback from callback state to continue cycle
             Transition(
               from = StateId("callback"),
-              to = StateId("active"),
+              to = StateId("ACTIVE"),
               eventName = "child_callback",
               guard = ConstExpression(BoolValue(true)),
               effect = ConstExpression(

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/FailureReasonSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/FailureReasonSuite.scala
@@ -41,13 +41,13 @@ object FailureReasonSuite extends SimpleIOSuite {
         definition = StateMachineDefinition(
           states = Map(
             StateId("idle")   -> State(StateId("idle")),
-            StateId("active") -> State(StateId("active"))
+            StateId("ACTIVE") -> State(StateId("ACTIVE"))
           ),
           initialState = StateId("idle"),
           transitions = List(
             Transition(
               from = StateId("idle"),
-              to = StateId("active"),
+              to = StateId("ACTIVE"),
               eventName = "activate",
               guard = ConstExpression(BoolValue(true)),
               effect = ConstExpression(MapValue(Map("activated" -> BoolValue(true))))

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/GasMeteringPhaseSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/GasMeteringPhaseSuite.scala
@@ -491,13 +491,13 @@ object GasMeteringPhaseSuite extends SimpleIOSuite {
                                   Map(
                                     "active" -> MapValue(
                                       Map(
-                                        "id"      -> MapValue(Map("value" -> StrValue("active"))),
+                                        "id"      -> MapValue(Map("value" -> StrValue("ACTIVE"))),
                                         "isFinal" -> BoolValue(false)
                                       )
                                     )
                                   )
                                 ),
-                                "initialState" -> MapValue(Map("value" -> StrValue("active"))),
+                                "initialState" -> MapValue(Map("value" -> StrValue("ACTIVE"))),
                                 "transitions"  -> ArrayValue(List.empty)
                               )
                             ),

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/MultiPartyTransitionSigningSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/MultiPartyTransitionSigningSuite.scala
@@ -1,0 +1,528 @@
+package xyz.kd5ujc.shared_data
+
+import cats.effect.IO
+import cats.effect.std.UUIDGen
+import cats.syntax.all._
+
+import io.constellationnetwork.currency.dataApplication.{DataState, L0NodeContext}
+import io.constellationnetwork.metagraph_sdk.json_logic._
+import io.constellationnetwork.security.SecurityProvider
+import io.constellationnetwork.security.signature.Signed
+
+import xyz.kd5ujc.schema.fiber._
+import xyz.kd5ujc.schema.{CalculatedState, OnChain, Records, Updates}
+import xyz.kd5ujc.shared_data.lifecycle.Combiner
+import xyz.kd5ujc.shared_test.Participant._
+import xyz.kd5ujc.shared_test.TestFixture
+
+import io.circe.parser._
+import weaver.SimpleIOSuite
+
+object MultiPartyTransitionSigningSuite extends SimpleIOSuite {
+
+  test("counterparty can sign accept transition on fiber they didn't create") {
+    TestFixture.resource(Set(Alice, Bob)).use { fixture =>
+      implicit val s: SecurityProvider[IO] = fixture.securityProvider
+      implicit val l0ctx: L0NodeContext[IO] = fixture.l0Context
+      for {
+        combiner <- Combiner.make[IO]().pure[IO]
+
+        contractFiberId <- UUIDGen.randomUUID[IO]
+
+        // Simple contract with accept/reject transitions
+        contractJson = """
+        {
+          "states": {
+            "pending": { "id": "pending", "isFinal": false },
+            "accepted": { "id": "accepted", "isFinal": true },
+            "rejected": { "id": "rejected", "isFinal": true }
+          },
+          "initialState": "pending",
+          "transitions": [
+            {
+              "from": "pending",
+              "to": "accepted",
+              "eventName": "accept",
+              "guard": true,
+              "effect": {
+                "status": "accepted",
+                "acceptedAt": { "var": "event.timestamp" }
+              },
+              "dependencies": []
+            },
+            {
+              "from": "pending",
+              "to": "rejected", 
+              "eventName": "reject",
+              "guard": true,
+              "effect": {
+                "status": "rejected",
+                "rejectedAt": { "var": "event.timestamp" }
+              },
+              "dependencies": []
+            }
+          ]
+        }
+        """
+
+        contractDef <- IO.fromEither(decode[StateMachineDefinition](contractJson))
+        initialData = MapValue(Map("counterparty" -> StrValue("Bob")))
+
+        // Alice creates the contract
+        createContract = Updates.CreateStateMachine(contractFiberId, contractDef, initialData)
+        createProof <- fixture.registry.generateProofs(createContract, Set(Alice))
+        stateAfterCreate <- combiner.insert(
+          DataState(OnChain.genesis, CalculatedState.genesis),
+          Signed(createContract, createProof)
+        )
+
+        // Bob (counterparty) signs the accept transition
+        acceptEvent = Updates.TransitionStateMachine(
+          contractFiberId,
+          "accept",
+          MapValue(Map("timestamp" -> IntValue(System.currentTimeMillis()))),
+          FiberOrdinal.MinValue
+        )
+        // This should work in the multi-party system - Bob can sign accept
+        acceptProof <- fixture.registry.generateProofs(acceptEvent, Set(Bob))
+        finalState  <- combiner.insert(stateAfterCreate, Signed(acceptEvent, acceptProof))
+
+        contract = finalState.calculated.stateMachines
+          .get(contractFiberId)
+          .collect { case r: Records.StateMachineFiberRecord => r }
+
+        status = contract.flatMap { f =>
+          f.stateData match {
+            case MapValue(m) => m.get("status").collect { case StrValue(s) => s }
+            case _           => None
+          }
+        }
+
+      } yield expect(contract.isDefined) and
+      expect(contract.map(_.currentState).contains(StateId("accepted"))) and
+      expect(status.contains("accepted"))
+    }
+  }
+
+  test("counterparty can sign reject transition") {
+    TestFixture.resource(Set(Alice, Bob)).use { fixture =>
+      implicit val s: SecurityProvider[IO] = fixture.securityProvider
+      implicit val l0ctx: L0NodeContext[IO] = fixture.l0Context
+      for {
+        combiner <- Combiner.make[IO]().pure[IO]
+
+        contractFiberId <- UUIDGen.randomUUID[IO]
+
+        contractJson = """
+        {
+          "states": {
+            "pending": { "id": "pending", "isFinal": false },
+            "accepted": { "id": "accepted", "isFinal": true },
+            "rejected": { "id": "rejected", "isFinal": true }
+          },
+          "initialState": "pending",
+          "transitions": [
+            {
+              "from": "pending",
+              "to": "accepted",
+              "eventName": "accept",
+              "guard": true,
+              "effect": {
+                "status": "accepted"
+              },
+              "dependencies": []
+            },
+            {
+              "from": "pending",
+              "to": "rejected", 
+              "eventName": "reject",
+              "guard": true,
+              "effect": {
+                "status": "rejected",
+                "reason": { "var": "event.reason" }
+              },
+              "dependencies": []
+            }
+          ]
+        }
+        """
+
+        contractDef <- IO.fromEither(decode[StateMachineDefinition](contractJson))
+        initialData = MapValue(Map("counterparty" -> StrValue("Bob")))
+
+        // Alice creates the contract
+        createContract = Updates.CreateStateMachine(contractFiberId, contractDef, initialData)
+        createProof <- fixture.registry.generateProofs(createContract, Set(Alice))
+        stateAfterCreate <- combiner.insert(
+          DataState(OnChain.genesis, CalculatedState.genesis),
+          Signed(createContract, createProof)
+        )
+
+        // Bob (counterparty) signs the reject transition
+        rejectEvent = Updates.TransitionStateMachine(
+          contractFiberId,
+          "reject",
+          MapValue(Map("reason" -> StrValue("terms not acceptable"))),
+          FiberOrdinal.MinValue
+        )
+        // This should work in the multi-party system - Bob can sign reject
+        rejectProof <- fixture.registry.generateProofs(rejectEvent, Set(Bob))
+        finalState  <- combiner.insert(stateAfterCreate, Signed(rejectEvent, rejectProof))
+
+        contract = finalState.calculated.stateMachines
+          .get(contractFiberId)
+          .collect { case r: Records.StateMachineFiberRecord => r }
+
+        status = contract.flatMap { f =>
+          f.stateData match {
+            case MapValue(m) => m.get("status").collect { case StrValue(s) => s }
+            case _           => None
+          }
+        }
+
+        reason = contract.flatMap { f =>
+          f.stateData match {
+            case MapValue(m) => m.get("reason").collect { case StrValue(r) => r }
+            case _           => None
+          }
+        }
+
+      } yield expect(contract.isDefined) and
+      expect(contract.map(_.currentState).contains(StateId("rejected"))) and
+      expect(status.contains("rejected")) and
+      expect(reason.contains("terms not acceptable"))
+    }
+  }
+
+  test("unauthorized third party CANNOT sign transitions") {
+    TestFixture.resource(Set(Alice, Bob, Charlie)).use { fixture =>
+      implicit val s: SecurityProvider[IO] = fixture.securityProvider
+      implicit val l0ctx: L0NodeContext[IO] = fixture.l0Context
+      for {
+        combiner <- Combiner.make[IO]().pure[IO]
+
+        contractFiberId <- UUIDGen.randomUUID[IO]
+
+        contractJson = """
+        {
+          "states": {
+            "pending": { "id": "pending", "isFinal": false },
+            "accepted": { "id": "accepted", "isFinal": true }
+          },
+          "initialState": "pending",
+          "transitions": [
+            {
+              "from": "pending",
+              "to": "accepted",
+              "eventName": "accept",
+              "guard": true,
+              "effect": {
+                "status": "accepted"
+              },
+              "dependencies": []
+            }
+          ]
+        }
+        """
+
+        contractDef <- IO.fromEither(decode[StateMachineDefinition](contractJson))
+        initialData = MapValue(Map("counterparty" -> StrValue("Bob")))
+
+        // Alice creates the contract
+        createContract = Updates.CreateStateMachine(contractFiberId, contractDef, initialData)
+        createProof <- fixture.registry.generateProofs(createContract, Set(Alice))
+        stateAfterCreate <- combiner.insert(
+          DataState(OnChain.genesis, CalculatedState.genesis),
+          Signed(createContract, createProof)
+        )
+
+        // Charlie (unauthorized third party) tries to sign accept transition
+        acceptEvent = Updates.TransitionStateMachine(
+          contractFiberId,
+          "accept",
+          MapValue(Map("timestamp" -> IntValue(System.currentTimeMillis()))),
+          FiberOrdinal.MinValue
+        )
+
+        // This should fail - Charlie is not owner (Alice) or counterparty (Bob)
+        charlieProof <- fixture.registry.generateProofs(acceptEvent, Set(Charlie))
+        result       <- combiner.insert(stateAfterCreate, Signed(acceptEvent, charlieProof)).attempt
+
+        // The system should reject this transaction
+        // In the current system this would pass, but in multi-party system it should fail
+
+      } yield expect(result.isLeft) // Should fail because Charlie is not authorized
+    }
+  }
+
+  test("owner can still sign all transitions") {
+    TestFixture.resource(Set(Alice, Bob)).use { fixture =>
+      implicit val s: SecurityProvider[IO] = fixture.securityProvider
+      implicit val l0ctx: L0NodeContext[IO] = fixture.l0Context
+      for {
+        combiner <- Combiner.make[IO]().pure[IO]
+
+        contractFiberId <- UUIDGen.randomUUID[IO]
+
+        contractJson = """
+        {
+          "states": {
+            "pending": { "id": "pending", "isFinal": false },
+            "cancelled": { "id": "cancelled", "isFinal": true }
+          },
+          "initialState": "pending",
+          "transitions": [
+            {
+              "from": "pending",
+              "to": "cancelled",
+              "eventName": "cancel",
+              "guard": true,
+              "effect": {
+                "status": "cancelled",
+                "cancelledBy": "owner"
+              },
+              "dependencies": []
+            }
+          ]
+        }
+        """
+
+        contractDef <- IO.fromEither(decode[StateMachineDefinition](contractJson))
+        initialData = MapValue(Map("counterparty" -> StrValue("Bob")))
+
+        // Alice creates the contract
+        createContract = Updates.CreateStateMachine(contractFiberId, contractDef, initialData)
+        createProof <- fixture.registry.generateProofs(createContract, Set(Alice))
+        stateAfterCreate <- combiner.insert(
+          DataState(OnChain.genesis, CalculatedState.genesis),
+          Signed(createContract, createProof)
+        )
+
+        // Alice (owner) signs the cancel transition - should always work
+        cancelEvent = Updates.TransitionStateMachine(
+          contractFiberId,
+          "cancel",
+          MapValue(Map.empty[String, JsonLogicValue]),
+          FiberOrdinal.MinValue
+        )
+        cancelProof <- fixture.registry.generateProofs(cancelEvent, Set(Alice))
+        finalState  <- combiner.insert(stateAfterCreate, Signed(cancelEvent, cancelProof))
+
+        contract = finalState.calculated.stateMachines
+          .get(contractFiberId)
+          .collect { case r: Records.StateMachineFiberRecord => r }
+
+        status = contract.flatMap { f =>
+          f.stateData match {
+            case MapValue(m) => m.get("status").collect { case StrValue(s) => s }
+            case _           => None
+          }
+        }
+
+      } yield expect(contract.isDefined) and
+      expect(contract.map(_.currentState).contains(StateId("cancelled"))) and
+      expect(status.contains("cancelled"))
+    }
+  }
+
+  test("guard conditions still evaluate correctly with counterparty signer") {
+    TestFixture.resource(Set(Alice, Bob)).use { fixture =>
+      implicit val s: SecurityProvider[IO] = fixture.securityProvider
+      implicit val l0ctx: L0NodeContext[IO] = fixture.l0Context
+      for {
+        combiner <- Combiner.make[IO]().pure[IO]
+
+        contractFiberId <- UUIDGen.randomUUID[IO]
+
+        // Contract with guard condition that must pass
+        contractJson = """
+        {
+          "states": {
+            "pending": { "id": "pending", "isFinal": false },
+            "approved": { "id": "approved", "isFinal": true },
+            "denied": { "id": "denied", "isFinal": true }
+          },
+          "initialState": "pending",
+          "transitions": [
+            {
+              "from": "pending",
+              "to": "approved",
+              "eventName": "approve",
+              "guard": {
+                ">=": [{ "var": "event.amount" }, { "var": "state.minimumAmount" }]
+              },
+              "effect": {
+                "status": "approved",
+                "finalAmount": { "var": "event.amount" }
+              },
+              "dependencies": []
+            },
+            {
+              "from": "pending",
+              "to": "denied",
+              "eventName": "approve",
+              "guard": {
+                "<": [{ "var": "event.amount" }, { "var": "state.minimumAmount" }]
+              },
+              "effect": {
+                "status": "denied",
+                "reason": "amount too low"
+              },
+              "dependencies": []
+            }
+          ]
+        }
+        """
+
+        contractDef <- IO.fromEither(decode[StateMachineDefinition](contractJson))
+        initialData = MapValue(
+          Map(
+            "counterparty"  -> StrValue("Bob"),
+            "minimumAmount" -> IntValue(1000)
+          )
+        )
+
+        // Alice creates the contract
+        createContract = Updates.CreateStateMachine(contractFiberId, contractDef, initialData)
+        createProof <- fixture.registry.generateProofs(createContract, Set(Alice))
+        stateAfterCreate <- combiner.insert(
+          DataState(OnChain.genesis, CalculatedState.genesis),
+          Signed(createContract, createProof)
+        )
+
+        // Bob approves with amount that meets guard condition
+        approveEvent = Updates.TransitionStateMachine(
+          contractFiberId,
+          "approve",
+          MapValue(Map("amount" -> IntValue(1500))),
+          FiberOrdinal.MinValue
+        )
+        // Guard should evaluate correctly even when Bob signs instead of Alice
+        approveProof <- fixture.registry.generateProofs(approveEvent, Set(Bob))
+        finalState   <- combiner.insert(stateAfterCreate, Signed(approveEvent, approveProof))
+
+        contract = finalState.calculated.stateMachines
+          .get(contractFiberId)
+          .collect { case r: Records.StateMachineFiberRecord => r }
+
+        status = contract.flatMap { f =>
+          f.stateData match {
+            case MapValue(m) => m.get("status").collect { case StrValue(s) => s }
+            case _           => None
+          }
+        }
+
+        finalAmount = contract.flatMap { f =>
+          f.stateData match {
+            case MapValue(m) => m.get("finalAmount").collect { case IntValue(a) => a }
+            case _           => None
+          }
+        }
+
+      } yield expect(contract.isDefined) and
+      expect(contract.map(_.currentState).contains(StateId("approved"))) and
+      expect(status.contains("approved")) and
+      expect(finalAmount.contains(BigInt(1500)))
+    }
+  }
+
+  test("guard condition fails correctly with counterparty signer") {
+    TestFixture.resource(Set(Alice, Bob)).use { fixture =>
+      implicit val s: SecurityProvider[IO] = fixture.securityProvider
+      implicit val l0ctx: L0NodeContext[IO] = fixture.l0Context
+      for {
+        combiner <- Combiner.make[IO]().pure[IO]
+
+        contractFiberId <- UUIDGen.randomUUID[IO]
+
+        // Same contract as above but test the failing guard condition
+        contractJson = """
+        {
+          "states": {
+            "pending": { "id": "pending", "isFinal": false },
+            "approved": { "id": "approved", "isFinal": true },
+            "denied": { "id": "denied", "isFinal": true }
+          },
+          "initialState": "pending",
+          "transitions": [
+            {
+              "from": "pending",
+              "to": "approved",
+              "eventName": "approve",
+              "guard": {
+                ">=": [{ "var": "event.amount" }, { "var": "state.minimumAmount" }]
+              },
+              "effect": {
+                "status": "approved",
+                "finalAmount": { "var": "event.amount" }
+              },
+              "dependencies": []
+            },
+            {
+              "from": "pending",
+              "to": "denied",
+              "eventName": "approve",
+              "guard": {
+                "<": [{ "var": "event.amount" }, { "var": "state.minimumAmount" }]
+              },
+              "effect": {
+                "status": "denied",
+                "reason": "amount too low"
+              },
+              "dependencies": []
+            }
+          ]
+        }
+        """
+
+        contractDef <- IO.fromEither(decode[StateMachineDefinition](contractJson))
+        initialData = MapValue(
+          Map(
+            "counterparty"  -> StrValue("Bob"),
+            "minimumAmount" -> IntValue(1000)
+          )
+        )
+
+        // Alice creates the contract
+        createContract = Updates.CreateStateMachine(contractFiberId, contractDef, initialData)
+        createProof <- fixture.registry.generateProofs(createContract, Set(Alice))
+        stateAfterCreate <- combiner.insert(
+          DataState(OnChain.genesis, CalculatedState.genesis),
+          Signed(createContract, createProof)
+        )
+
+        // Bob approves with amount below minimum - should trigger second guard
+        approveEvent = Updates.TransitionStateMachine(
+          contractFiberId,
+          "approve",
+          MapValue(Map("amount" -> IntValue(500))), // Below minimum of 1000
+          FiberOrdinal.MinValue
+        )
+        approveProof <- fixture.registry.generateProofs(approveEvent, Set(Bob))
+        finalState   <- combiner.insert(stateAfterCreate, Signed(approveEvent, approveProof))
+
+        contract = finalState.calculated.stateMachines
+          .get(contractFiberId)
+          .collect { case r: Records.StateMachineFiberRecord => r }
+
+        status = contract.flatMap { f =>
+          f.stateData match {
+            case MapValue(m) => m.get("status").collect { case StrValue(s) => s }
+            case _           => None
+          }
+        }
+
+        reason = contract.flatMap { f =>
+          f.stateData match {
+            case MapValue(m) => m.get("reason").collect { case StrValue(r) => r }
+            case _           => None
+          }
+        }
+
+      } yield expect(contract.isDefined) and
+      expect(contract.map(_.currentState).contains(StateId("denied"))) and
+      expect(status.contains("denied")) and
+      expect(reason.contains("amount too low"))
+    }
+  }
+}

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/MultiPartyTransitionSigningSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/MultiPartyTransitionSigningSuite.scala
@@ -33,15 +33,15 @@ object MultiPartyTransitionSigningSuite extends SimpleIOSuite {
         contractJson = """
         {
           "states": {
-            "pending": { "id": "pending", "isFinal": false },
-            "accepted": { "id": "accepted", "isFinal": true },
-            "rejected": { "id": "rejected", "isFinal": true }
+            "pending": { "id": { "value": "pending" }, "isFinal": false },
+            "accepted": { "id": { "value": "accepted" }, "isFinal": true },
+            "rejected": { "id": { "value": "rejected" }, "isFinal": true }
           },
-          "initialState": "pending",
+          "initialState": { "value": "pending" },
           "transitions": [
             {
-              "from": "pending",
-              "to": "accepted",
+              "from": { "value": "pending" },
+              "to": { "value": "accepted" },
               "eventName": "accept",
               "guard": true,
               "effect": {
@@ -51,8 +51,8 @@ object MultiPartyTransitionSigningSuite extends SimpleIOSuite {
               "dependencies": []
             },
             {
-              "from": "pending",
-              "to": "rejected", 
+              "from": { "value": "pending" },
+              "to": { "value": "rejected" }, 
               "eventName": "reject",
               "guard": true,
               "effect": {
@@ -85,7 +85,7 @@ object MultiPartyTransitionSigningSuite extends SimpleIOSuite {
         )
         // This should work in the multi-party system - Bob can sign accept
         acceptProof <- fixture.registry.generateProofs(acceptEvent, Set(Bob))
-        finalState  <- combiner.insert(stateAfterCreate, Signed(acceptEvent, acceptProof))
+        finalState <- combiner.insert(stateAfterCreate, Signed(acceptEvent, acceptProof))
 
         contract = finalState.calculated.stateMachines
           .get(contractFiberId)
@@ -94,7 +94,7 @@ object MultiPartyTransitionSigningSuite extends SimpleIOSuite {
         status = contract.flatMap { f =>
           f.stateData match {
             case MapValue(m) => m.get("status").collect { case StrValue(s) => s }
-            case _           => None
+            case _ => None
           }
         }
 
@@ -116,15 +116,15 @@ object MultiPartyTransitionSigningSuite extends SimpleIOSuite {
         contractJson = """
         {
           "states": {
-            "pending": { "id": "pending", "isFinal": false },
-            "accepted": { "id": "accepted", "isFinal": true },
-            "rejected": { "id": "rejected", "isFinal": true }
+            "pending": { "id": { "value": "pending" }, "isFinal": false },
+            "accepted": { "id": { "value": "accepted" }, "isFinal": true },
+            "rejected": { "id": { "value": "rejected" }, "isFinal": true }
           },
-          "initialState": "pending",
+          "initialState": { "value": "pending" },
           "transitions": [
             {
-              "from": "pending",
-              "to": "accepted",
+              "from": { "value": "pending" },
+              "to": { "value": "accepted" },
               "eventName": "accept",
               "guard": true,
               "effect": {
@@ -133,8 +133,8 @@ object MultiPartyTransitionSigningSuite extends SimpleIOSuite {
               "dependencies": []
             },
             {
-              "from": "pending",
-              "to": "rejected", 
+              "from": { "value": "pending" },
+              "to": { "value": "rejected" }, 
               "eventName": "reject",
               "guard": true,
               "effect": {
@@ -167,7 +167,7 @@ object MultiPartyTransitionSigningSuite extends SimpleIOSuite {
         )
         // This should work in the multi-party system - Bob can sign reject
         rejectProof <- fixture.registry.generateProofs(rejectEvent, Set(Bob))
-        finalState  <- combiner.insert(stateAfterCreate, Signed(rejectEvent, rejectProof))
+        finalState <- combiner.insert(stateAfterCreate, Signed(rejectEvent, rejectProof))
 
         contract = finalState.calculated.stateMachines
           .get(contractFiberId)
@@ -176,14 +176,14 @@ object MultiPartyTransitionSigningSuite extends SimpleIOSuite {
         status = contract.flatMap { f =>
           f.stateData match {
             case MapValue(m) => m.get("status").collect { case StrValue(s) => s }
-            case _           => None
+            case _ => None
           }
         }
 
         reason = contract.flatMap { f =>
           f.stateData match {
             case MapValue(m) => m.get("reason").collect { case StrValue(r) => r }
-            case _           => None
+            case _ => None
           }
         }
 
@@ -206,14 +206,14 @@ object MultiPartyTransitionSigningSuite extends SimpleIOSuite {
         contractJson = """
         {
           "states": {
-            "pending": { "id": "pending", "isFinal": false },
-            "accepted": { "id": "accepted", "isFinal": true }
+            "pending": { "id": { "value": "pending" }, "isFinal": false },
+            "accepted": { "id": { "value": "accepted" }, "isFinal": true }
           },
-          "initialState": "pending",
+          "initialState": { "value": "pending" },
           "transitions": [
             {
-              "from": "pending",
-              "to": "accepted",
+              "from": { "value": "pending" },
+              "to": { "value": "accepted" },
               "eventName": "accept",
               "guard": true,
               "effect": {
@@ -243,10 +243,10 @@ object MultiPartyTransitionSigningSuite extends SimpleIOSuite {
           MapValue(Map("timestamp" -> IntValue(System.currentTimeMillis()))),
           FiberOrdinal.MinValue
         )
-
+        
         // This should fail - Charlie is not owner (Alice) or counterparty (Bob)
         charlieProof <- fixture.registry.generateProofs(acceptEvent, Set(Charlie))
-        result       <- combiner.insert(stateAfterCreate, Signed(acceptEvent, charlieProof)).attempt
+        result <- combiner.insert(stateAfterCreate, Signed(acceptEvent, charlieProof)).attempt
 
         // The system should reject this transaction
         // In the current system this would pass, but in multi-party system it should fail
@@ -267,14 +267,14 @@ object MultiPartyTransitionSigningSuite extends SimpleIOSuite {
         contractJson = """
         {
           "states": {
-            "pending": { "id": "pending", "isFinal": false },
-            "cancelled": { "id": "cancelled", "isFinal": true }
+            "pending": { "id": { "value": "pending" }, "isFinal": false },
+            "cancelled": { "id": { "value": "cancelled" }, "isFinal": true }
           },
-          "initialState": "pending",
+          "initialState": { "value": "pending" },
           "transitions": [
             {
-              "from": "pending",
-              "to": "cancelled",
+              "from": { "value": "pending" },
+              "to": { "value": "cancelled" },
               "eventName": "cancel",
               "guard": true,
               "effect": {
@@ -306,7 +306,7 @@ object MultiPartyTransitionSigningSuite extends SimpleIOSuite {
           FiberOrdinal.MinValue
         )
         cancelProof <- fixture.registry.generateProofs(cancelEvent, Set(Alice))
-        finalState  <- combiner.insert(stateAfterCreate, Signed(cancelEvent, cancelProof))
+        finalState <- combiner.insert(stateAfterCreate, Signed(cancelEvent, cancelProof))
 
         contract = finalState.calculated.stateMachines
           .get(contractFiberId)
@@ -315,7 +315,7 @@ object MultiPartyTransitionSigningSuite extends SimpleIOSuite {
         status = contract.flatMap { f =>
           f.stateData match {
             case MapValue(m) => m.get("status").collect { case StrValue(s) => s }
-            case _           => None
+            case _ => None
           }
         }
 
@@ -338,15 +338,15 @@ object MultiPartyTransitionSigningSuite extends SimpleIOSuite {
         contractJson = """
         {
           "states": {
-            "pending": { "id": "pending", "isFinal": false },
-            "approved": { "id": "approved", "isFinal": true },
-            "denied": { "id": "denied", "isFinal": true }
+            "pending": { "id": { "value": "pending" }, "isFinal": false },
+            "approved": { "id": { "value": "approved" }, "isFinal": true },
+            "denied": { "id": { "value": "denied" }, "isFinal": true }
           },
-          "initialState": "pending",
+          "initialState": { "value": "pending" },
           "transitions": [
             {
-              "from": "pending",
-              "to": "approved",
+              "from": { "value": "pending" },
+              "to": { "value": "approved" },
               "eventName": "approve",
               "guard": {
                 ">=": [{ "var": "event.amount" }, { "var": "state.minimumAmount" }]
@@ -358,8 +358,8 @@ object MultiPartyTransitionSigningSuite extends SimpleIOSuite {
               "dependencies": []
             },
             {
-              "from": "pending",
-              "to": "denied",
+              "from": { "value": "pending" },
+              "to": { "value": "denied" },
               "eventName": "approve",
               "guard": {
                 "<": [{ "var": "event.amount" }, { "var": "state.minimumAmount" }]
@@ -375,12 +375,10 @@ object MultiPartyTransitionSigningSuite extends SimpleIOSuite {
         """
 
         contractDef <- IO.fromEither(decode[StateMachineDefinition](contractJson))
-        initialData = MapValue(
-          Map(
-            "counterparty"  -> StrValue("Bob"),
-            "minimumAmount" -> IntValue(1000)
-          )
-        )
+        initialData = MapValue(Map(
+          "counterparty" -> StrValue("Bob"),
+          "minimumAmount" -> IntValue(1000)
+        ))
 
         // Alice creates the contract
         createContract = Updates.CreateStateMachine(contractFiberId, contractDef, initialData)
@@ -399,7 +397,7 @@ object MultiPartyTransitionSigningSuite extends SimpleIOSuite {
         )
         // Guard should evaluate correctly even when Bob signs instead of Alice
         approveProof <- fixture.registry.generateProofs(approveEvent, Set(Bob))
-        finalState   <- combiner.insert(stateAfterCreate, Signed(approveEvent, approveProof))
+        finalState <- combiner.insert(stateAfterCreate, Signed(approveEvent, approveProof))
 
         contract = finalState.calculated.stateMachines
           .get(contractFiberId)
@@ -408,14 +406,14 @@ object MultiPartyTransitionSigningSuite extends SimpleIOSuite {
         status = contract.flatMap { f =>
           f.stateData match {
             case MapValue(m) => m.get("status").collect { case StrValue(s) => s }
-            case _           => None
+            case _ => None
           }
         }
 
         finalAmount = contract.flatMap { f =>
           f.stateData match {
             case MapValue(m) => m.get("finalAmount").collect { case IntValue(a) => a }
-            case _           => None
+            case _ => None
           }
         }
 
@@ -439,15 +437,15 @@ object MultiPartyTransitionSigningSuite extends SimpleIOSuite {
         contractJson = """
         {
           "states": {
-            "pending": { "id": "pending", "isFinal": false },
-            "approved": { "id": "approved", "isFinal": true },
-            "denied": { "id": "denied", "isFinal": true }
+            "pending": { "id": { "value": "pending" }, "isFinal": false },
+            "approved": { "id": { "value": "approved" }, "isFinal": true },
+            "denied": { "id": { "value": "denied" }, "isFinal": true }
           },
-          "initialState": "pending",
+          "initialState": { "value": "pending" },
           "transitions": [
             {
-              "from": "pending",
-              "to": "approved",
+              "from": { "value": "pending" },
+              "to": { "value": "approved" },
               "eventName": "approve",
               "guard": {
                 ">=": [{ "var": "event.amount" }, { "var": "state.minimumAmount" }]
@@ -459,8 +457,8 @@ object MultiPartyTransitionSigningSuite extends SimpleIOSuite {
               "dependencies": []
             },
             {
-              "from": "pending",
-              "to": "denied",
+              "from": { "value": "pending" },
+              "to": { "value": "denied" },
               "eventName": "approve",
               "guard": {
                 "<": [{ "var": "event.amount" }, { "var": "state.minimumAmount" }]
@@ -476,12 +474,10 @@ object MultiPartyTransitionSigningSuite extends SimpleIOSuite {
         """
 
         contractDef <- IO.fromEither(decode[StateMachineDefinition](contractJson))
-        initialData = MapValue(
-          Map(
-            "counterparty"  -> StrValue("Bob"),
-            "minimumAmount" -> IntValue(1000)
-          )
-        )
+        initialData = MapValue(Map(
+          "counterparty" -> StrValue("Bob"),
+          "minimumAmount" -> IntValue(1000)
+        ))
 
         // Alice creates the contract
         createContract = Updates.CreateStateMachine(contractFiberId, contractDef, initialData)
@@ -499,7 +495,7 @@ object MultiPartyTransitionSigningSuite extends SimpleIOSuite {
           FiberOrdinal.MinValue
         )
         approveProof <- fixture.registry.generateProofs(approveEvent, Set(Bob))
-        finalState   <- combiner.insert(stateAfterCreate, Signed(approveEvent, approveProof))
+        finalState <- combiner.insert(stateAfterCreate, Signed(approveEvent, approveProof))
 
         contract = finalState.calculated.stateMachines
           .get(contractFiberId)
@@ -508,14 +504,14 @@ object MultiPartyTransitionSigningSuite extends SimpleIOSuite {
         status = contract.flatMap { f =>
           f.stateData match {
             case MapValue(m) => m.get("status").collect { case StrValue(s) => s }
-            case _           => None
+            case _ => None
           }
         }
 
         reason = contract.flatMap { f =>
           f.stateData match {
             case MapValue(m) => m.get("reason").collect { case StrValue(r) => r }
-            case _           => None
+            case _ => None
           }
         }
 

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/MultiPartyTransitionSigningSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/MultiPartyTransitionSigningSuite.scala
@@ -4,14 +4,14 @@ import cats.effect.IO
 import cats.effect.std.UUIDGen
 import cats.syntax.all._
 
-import io.constellationnetwork.currency.dataApplication.{DataState, L0NodeContext}
+import io.constellationnetwork.currency.dataApplication.{DataState, L0NodeContext, L1NodeContext}
 import io.constellationnetwork.metagraph_sdk.json_logic._
 import io.constellationnetwork.security.SecurityProvider
 import io.constellationnetwork.security.signature.Signed
 
 import xyz.kd5ujc.schema.fiber._
 import xyz.kd5ujc.schema.{CalculatedState, OnChain, Records, Updates}
-import xyz.kd5ujc.shared_data.lifecycle.Combiner
+import xyz.kd5ujc.shared_data.lifecycle.{Combiner, Validator}
 import xyz.kd5ujc.shared_test.Participant._
 import xyz.kd5ujc.shared_test.TestFixture
 
@@ -85,7 +85,7 @@ object MultiPartyTransitionSigningSuite extends SimpleIOSuite {
         )
         // This should work in the multi-party system - Bob can sign accept
         acceptProof <- fixture.registry.generateProofs(acceptEvent, Set(Bob))
-        finalState <- combiner.insert(stateAfterCreate, Signed(acceptEvent, acceptProof))
+        finalState  <- combiner.insert(stateAfterCreate, Signed(acceptEvent, acceptProof))
 
         contract = finalState.calculated.stateMachines
           .get(contractFiberId)
@@ -94,7 +94,7 @@ object MultiPartyTransitionSigningSuite extends SimpleIOSuite {
         status = contract.flatMap { f =>
           f.stateData match {
             case MapValue(m) => m.get("status").collect { case StrValue(s) => s }
-            case _ => None
+            case _           => None
           }
         }
 
@@ -167,7 +167,7 @@ object MultiPartyTransitionSigningSuite extends SimpleIOSuite {
         )
         // This should work in the multi-party system - Bob can sign reject
         rejectProof <- fixture.registry.generateProofs(rejectEvent, Set(Bob))
-        finalState <- combiner.insert(stateAfterCreate, Signed(rejectEvent, rejectProof))
+        finalState  <- combiner.insert(stateAfterCreate, Signed(rejectEvent, rejectProof))
 
         contract = finalState.calculated.stateMachines
           .get(contractFiberId)
@@ -176,14 +176,14 @@ object MultiPartyTransitionSigningSuite extends SimpleIOSuite {
         status = contract.flatMap { f =>
           f.stateData match {
             case MapValue(m) => m.get("status").collect { case StrValue(s) => s }
-            case _ => None
+            case _           => None
           }
         }
 
         reason = contract.flatMap { f =>
           f.stateData match {
             case MapValue(m) => m.get("reason").collect { case StrValue(r) => r }
-            case _ => None
+            case _           => None
           }
         }
 
@@ -198,8 +198,10 @@ object MultiPartyTransitionSigningSuite extends SimpleIOSuite {
     TestFixture.resource(Set(Alice, Bob, Charlie)).use { fixture =>
       implicit val s: SecurityProvider[IO] = fixture.securityProvider
       implicit val l0ctx: L0NodeContext[IO] = fixture.l0Context
+      implicit val l1ctx: L1NodeContext[IO] = fixture.l1Context
       for {
-        combiner <- Combiner.make[IO]().pure[IO]
+        combiner  <- Combiner.make[IO]().pure[IO]
+        validator <- Validator.make[IO]
 
         contractFiberId <- UUIDGen.randomUUID[IO]
 
@@ -228,7 +230,7 @@ object MultiPartyTransitionSigningSuite extends SimpleIOSuite {
         contractDef <- IO.fromEither(decode[StateMachineDefinition](contractJson))
         initialData = MapValue(Map("counterparty" -> StrValue("Bob")))
 
-        // Alice creates the contract
+        // Alice creates the contract (only Alice is owner, no participants declared)
         createContract = Updates.CreateStateMachine(contractFiberId, contractDef, initialData)
         createProof <- fixture.registry.generateProofs(createContract, Set(Alice))
         stateAfterCreate <- combiner.insert(
@@ -243,15 +245,18 @@ object MultiPartyTransitionSigningSuite extends SimpleIOSuite {
           MapValue(Map("timestamp" -> IntValue(System.currentTimeMillis()))),
           FiberOrdinal.MinValue
         )
-        
-        // This should fail - Charlie is not owner (Alice) or counterparty (Bob)
+
+        // Validator should reject Charlie — not owner and not in participants
         charlieProof <- fixture.registry.generateProofs(acceptEvent, Set(Charlie))
-        result <- combiner.insert(stateAfterCreate, Signed(acceptEvent, charlieProof)).attempt
+        result       <- validator.validateSignedUpdate(stateAfterCreate, Signed(acceptEvent, charlieProof))
 
-        // The system should reject this transaction
-        // In the current system this would pass, but in multi-party system it should fail
-
-      } yield expect(result.isLeft) // Should fail because Charlie is not authorized
+      } yield expect(result.isInvalid) and
+      expect(
+        result.swap
+          .exists(
+            _.exists(e => e.message.toLowerCase.contains("authorized") || e.message.toLowerCase.contains("owner"))
+          )
+      )
     }
   }
 
@@ -306,7 +311,7 @@ object MultiPartyTransitionSigningSuite extends SimpleIOSuite {
           FiberOrdinal.MinValue
         )
         cancelProof <- fixture.registry.generateProofs(cancelEvent, Set(Alice))
-        finalState <- combiner.insert(stateAfterCreate, Signed(cancelEvent, cancelProof))
+        finalState  <- combiner.insert(stateAfterCreate, Signed(cancelEvent, cancelProof))
 
         contract = finalState.calculated.stateMachines
           .get(contractFiberId)
@@ -315,7 +320,7 @@ object MultiPartyTransitionSigningSuite extends SimpleIOSuite {
         status = contract.flatMap { f =>
           f.stateData match {
             case MapValue(m) => m.get("status").collect { case StrValue(s) => s }
-            case _ => None
+            case _           => None
           }
         }
 
@@ -375,10 +380,12 @@ object MultiPartyTransitionSigningSuite extends SimpleIOSuite {
         """
 
         contractDef <- IO.fromEither(decode[StateMachineDefinition](contractJson))
-        initialData = MapValue(Map(
-          "counterparty" -> StrValue("Bob"),
-          "minimumAmount" -> IntValue(1000)
-        ))
+        initialData = MapValue(
+          Map(
+            "counterparty"  -> StrValue("Bob"),
+            "minimumAmount" -> IntValue(1000)
+          )
+        )
 
         // Alice creates the contract
         createContract = Updates.CreateStateMachine(contractFiberId, contractDef, initialData)
@@ -397,7 +404,7 @@ object MultiPartyTransitionSigningSuite extends SimpleIOSuite {
         )
         // Guard should evaluate correctly even when Bob signs instead of Alice
         approveProof <- fixture.registry.generateProofs(approveEvent, Set(Bob))
-        finalState <- combiner.insert(stateAfterCreate, Signed(approveEvent, approveProof))
+        finalState   <- combiner.insert(stateAfterCreate, Signed(approveEvent, approveProof))
 
         contract = finalState.calculated.stateMachines
           .get(contractFiberId)
@@ -406,14 +413,14 @@ object MultiPartyTransitionSigningSuite extends SimpleIOSuite {
         status = contract.flatMap { f =>
           f.stateData match {
             case MapValue(m) => m.get("status").collect { case StrValue(s) => s }
-            case _ => None
+            case _           => None
           }
         }
 
         finalAmount = contract.flatMap { f =>
           f.stateData match {
             case MapValue(m) => m.get("finalAmount").collect { case IntValue(a) => a }
-            case _ => None
+            case _           => None
           }
         }
 
@@ -474,10 +481,12 @@ object MultiPartyTransitionSigningSuite extends SimpleIOSuite {
         """
 
         contractDef <- IO.fromEither(decode[StateMachineDefinition](contractJson))
-        initialData = MapValue(Map(
-          "counterparty" -> StrValue("Bob"),
-          "minimumAmount" -> IntValue(1000)
-        ))
+        initialData = MapValue(
+          Map(
+            "counterparty"  -> StrValue("Bob"),
+            "minimumAmount" -> IntValue(1000)
+          )
+        )
 
         // Alice creates the contract
         createContract = Updates.CreateStateMachine(contractFiberId, contractDef, initialData)
@@ -495,7 +504,7 @@ object MultiPartyTransitionSigningSuite extends SimpleIOSuite {
           FiberOrdinal.MinValue
         )
         approveProof <- fixture.registry.generateProofs(approveEvent, Set(Bob))
-        finalState <- combiner.insert(stateAfterCreate, Signed(approveEvent, approveProof))
+        finalState   <- combiner.insert(stateAfterCreate, Signed(approveEvent, approveProof))
 
         contract = finalState.calculated.stateMachines
           .get(contractFiberId)
@@ -504,14 +513,14 @@ object MultiPartyTransitionSigningSuite extends SimpleIOSuite {
         status = contract.flatMap { f =>
           f.stateData match {
             case MapValue(m) => m.get("status").collect { case StrValue(s) => s }
-            case _ => None
+            case _           => None
           }
         }
 
         reason = contract.flatMap { f =>
           f.stateData match {
             case MapValue(m) => m.get("reason").collect { case StrValue(r) => r }
-            case _ => None
+            case _           => None
           }
         }
 

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/ParentChildStateMachineSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/ParentChildStateMachineSuite.scala
@@ -35,14 +35,14 @@ object ParentChildStateMachineSuite extends SimpleIOSuite {
 
         orderJson = s"""{
           "states": {
-            "pending": { "id": { "value": "pending" }, "isFinal": false },
+            "PENDING": { "id": { "value": "PENDING" }, "isFinal": false },
             "confirmed": { "id": { "value": "confirmed" }, "isFinal": false },
             "shipped": { "id": { "value": "shipped" }, "isFinal": true }
           },
-          "initialState": { "value": "pending" },
+          "initialState": { "value": "PENDING" },
           "transitions": [
             {
-              "from": { "value": "pending" },
+              "from": { "value": "PENDING" },
               "to": { "value": "confirmed" },
               "eventName": "confirm",
               "guard": true,
@@ -102,7 +102,7 @@ object ParentChildStateMachineSuite extends SimpleIOSuite {
             "orderId"       -> StrValue("ORDER-123"),
             "customerEmail" -> StrValue("customer@example.com"),
             "customerPhone" -> StrValue("+1234567890"),
-            "status"        -> StrValue("pending")
+            "status"        -> StrValue("PENDING")
           )
         )
 
@@ -173,18 +173,18 @@ object ParentChildStateMachineSuite extends SimpleIOSuite {
 
         parentJson = s"""{
           "states": {
-            "active": { "id": { "value": "active" }, "isFinal": false },
-            "suspended": { "id": { "value": "suspended" }, "isFinal": false }
+            "ACTIVE": { "id": { "value": "ACTIVE" }, "isFinal": false },
+            "SUSPENDED": { "id": { "value": "SUSPENDED" }, "isFinal": false }
           },
-          "initialState": { "value": "active" },
+          "initialState": { "value": "ACTIVE" },
           "transitions": [
             {
-              "from": { "value": "active" },
-              "to": { "value": "suspended" },
+              "from": { "value": "ACTIVE" },
+              "to": { "value": "SUSPENDED" },
               "eventName": "suspend",
               "guard": true,
               "effect": {
-                "status": "suspended"
+                "status": "SUSPENDED"
               },
               "dependencies": []
             }
@@ -205,7 +205,7 @@ object ParentChildStateMachineSuite extends SimpleIOSuite {
               "guard": {
                 "===": [
                   { "var": "parent.state.status" },
-                  "suspended"
+                  "SUSPENDED"
                 ]
               },
               "effect": {
@@ -220,7 +220,7 @@ object ParentChildStateMachineSuite extends SimpleIOSuite {
         parentDef <- IO.fromEither(decode[StateMachineDefinition](parentJson))
         childDef  <- IO.fromEither(decode[StateMachineDefinition](childJson))
 
-        parentInitialData = MapValue(Map("status" -> StrValue("active")))
+        parentInitialData = MapValue(Map("status" -> StrValue("ACTIVE")))
         childInitialData = MapValue(Map("status" -> StrValue("running")))
 
         createParent = Updates.CreateStateMachine(parentfiberId, parentDef, parentInitialData)
@@ -276,8 +276,8 @@ object ParentChildStateMachineSuite extends SimpleIOSuite {
         childParentId = finalChild.flatMap(_.parentFiberId)
 
       } yield expect(finalParent.isDefined) and
-      expect(finalParent.map(_.currentState).contains(StateId("suspended"))) and
-      expect(parentStatus.contains("suspended")) and
+      expect(finalParent.map(_.currentState).contains(StateId("SUSPENDED"))) and
+      expect(parentStatus.contains("SUSPENDED")) and
       expect(finalChild.isDefined) and
       expect(finalChild.map(_.currentState).contains(StateId("paused"))) and
       expect(childStatus.contains("paused")) and
@@ -300,13 +300,13 @@ object ParentChildStateMachineSuite extends SimpleIOSuite {
 
         simpleDef = StateMachineDefinition(
           states = Map(
-            StateId("active") -> State(StateId("active"), isFinal = false)
+            StateId("ACTIVE") -> State(StateId("ACTIVE"), isFinal = false)
           ),
-          initialState = StateId("active"),
+          initialState = StateId("ACTIVE"),
           transitions = List.empty
         )
 
-        initialData = MapValue(Map("status" -> StrValue("active")))
+        initialData = MapValue(Map("status" -> StrValue("ACTIVE")))
 
         createParent = Updates.CreateStateMachine(parentfiberId, simpleDef, initialData)
         parentProof <- registry.generateProofs(createParent, Set(Alice))
@@ -440,13 +440,13 @@ object ParentChildStateMachineSuite extends SimpleIOSuite {
 
         json = s"""{
           "states": {
-            "pending": { "id": { "value": "pending" }, "isFinal": false },
+            "PENDING": { "id": { "value": "PENDING" }, "isFinal": false },
             "done": { "id": { "value": "done" }, "isFinal": true }
           },
-          "initialState": { "value": "pending" },
+          "initialState": { "value": "PENDING" },
           "transitions": [
             {
-              "from": { "value": "pending" },
+              "from": { "value": "PENDING" },
               "to": { "value": "done" },
               "eventName": "complete",
               "guard": true,
@@ -471,7 +471,7 @@ object ParentChildStateMachineSuite extends SimpleIOSuite {
 
         def_ <- IO.fromEither(decode[StateMachineDefinition](json))
 
-        initialData = MapValue(Map("status" -> StrValue("pending")))
+        initialData = MapValue(Map("status" -> StrValue("PENDING")))
         initialHash <- (initialData: JsonLogicValue).computeDigest
 
         owners = Set(Alice).map(registry.addresses)
@@ -482,7 +482,7 @@ object ParentChildStateMachineSuite extends SimpleIOSuite {
           previousUpdateOrdinal = fixture.ordinal,
           latestUpdateOrdinal = fixture.ordinal,
           definition = def_,
-          currentState = StateId("pending"),
+          currentState = StateId("PENDING"),
           stateData = initialData,
           stateDataHash = initialHash,
           sequenceNumber = FiberOrdinal.MinValue,

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/ProofValidationSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/ProofValidationSuite.scala
@@ -135,13 +135,13 @@ object ProofValidationSuite extends SimpleIOSuite {
         machineJson = s"""
         {
           "states": {
-            "pending": { "id": { "value": "pending" }, "isFinal": false },
+            "PENDING": { "id": { "value": "PENDING" }, "isFinal": false },
             "approved": { "id": { "value": "approved" }, "isFinal": false }
           },
-          "initialState": { "value": "pending" },
+          "initialState": { "value": "PENDING" },
           "transitions": [
             {
-              "from": { "value": "pending" },
+              "from": { "value": "PENDING" },
               "to": { "value": "approved" },
               "eventName": "approve",
               "guard": {
@@ -161,7 +161,7 @@ object ProofValidationSuite extends SimpleIOSuite {
         """
 
         machineDef <- IO.fromEither(decode[StateMachineDefinition](machineJson))
-        initialData = MapValue(Map("status" -> StrValue("pending")))
+        initialData = MapValue(Map("status" -> StrValue("PENDING")))
 
         createMachine = Updates.CreateStateMachine(machineFiberId, machineDef, initialData)
         machineProof <- registry.generateProofs(createMachine, Set(Bob))
@@ -206,7 +206,7 @@ object ProofValidationSuite extends SimpleIOSuite {
         }
 
       } yield expect(machineBob.isDefined) and
-      expect(machineBob.map(_.currentState).contains(StateId("pending"))) and
+      expect(machineBob.map(_.currentState).contains(StateId("PENDING"))) and
       expect(machineAlice.isDefined) and
       expect(machineAlice.map(_.currentState).contains(StateId("approved"))) and
       expect(statusAfterAlice.contains("approved"))
@@ -227,13 +227,13 @@ object ProofValidationSuite extends SimpleIOSuite {
         machineJson = """
         {
           "states": {
-            "pending": { "id": { "value": "pending" }, "isFinal": false },
+            "PENDING": { "id": { "value": "PENDING" }, "isFinal": false },
             "approved": { "id": { "value": "approved" }, "isFinal": false }
           },
-          "initialState": { "value": "pending" },
+          "initialState": { "value": "PENDING" },
           "transitions": [
             {
-              "from": { "value": "pending" },
+              "from": { "value": "PENDING" },
               "to": { "value": "approved" },
               "eventName": "approve",
               "guard": {
@@ -253,7 +253,7 @@ object ProofValidationSuite extends SimpleIOSuite {
         """
 
         machineDef <- IO.fromEither(decode[StateMachineDefinition](machineJson))
-        initialData = MapValue(Map("status" -> StrValue("pending")))
+        initialData = MapValue(Map("status" -> StrValue("PENDING")))
 
         createMachine = Updates.CreateStateMachine(machineFiberId, machineDef, initialData)
         machineProof <- registry.generateProofs(createMachine, Set(Alice))
@@ -298,7 +298,7 @@ object ProofValidationSuite extends SimpleIOSuite {
         }
 
       } yield expect(machineAfterAliceOnly.isDefined) and
-      expect(machineAfterAliceOnly.map(_.currentState).contains(StateId("pending"))) and
+      expect(machineAfterAliceOnly.map(_.currentState).contains(StateId("PENDING"))) and
       expect(machineAfterAliceBob.isDefined) and
       expect(machineAfterAliceBob.map(_.currentState).contains(StateId("approved"))) and
       expect(statusAfterAliceBob.contains("approved"))
@@ -323,13 +323,13 @@ object ProofValidationSuite extends SimpleIOSuite {
         machineJson = s"""
         {
           "states": {
-            "pending": { "id": { "value": "pending" }, "isFinal": false },
+            "PENDING": { "id": { "value": "PENDING" }, "isFinal": false },
             "approved": { "id": { "value": "approved" }, "isFinal": false }
           },
-          "initialState": { "value": "pending" },
+          "initialState": { "value": "PENDING" },
           "transitions": [
             {
-              "from": { "value": "pending" },
+              "from": { "value": "PENDING" },
               "to": { "value": "approved" },
               "eventName": "approve",
               "guard": {
@@ -355,7 +355,7 @@ object ProofValidationSuite extends SimpleIOSuite {
         """
 
         machineDef <- IO.fromEither(decode[StateMachineDefinition](machineJson))
-        initialData = MapValue(Map("status" -> StrValue("pending")))
+        initialData = MapValue(Map("status" -> StrValue("PENDING")))
 
         createMachine = Updates.CreateStateMachine(machineFiberId, machineDef, initialData)
         machineProof <- registry.generateProofs(createMachine, Set(Alice))

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/RollbackCompensationSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/RollbackCompensationSuite.scala
@@ -114,13 +114,13 @@ object RollbackCompensationSuite extends SimpleIOSuite {
         // Machine C fails (guard always false, no valid transition)
         defC = StateMachineDefinition(
           states = Map(
-            StateId("pending")  -> State(StateId("pending")),
+            StateId("PENDING")  -> State(StateId("PENDING")),
             StateId("finished") -> State(StateId("finished"))
           ),
-          initialState = StateId("pending"),
+          initialState = StateId("PENDING"),
           transitions = List(
             Transition(
-              from = StateId("pending"),
+              from = StateId("PENDING"),
               to = StateId("finished"),
               eventName = "finish",
               // Guard that always fails
@@ -173,7 +173,7 @@ object RollbackCompensationSuite extends SimpleIOSuite {
           previousUpdateOrdinal = ordinal,
           latestUpdateOrdinal = ordinal,
           definition = defC,
-          currentState = StateId("pending"),
+          currentState = StateId("PENDING"),
           stateData = dataC,
           stateDataHash = hashC,
           sequenceNumber = FiberOrdinal.MinValue,
@@ -205,7 +205,7 @@ object RollbackCompensationSuite extends SimpleIOSuite {
             calculatedState.stateMachines.get(machineB).exists(_.currentState == StateId("waiting"))
           ) and
           expect(
-            calculatedState.stateMachines.get(machineC).exists(_.currentState == StateId("pending"))
+            calculatedState.stateMachines.get(machineC).exists(_.currentState == StateId("PENDING"))
           ) and
           expect(calculatedState.stateMachines.get(machineA).exists(_.sequenceNumber == FiberOrdinal.MinValue)) and
           expect(calculatedState.stateMachines.get(machineB).exists(_.sequenceNumber == FiberOrdinal.MinValue)) and

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/ScriptStateMachineIntegrationSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/ScriptStateMachineIntegrationSuite.scala
@@ -57,13 +57,13 @@ object OracleStateMachineIntegrationSuite extends SimpleIOSuite {
         machineJson = s"""
         {
           "states": {
-            "pending": { "id": { "value": "pending" }, "isFinal": false },
+            "PENDING": { "id": { "value": "PENDING" }, "isFinal": false },
             "validated": { "id": { "value": "validated" }, "isFinal": false }
           },
-          "initialState": { "value": "pending" },
+          "initialState": { "value": "PENDING" },
           "transitions": [
             {
-              "from": { "value": "pending" },
+              "from": { "value": "PENDING" },
               "to": { "value": "validated" },
               "eventName": "submit",
               "guard": true,
@@ -85,7 +85,7 @@ object OracleStateMachineIntegrationSuite extends SimpleIOSuite {
         """
 
         machineDef <- IO.fromEither(decode[StateMachineDefinition](machineJson))
-        initialData = MapValue(Map("status" -> StrValue("pending")))
+        initialData = MapValue(Map("status" -> StrValue("PENDING")))
 
         createMachine = Updates.CreateStateMachine(machineFiberId, machineDef, initialData)
         machineProof      <- registry.generateProofs(createMachine, Set(Bob))
@@ -170,13 +170,13 @@ object OracleStateMachineIntegrationSuite extends SimpleIOSuite {
         machineJson = s"""
         {
           "states": {
-            "pending": { "id": { "value": "pending" }, "isFinal": false },
+            "PENDING": { "id": { "value": "PENDING" }, "isFinal": false },
             "validated": { "id": { "value": "validated" }, "isFinal": false }
           },
-          "initialState": { "value": "pending" },
+          "initialState": { "value": "PENDING" },
           "transitions": [
             {
-              "from": { "value": "pending" },
+              "from": { "value": "PENDING" },
               "to": { "value": "validated" },
               "eventName": "submit",
               "guard": true,
@@ -198,7 +198,7 @@ object OracleStateMachineIntegrationSuite extends SimpleIOSuite {
         """
 
         machineDef <- IO.fromEither(decode[StateMachineDefinition](machineJson))
-        initialData = MapValue(Map("status" -> StrValue("pending")))
+        initialData = MapValue(Map("status" -> StrValue("PENDING")))
 
         createMachine = Updates.CreateStateMachine(machineFiberId, machineDef, initialData)
         machineProof      <- registry.generateProofs(createMachine, Set(Bob))
@@ -220,7 +220,7 @@ object OracleStateMachineIntegrationSuite extends SimpleIOSuite {
         oracle = finalState.calculated.scripts.get(oracleFiberId)
 
       } yield expect(machine.isDefined) and
-      expect(machine.map(_.currentState).contains(StateId("pending"))) and
+      expect(machine.map(_.currentState).contains(StateId("PENDING"))) and
       expect(machine.exists(_.lastReceipt.exists(r => !r.success))) and
       expect(oracle.isDefined) and
       expect(oracle.map(_.sequenceNumber).contains(FiberOrdinal.MinValue)) and
@@ -371,7 +371,7 @@ object OracleStateMachineIntegrationSuite extends SimpleIOSuite {
           "states": {
             "idle": { "id": { "value": "idle" }, "isFinal": false },
             "processing": { "id": { "value": "processing" }, "isFinal": false },
-            "completed": { "id": { "value": "completed" }, "isFinal": false }
+            "COMPLETED": { "id": { "value": "COMPLETED" }, "isFinal": false }
           },
           "initialState": { "value": "idle" },
           "transitions": [
@@ -394,7 +394,7 @@ object OracleStateMachineIntegrationSuite extends SimpleIOSuite {
             },
             {
               "from": { "value": "processing" },
-              "to": { "value": "completed" },
+              "to": { "value": "COMPLETED" },
               "eventName": "finalize",
               "guard": true,
               "effect": [
@@ -403,7 +403,7 @@ object OracleStateMachineIntegrationSuite extends SimpleIOSuite {
                   { "var": "scripts.$oracleFiberId.lastInvocation.result" }
                 ]}],
                 ["feeCalculated", { "var": "scripts.$oracleFiberId.lastInvocation.result" }],
-                ["status", "completed"]
+                ["status", "COMPLETED"]
               ],
               "dependencies": ["$oracleFiberId"]
             }
@@ -470,10 +470,10 @@ object OracleStateMachineIntegrationSuite extends SimpleIOSuite {
         }
 
       } yield expect(machine.isDefined) and
-      expect(machine.map(_.currentState).contains(StateId("completed"))) and
+      expect(machine.map(_.currentState).contains(StateId("COMPLETED"))) and
       expect(feeCalculated.contains(BigInt(50))) and
       expect(totalAmount.contains(BigInt(1050))) and
-      expect(status.contains("completed"))
+      expect(status.contains("COMPLETED"))
     }
   }
 

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/SpawnMachinesSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/SpawnMachinesSuite.scala
@@ -55,9 +55,9 @@ object SpawnMachinesSuite extends SimpleIOSuite {
                     "childId": "$childfiberId",
                     "definition": {
                       "states": {
-                        "active": { "id": { "value": "active" }, "isFinal": false }
+                        "ACTIVE": { "id": { "value": "ACTIVE" }, "isFinal": false }
                       },
-                      "initialState": { "value": "active" },
+                      "initialState": { "value": "ACTIVE" },
                       "transitions": []
                     },
                     "initialData": {
@@ -115,7 +115,7 @@ object SpawnMachinesSuite extends SimpleIOSuite {
       expect(parent.map(_.currentState).contains(StateId("spawned"))) and
       expect(parent.exists(_.childFiberIds.contains(childfiberId))) and
       expect(child.isDefined) and
-      expect(child.map(_.currentState).contains(StateId("active"))) and
+      expect(child.map(_.currentState).contains(StateId("ACTIVE"))) and
       expect(child.map(_.parentFiberId).contains(Some(parentfiberId))) and
       expect(child.map(_.status).contains(FiberStatus.Active)) and
       expect(childParentId.contains(parentfiberId.toString)) and
@@ -154,9 +154,9 @@ object SpawnMachinesSuite extends SimpleIOSuite {
                     "childId": "$child1fiberId",
                     "definition": {
                       "states": {
-                        "active": { "id": { "value": "active" }, "isFinal": false }
+                        "ACTIVE": { "id": { "value": "ACTIVE" }, "isFinal": false }
                       },
-                      "initialState": { "value": "active" },
+                      "initialState": { "value": "ACTIVE" },
                       "transitions": []
                     },
                     "initialData": { "index": 0 }
@@ -165,9 +165,9 @@ object SpawnMachinesSuite extends SimpleIOSuite {
                     "childId": "$child2fiberId",
                     "definition": {
                       "states": {
-                        "active": { "id": { "value": "active" }, "isFinal": false }
+                        "ACTIVE": { "id": { "value": "ACTIVE" }, "isFinal": false }
                       },
-                      "initialState": { "value": "active" },
+                      "initialState": { "value": "ACTIVE" },
                       "transitions": []
                     },
                     "initialData": { "index": 1 }
@@ -176,9 +176,9 @@ object SpawnMachinesSuite extends SimpleIOSuite {
                     "childId": "$child3fiberId",
                     "definition": {
                       "states": {
-                        "active": { "id": { "value": "active" }, "isFinal": false }
+                        "ACTIVE": { "id": { "value": "ACTIVE" }, "isFinal": false }
                       },
-                      "initialState": { "value": "active" },
+                      "initialState": { "value": "ACTIVE" },
                       "transitions": []
                     },
                     "initialData": { "index": 2 }
@@ -401,12 +401,12 @@ object SpawnMachinesSuite extends SimpleIOSuite {
                     "childId": "$childfiberId",
                     "definition": {
                       "states": {
-                        "active": { "id": { "value": "active" }, "isFinal": false }
+                        "ACTIVE": { "id": { "value": "ACTIVE" }, "isFinal": false }
                       },
-                      "initialState": { "value": "active" },
+                      "initialState": { "value": "ACTIVE" },
                       "transitions": []
                     },
-                    "initialData": { "status": "active" }
+                    "initialData": { "status": "ACTIVE" }
                   }
                 ],
                 "status": "spawned"
@@ -624,17 +624,17 @@ object SpawnMachinesSuite extends SimpleIOSuite {
                     "definition": {
                       "states": {
                         "idle": { "id": { "value": "idle" }, "isFinal": false },
-                        "active": { "id": { "value": "active" }, "isFinal": false }
+                        "ACTIVE": { "id": { "value": "ACTIVE" }, "isFinal": false }
                       },
                       "initialState": { "value": "idle" },
                       "transitions": [
                         {
                           "from": { "value": "idle" },
-                          "to": { "value": "active" },
+                          "to": { "value": "ACTIVE" },
                           "eventName": "activate",
                           "guard": true,
                           "effect": {
-                            "status": "active",
+                            "status": "ACTIVE",
                             "eventMessage": { "var": "event.msg" },
                             "eventAmount": { "var": "event.amount" },
                             "parentState": { "var": "parent.state.level" },
@@ -713,7 +713,7 @@ object SpawnMachinesSuite extends SimpleIOSuite {
         }
 
       } yield expect(child.isDefined) and
-      expect(child.map(_.currentState).contains(StateId("active"))) and
+      expect(child.map(_.currentState).contains(StateId("ACTIVE"))) and
       expect(childEventMessage.contains("Hello")) and
       expect(childEventAmount.contains(BigInt(42))) and
       expect(childParentState.contains(BigInt(1))) and
@@ -767,13 +767,13 @@ object SpawnMachinesSuite extends SimpleIOSuite {
                                 "childId": "$childfiberId",
                                 "definition": {
                                   "states": {
-                                    "active": { "id": { "value": "active" }, "isFinal": false }
+                                    "ACTIVE": { "id": { "value": "ACTIVE" }, "isFinal": false }
                                   },
-                                  "initialState": { "value": "active" },
+                                  "initialState": { "value": "ACTIVE" },
                                   "transitions": [
                                     {
-                                      "from": { "value": "active" },
-                                      "to": { "value": "active" },
+                                      "from": { "value": "ACTIVE" },
+                                      "to": { "value": "ACTIVE" },
                                       "eventName": "activate",
                                       "guard": true,
                                       "effect": {
@@ -881,7 +881,7 @@ object SpawnMachinesSuite extends SimpleIOSuite {
       expect(parent.map(_.parentFiberId).contains(Some(grandparentfiberId))) and
       expect(parent.exists(_.childFiberIds.contains(childfiberId))) and
       expect(grandchild.isDefined) and
-      expect(grandchild.map(_.currentState).contains(StateId("active"))) and
+      expect(grandchild.map(_.currentState).contains(StateId("ACTIVE"))) and
       expect(grandchild.map(_.parentFiberId).contains(Some(parentfiberId))) and
       expect(grandchildGrandparentId.contains(grandparentfiberId.toString)) and
       expect(grandchildActivatedBy.contains(parentfiberId.toString))
@@ -919,9 +919,9 @@ object SpawnMachinesSuite extends SimpleIOSuite {
                     "childId": "$child1fiberId",
                     "definition": {
                       "states": {
-                        "active": { "id": { "value": "active" }, "isFinal": false }
+                        "ACTIVE": { "id": { "value": "ACTIVE" }, "isFinal": false }
                       },
-                      "initialState": { "value": "active" },
+                      "initialState": { "value": "ACTIVE" },
                       "transitions": []
                     },
                     "initialData": { "index": 0 }
@@ -953,9 +953,9 @@ object SpawnMachinesSuite extends SimpleIOSuite {
                     "childId": "$child3fiberId",
                     "definition": {
                       "states": {
-                        "active": { "id": { "value": "active" }, "isFinal": false }
+                        "ACTIVE": { "id": { "value": "ACTIVE" }, "isFinal": false }
                       },
-                      "initialState": { "value": "active" },
+                      "initialState": { "value": "ACTIVE" },
                       "transitions": []
                     },
                     "initialData": { "index": 2 }
@@ -1035,12 +1035,12 @@ object SpawnMachinesSuite extends SimpleIOSuite {
             "childId": "$fiberId",
             "definition": {
               "states": {
-                "active": { "id": { "value": "active" }, "isFinal": false }
+                "ACTIVE": { "id": { "value": "ACTIVE" }, "isFinal": false }
               },
-              "initialState": { "value": "active" },
+              "initialState": { "value": "ACTIVE" },
               "transitions": []
             },
-            "initialData": { "status": "active" }
+            "initialData": { "status": "ACTIVE" }
           }
           """
           }
@@ -1139,9 +1139,9 @@ object SpawnMachinesSuite extends SimpleIOSuite {
                     "childId": "$childfiberId",
                     "definition": {
                       "states": {
-                        "active": { "id": { "value": "active" }, "isFinal": false }
+                        "ACTIVE": { "id": { "value": "ACTIVE" }, "isFinal": false }
                       },
-                      "initialState": { "value": "active" },
+                      "initialState": { "value": "ACTIVE" },
                       "transitions": []
                     },
                     "initialData": { "index": 1 }
@@ -1150,9 +1150,9 @@ object SpawnMachinesSuite extends SimpleIOSuite {
                     "childId": "$childfiberId",
                     "definition": {
                       "states": {
-                        "active": { "id": { "value": "active" }, "isFinal": false }
+                        "ACTIVE": { "id": { "value": "ACTIVE" }, "isFinal": false }
                       },
-                      "initialState": { "value": "active" },
+                      "initialState": { "value": "ACTIVE" },
                       "transitions": []
                     },
                     "initialData": { "index": 2 }
@@ -1240,9 +1240,9 @@ object SpawnMachinesSuite extends SimpleIOSuite {
                     "childId": "$existingfiberId",
                     "definition": {
                       "states": {
-                        "active": { "id": { "value": "active" }, "isFinal": false }
+                        "ACTIVE": { "id": { "value": "ACTIVE" }, "isFinal": false }
                       },
-                      "initialState": { "value": "active" },
+                      "initialState": { "value": "ACTIVE" },
                       "transitions": []
                     },
                     "initialData": { "value": 1 }
@@ -1360,9 +1360,9 @@ object SpawnMachinesSuite extends SimpleIOSuite {
                     "childId": "$childfiberId",
                     "definition": {
                       "states": {
-                        "active": { "id": { "value": "active" }, "isFinal": false }
+                        "ACTIVE": { "id": { "value": "ACTIVE" }, "isFinal": false }
                       },
-                      "initialState": { "value": "active" },
+                      "initialState": { "value": "ACTIVE" },
                       "transitions": []
                     },
                     "initialData": { "testData": "$testData" }
@@ -1448,12 +1448,12 @@ object SpawnMachinesSuite extends SimpleIOSuite {
                     "childId": "$childfiberId",
                     "definition": {
                       "states": {
-                        "active": { "id": { "value": "active" }, "isFinal": false }
+                        "ACTIVE": { "id": { "value": "ACTIVE" }, "isFinal": false }
                       },
-                      "initialState": { "value": "active" },
+                      "initialState": { "value": "ACTIVE" },
                       "transitions": []
                     },
-                    "initialData": { "status": "active" }
+                    "initialData": { "status": "ACTIVE" }
                   }
                 ],
                 "status": "spawned"
@@ -1536,12 +1536,12 @@ object SpawnMachinesSuite extends SimpleIOSuite {
                     "childId": "$childfiberId",
                     "definition": {
                       "states": {
-                        "active": { "id": { "value": "active" }, "isFinal": false }
+                        "ACTIVE": { "id": { "value": "ACTIVE" }, "isFinal": false }
                       },
-                      "initialState": { "value": "active" },
+                      "initialState": { "value": "ACTIVE" },
                       "transitions": []
                     },
-                    "initialData": { "status": "active" },
+                    "initialData": { "status": "ACTIVE" },
                     "owners": { "var": "event.customOwners" }
                   }
                 ],
@@ -1632,13 +1632,13 @@ object SpawnMachinesSuite extends SimpleIOSuite {
                                   Map(
                                     "active" -> MapValue(
                                       Map(
-                                        "id"      -> MapValue(Map("value" -> StrValue("active"))),
+                                        "id"      -> MapValue(Map("value" -> StrValue("ACTIVE"))),
                                         "isFinal" -> BoolValue(false)
                                       )
                                     )
                                   )
                                 ),
-                                "initialState" -> MapValue(Map("value" -> StrValue("active"))),
+                                "initialState" -> MapValue(Map("value" -> StrValue("ACTIVE"))),
                                 "transitions"  -> ArrayValue(List.empty)
                               )
                             ),
@@ -1738,13 +1738,13 @@ object SpawnMachinesSuite extends SimpleIOSuite {
                                   Map(
                                     "active" -> MapValue(
                                       Map(
-                                        "id"      -> MapValue(Map("value" -> StrValue("active"))),
+                                        "id"      -> MapValue(Map("value" -> StrValue("ACTIVE"))),
                                         "isFinal" -> BoolValue(false)
                                       )
                                     )
                                   )
                                 ),
-                                "initialState" -> MapValue(Map("value" -> StrValue("active"))),
+                                "initialState" -> MapValue(Map("value" -> StrValue("ACTIVE"))),
                                 "transitions"  -> ArrayValue(List.empty)
                               )
                             ),
@@ -1841,13 +1841,13 @@ object SpawnMachinesSuite extends SimpleIOSuite {
                                   Map(
                                     "active" -> MapValue(
                                       Map(
-                                        "id"      -> MapValue(Map("value" -> StrValue("active"))),
+                                        "id"      -> MapValue(Map("value" -> StrValue("ACTIVE"))),
                                         "isFinal" -> BoolValue(false)
                                       )
                                     )
                                   )
                                 ),
-                                "initialState" -> MapValue(Map("value" -> StrValue("active"))),
+                                "initialState" -> MapValue(Map("value" -> StrValue("ACTIVE"))),
                                 "transitions"  -> ArrayValue(List.empty)
                               )
                             ),
@@ -1945,13 +1945,13 @@ object SpawnMachinesSuite extends SimpleIOSuite {
                                   Map(
                                     "active" -> MapValue(
                                       Map(
-                                        "id"      -> MapValue(Map("value" -> StrValue("active"))),
+                                        "id"      -> MapValue(Map("value" -> StrValue("ACTIVE"))),
                                         "isFinal" -> BoolValue(false)
                                       )
                                     )
                                   )
                                 ),
-                                "initialState" -> MapValue(Map("value" -> StrValue("active"))),
+                                "initialState" -> MapValue(Map("value" -> StrValue("ACTIVE"))),
                                 "transitions"  -> ArrayValue(List.empty)
                               )
                             ),

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/TriggerEventsSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/TriggerEventsSuite.scala
@@ -68,17 +68,17 @@ object TriggerEventsSuite extends SimpleIOSuite {
         {
           "states": {
             "inactive": { "id": { "value": "inactive" }, "isFinal": false },
-            "active": { "id": { "value": "active" }, "isFinal": false }
+            "ACTIVE": { "id": { "value": "ACTIVE" }, "isFinal": false }
           },
           "initialState": { "value": "inactive" },
           "transitions": [
             {
               "from": { "value": "inactive" },
-              "to": { "value": "active" },
+              "to": { "value": "ACTIVE" },
               "eventName": "activate",
               "guard": true,
               "effect": [
-                ["status", "active"],
+                ["status", "ACTIVE"],
                 ["activatedBy", { "var": "event.initiator" }],
                 ["activatedAt", { "var": "event.timestamp" }]
               ],
@@ -143,8 +143,8 @@ object TriggerEventsSuite extends SimpleIOSuite {
       } yield expect(initiator.isDefined) and
       expect(initiator.map(_.currentState).contains(StateId("triggered"))) and
       expect(target.isDefined) and
-      expect(target.map(_.currentState).contains(StateId("active"))) and
-      expect(targetStatus.contains("active")) and
+      expect(target.map(_.currentState).contains(StateId("ACTIVE"))) and
+      expect(targetStatus.contains("ACTIVE")) and
       expect(targetActivatedBy.contains(initiatorfiberId.toString)) and
       expect(targetActivatedAt.contains(BigInt(12345)))
     }

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/examples/AgentIdentityLifecycleSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/examples/AgentIdentityLifecycleSuite.scala
@@ -63,27 +63,27 @@ object AgentIdentityLifecycleSuite extends SimpleIOSuite {
         agentIdentityJson =
           s"""{
           "states": {
-            "registered": { "id": { "value": "registered" }, "isFinal": false },
-            "active": { "id": { "value": "active" }, "isFinal": false },
-            "challenged": { "id": { "value": "challenged" }, "isFinal": false },
-            "suspended": { "id": { "value": "suspended" }, "isFinal": false },
-            "probation": { "id": { "value": "probation" }, "isFinal": false },
-            "withdrawn": { "id": { "value": "withdrawn" }, "isFinal": true }
+            "REGISTERED": { "id": { "value": "REGISTERED" }, "isFinal": false },
+            "ACTIVE": { "id": { "value": "ACTIVE" }, "isFinal": false },
+            "CHALLENGED": { "id": { "value": "CHALLENGED" }, "isFinal": false },
+            "SUSPENDED": { "id": { "value": "SUSPENDED" }, "isFinal": false },
+            "PROBATION": { "id": { "value": "PROBATION" }, "isFinal": false },
+            "WITHDRAWN": { "id": { "value": "WITHDRAWN" }, "isFinal": true }
           },
-          "initialState": { "value": "registered" },
+          "initialState": { "value": "REGISTERED" },
           "transitions": [
             {
-              "from": { "value": "registered" },
-              "to": { "value": "active" },
+              "from": { "value": "REGISTERED" },
+              "to": { "value": "ACTIVE" },
               "eventName": "first_attestation",
               "guard": {
                 "and": [
-                  { "===": [ { "var": "machines.${platformfiberId}.state.status" }, "verified" ] },
+                  { "===": [ { "var": "machines.${platformfiberId}.state.status" }, "VERIFIED" ] },
                   { ">": [ { "var": "state.stakeAmount" }, 0 ] }
                 ]
               },
               "effect": [
-                ["status", "active"],
+                ["status", "ACTIVE"],
                 ["activatedAt", { "var": "event.timestamp" }],
                 ["attestationCount", 1],
                 ["completionCount", { "if": [ { "===": [ { "var": "event.attestationType" }, "COMPLETION" ] }, 1, 0 ] }],
@@ -97,12 +97,12 @@ object AgentIdentityLifecycleSuite extends SimpleIOSuite {
               "dependencies": ["${platformfiberId}"]
             },
             {
-              "from": { "value": "active" },
-              "to": { "value": "active" },
+              "from": { "value": "ACTIVE" },
+              "to": { "value": "ACTIVE" },
               "eventName": "submit_attestation",
               "guard": {
                 "and": [
-                  { "===": [ { "var": "machines.${platformfiberId}.state.status" }, "verified" ] },
+                  { "===": [ { "var": "machines.${platformfiberId}.state.status" }, "VERIFIED" ] },
                   { "in": [ { "var": "event.attestationType" }, ["BEHAVIORAL", "COMPLETION", "VOUCH"] ] }
                 ]
               },
@@ -126,11 +126,11 @@ object AgentIdentityLifecycleSuite extends SimpleIOSuite {
               "dependencies": ["${platformfiberId}"]
             },
             {
-              "from": { "value": "active" },
-              "to": { "value": "active" },
+              "from": { "value": "ACTIVE" },
+              "to": { "value": "ACTIVE" },
               "eventName": "submit_violation",
               "guard": {
-                "===": [ { "var": "machines.${platformfiberId}.state.status" }, "verified" ]
+                "===": [ { "var": "machines.${platformfiberId}.state.status" }, "VERIFIED" ]
               },
               "effect": [
                 ["attestationCount", { "+": [ { "var": "state.attestationCount" }, 1 ] }],
@@ -144,8 +144,8 @@ object AgentIdentityLifecycleSuite extends SimpleIOSuite {
               "dependencies": ["${platformfiberId}"]
             },
             {
-              "from": { "value": "active" },
-              "to": { "value": "challenged" },
+              "from": { "value": "ACTIVE" },
+              "to": { "value": "CHALLENGED" },
               "eventName": "file_challenge",
               "guard": {
                 "and": [
@@ -154,7 +154,7 @@ object AgentIdentityLifecycleSuite extends SimpleIOSuite {
                 ]
               },
               "effect": [
-                ["status", "challenged"],
+                ["status", "CHALLENGED"],
                 ["challengedAt", { "var": "event.timestamp" }],
                 ["challengerId", { "var": "event.challengerId" }],
                 ["challengerStake", { "var": "event.challengerStake" }],
@@ -164,14 +164,14 @@ object AgentIdentityLifecycleSuite extends SimpleIOSuite {
               "dependencies": []
             },
             {
-              "from": { "value": "challenged" },
-              "to": { "value": "active" },
+              "from": { "value": "CHALLENGED" },
+              "to": { "value": "ACTIVE" },
               "eventName": "dismiss_challenge",
               "guard": {
                 ">=": [ { "var": "event.dismissalVotes" }, 3 ]
               },
               "effect": [
-                ["status", "active"],
+                ["status", "ACTIVE"],
                 ["challengeResolution", "dismissed"],
                 ["challengeResolvedAt", { "var": "event.timestamp" }],
                 ["reputationScore", { "+": [ { "var": "state.reputationScore" }, 5 ] }]
@@ -179,14 +179,14 @@ object AgentIdentityLifecycleSuite extends SimpleIOSuite {
               "dependencies": []
             },
             {
-              "from": { "value": "challenged" },
-              "to": { "value": "suspended" },
+              "from": { "value": "CHALLENGED" },
+              "to": { "value": "SUSPENDED" },
               "eventName": "uphold_challenge",
               "guard": {
                 ">=": [ { "var": "event.upholdVotes" }, 3 ]
               },
               "effect": [
-                ["status", "suspended"],
+                ["status", "SUSPENDED"],
                 ["suspendedAt", { "var": "event.timestamp" }],
                 ["challengeResolution", "upheld"],
                 ["challengeResolvedAt", { "var": "event.timestamp" }],
@@ -197,8 +197,8 @@ object AgentIdentityLifecycleSuite extends SimpleIOSuite {
               "dependencies": []
             },
             {
-              "from": { "value": "suspended" },
-              "to": { "value": "probation" },
+              "from": { "value": "SUSPENDED" },
+              "to": { "value": "PROBATION" },
               "eventName": "begin_probation",
               "guard": {
                 "and": [
@@ -210,7 +210,7 @@ object AgentIdentityLifecycleSuite extends SimpleIOSuite {
                 ]
               },
               "effect": [
-                ["status", "probation"],
+                ["status", "PROBATION"],
                 ["probationStartedAt", { "var": "event.timestamp" }],
                 ["stakeAmount", { "+": [ { "var": "state.stakeAmount" }, { "var": "event.reinstateStake" } ] }],
                 ["probationAttestationsRequired", 10]
@@ -218,12 +218,12 @@ object AgentIdentityLifecycleSuite extends SimpleIOSuite {
               "dependencies": []
             },
             {
-              "from": { "value": "probation" },
-              "to": { "value": "probation" },
+              "from": { "value": "PROBATION" },
+              "to": { "value": "PROBATION" },
               "eventName": "probation_attestation",
               "guard": {
                 "and": [
-                  { "===": [ { "var": "machines.${platformfiberId}.state.status" }, "verified" ] },
+                  { "===": [ { "var": "machines.${platformfiberId}.state.status" }, "VERIFIED" ] },
                   { ">": [ { "var": "state.probationAttestationsRequired" }, 0 ] }
                 ]
               },
@@ -236,26 +236,26 @@ object AgentIdentityLifecycleSuite extends SimpleIOSuite {
               "dependencies": ["${platformfiberId}"]
             },
             {
-              "from": { "value": "probation" },
-              "to": { "value": "active" },
+              "from": { "value": "PROBATION" },
+              "to": { "value": "ACTIVE" },
               "eventName": "complete_probation",
               "guard": {
                 "<=": [ { "var": "state.probationAttestationsRequired" }, 0 ]
               },
               "effect": [
-                ["status", "active"],
+                ["status", "ACTIVE"],
                 ["probationCompletedAt", { "var": "event.timestamp" }],
                 ["reputationScore", { "+": [ { "var": "state.reputationScore" }, 10 ] }]
               ],
               "dependencies": []
             },
             {
-              "from": { "value": "active" },
-              "to": { "value": "withdrawn" },
+              "from": { "value": "ACTIVE" },
+              "to": { "value": "WITHDRAWN" },
               "eventName": "withdraw",
               "guard": true,
               "effect": [
-                ["status", "withdrawn"],
+                ["status", "WITHDRAWN"],
                 ["withdrawnAt", { "var": "event.timestamp" }],
                 ["stakeReturned", { "var": "state.stakeAmount" }],
                 ["finalReputationScore", { "var": "state.reputationScore" }],
@@ -271,16 +271,16 @@ object AgentIdentityLifecycleSuite extends SimpleIOSuite {
         platformRegistryJson =
           """{
           "states": {
-            "pending": { "id": { "value": "pending" }, "isFinal": false },
-            "verified": { "id": { "value": "verified" }, "isFinal": false },
-            "suspended": { "id": { "value": "suspended" }, "isFinal": false },
+            "PENDING": { "id": { "value": "PENDING" }, "isFinal": false },
+            "VERIFIED": { "id": { "value": "VERIFIED" }, "isFinal": false },
+            "SUSPENDED": { "id": { "value": "SUSPENDED" }, "isFinal": false },
             "revoked": { "id": { "value": "revoked" }, "isFinal": true }
           },
-          "initialState": { "value": "pending" },
+          "initialState": { "value": "PENDING" },
           "transitions": [
             {
-              "from": { "value": "pending" },
-              "to": { "value": "verified" },
+              "from": { "value": "PENDING" },
+              "to": { "value": "VERIFIED" },
               "eventName": "verify_platform",
               "guard": {
                 "and": [
@@ -289,7 +289,7 @@ object AgentIdentityLifecycleSuite extends SimpleIOSuite {
                 ]
               },
               "effect": [
-                ["status", "verified"],
+                ["status", "VERIFIED"],
                 ["verifiedAt", { "var": "event.timestamp" }],
                 ["platformStake", { "var": "event.platformStake" }],
                 ["verificationScore", { "var": "event.verificationScore" }],
@@ -298,8 +298,8 @@ object AgentIdentityLifecycleSuite extends SimpleIOSuite {
               "dependencies": []
             },
             {
-              "from": { "value": "verified" },
-              "to": { "value": "verified" },
+              "from": { "value": "VERIFIED" },
+              "to": { "value": "VERIFIED" },
               "eventName": "record_attestation_submitted",
               "guard": true,
               "effect": [
@@ -309,30 +309,30 @@ object AgentIdentityLifecycleSuite extends SimpleIOSuite {
               "dependencies": []
             },
             {
-              "from": { "value": "verified" },
-              "to": { "value": "suspended" },
+              "from": { "value": "VERIFIED" },
+              "to": { "value": "SUSPENDED" },
               "eventName": "suspend_platform",
               "guard": true,
               "effect": [
-                ["status", "suspended"],
+                ["status", "SUSPENDED"],
                 ["suspendedAt", { "var": "event.timestamp" }],
                 ["suspensionReason", { "var": "event.reason" }]
               ],
               "dependencies": []
             },
             {
-              "from": { "value": "suspended" },
-              "to": { "value": "verified" },
+              "from": { "value": "SUSPENDED" },
+              "to": { "value": "VERIFIED" },
               "eventName": "reinstate_platform",
               "guard": true,
               "effect": [
-                ["status", "verified"],
+                ["status", "VERIFIED"],
                 ["reinstatedAt", { "var": "event.timestamp" }]
               ],
               "dependencies": []
             },
             {
-              "from": { "value": "suspended" },
+              "from": { "value": "SUSPENDED" },
               "to": { "value": "revoked" },
               "eventName": "revoke_platform",
               "guard": true,
@@ -371,7 +371,7 @@ object AgentIdentityLifecycleSuite extends SimpleIOSuite {
               )
             ),
             "registeredAt" -> IntValue(100),
-            "status"       -> StrValue("registered"),
+            "status"       -> StrValue("REGISTERED"),
             "isGenesis"    -> BoolValue(true)
           )
         )
@@ -383,7 +383,7 @@ object AgentIdentityLifecycleSuite extends SimpleIOSuite {
             "platformName" -> StrValue("GitHub"),
             "platformType" -> StrValue("code_hosting"),
             "operatorId"   -> StrValue(registry.addresses(Bob).toString),
-            "status"       -> StrValue("pending")
+            "status"       -> StrValue("PENDING")
           )
         )
         platformHash <- (platformData: JsonLogicValue).computeDigest
@@ -394,7 +394,7 @@ object AgentIdentityLifecycleSuite extends SimpleIOSuite {
           previousUpdateOrdinal = ordinal,
           latestUpdateOrdinal = ordinal,
           definition = agentDef,
-          currentState = StateId("registered"),
+          currentState = StateId("REGISTERED"),
           stateData = agentData,
           stateDataHash = agentHash,
           sequenceNumber = FiberOrdinal.MinValue,
@@ -408,7 +408,7 @@ object AgentIdentityLifecycleSuite extends SimpleIOSuite {
           previousUpdateOrdinal = ordinal,
           latestUpdateOrdinal = ordinal,
           definition = platformDef,
-          currentState = StateId("pending"),
+          currentState = StateId("PENDING"),
           stateData = platformData,
           stateDataHash = platformHash,
           sequenceNumber = FiberOrdinal.MinValue,
@@ -443,7 +443,7 @@ object AgentIdentityLifecycleSuite extends SimpleIOSuite {
         platformAfterVerify = state1.calculated.stateMachines
           .get(platformfiberId)
           .collect { case r: Records.StateMachineFiberRecord => r }
-        _ = expect(platformAfterVerify.map(_.currentState).contains(StateId("verified")))
+        _ = expect(platformAfterVerify.map(_.currentState).contains(StateId("VERIFIED")))
 
         // ── STEP 2: First attestation — activates the agent ──
         firstAttestationUpdate = Updates.TransitionStateMachine(
@@ -466,8 +466,8 @@ object AgentIdentityLifecycleSuite extends SimpleIOSuite {
           .get(agentfiberId)
           .collect { case r: Records.StateMachineFiberRecord => r }
         _ = expect.all(
-          agentAfterActivation.map(_.currentState).contains(StateId("active")),
-          agentAfterActivation.flatMap(extractStrField(_, "status")).contains("active")
+          agentAfterActivation.map(_.currentState).contains(StateId("ACTIVE")),
+          agentAfterActivation.flatMap(extractStrField(_, "status")).contains("ACTIVE")
         )
 
         // ── STEP 3: Submit several attestations to build reputation ──
@@ -531,7 +531,7 @@ object AgentIdentityLifecycleSuite extends SimpleIOSuite {
         reputationScore = agentAfterAttestations.flatMap(extractIntField(_, "reputationScore"))
 
       } yield expect.all(
-        agentAfterAttestations.map(_.currentState).contains(StateId("active")),
+        agentAfterAttestations.map(_.currentState).contains(StateId("ACTIVE")),
         attestationCount.contains(BigInt(4)), // 1 first + 3 more
         completionCount.contains(BigInt(2)), // first_attestation(COMPLETION) + 1 more
         behavioralCount.contains(BigInt(1)),
@@ -567,7 +567,7 @@ object AgentIdentityLifecycleSuite extends SimpleIOSuite {
             "stakeAmount"      -> IntValue(1000),
             "capabilities"     -> ArrayValue(List(StrValue("testing"))),
             "registeredAt"     -> IntValue(100),
-            "status"           -> StrValue("registered"),
+            "status"           -> StrValue("REGISTERED"),
             "isGenesis"        -> BoolValue(false),
             "suspensionPeriod" -> IntValue(1000)
           )
@@ -579,7 +579,7 @@ object AgentIdentityLifecycleSuite extends SimpleIOSuite {
             "platformName" -> StrValue("TestPlatform"),
             "platformType" -> StrValue("social"),
             "operatorId"   -> StrValue(registry.addresses(Bob).toString),
-            "status"       -> StrValue("pending")
+            "status"       -> StrValue("PENDING")
           )
         )
         platformHash <- (platformData: JsonLogicValue).computeDigest
@@ -588,7 +588,7 @@ object AgentIdentityLifecycleSuite extends SimpleIOSuite {
           agentfiberId,
           ordinal,
           agentDef,
-          "registered",
+          "REGISTERED",
           agentData,
           agentHash,
           Set(Alice).map(registry.addresses)
@@ -597,7 +597,7 @@ object AgentIdentityLifecycleSuite extends SimpleIOSuite {
           platformfiberId,
           ordinal,
           platformDef,
-          "pending",
+          "PENDING",
           platformData,
           platformHash,
           Set(Bob).map(registry.addresses)
@@ -645,7 +645,7 @@ object AgentIdentityLifecycleSuite extends SimpleIOSuite {
         agentAfterChallenge = state6.calculated.stateMachines
           .get(agentfiberId)
           .collect { case r: Records.StateMachineFiberRecord => r }
-        _ = expect(agentAfterChallenge.map(_.currentState).contains(StateId("challenged")))
+        _ = expect(agentAfterChallenge.map(_.currentState).contains(StateId("CHALLENGED")))
 
         // ── STEP: Uphold the challenge ──
         upholdSeqNum = state6.calculated.stateMachines(agentfiberId).sequenceNumber
@@ -667,7 +667,7 @@ object AgentIdentityLifecycleSuite extends SimpleIOSuite {
           .get(agentfiberId)
           .collect { case r: Records.StateMachineFiberRecord => r }
         _ = expect.all(
-          agentAfterSuspension.map(_.currentState).contains(StateId("suspended")),
+          agentAfterSuspension.map(_.currentState).contains(StateId("SUSPENDED")),
           // Stake should be slashed by half: 1000 / 2 = 500
           agentAfterSuspension.flatMap(extractIntField(_, "stakeAmount")).contains(BigInt(500)),
           // Reputation: 23 - 25 = 0 (clamped to 0 by max)
@@ -694,7 +694,7 @@ object AgentIdentityLifecycleSuite extends SimpleIOSuite {
           .get(agentfiberId)
           .collect { case r: Records.StateMachineFiberRecord => r }
         _ = expect.all(
-          agentAfterProbation.map(_.currentState).contains(StateId("probation")),
+          agentAfterProbation.map(_.currentState).contains(StateId("PROBATION")),
           agentAfterProbation.flatMap(extractIntField(_, "stakeAmount")).contains(BigInt(1000)), // 500 + 500
           agentAfterProbation.flatMap(extractIntField(_, "probationAttestationsRequired")).contains(BigInt(10))
         )
@@ -753,8 +753,8 @@ object AgentIdentityLifecycleSuite extends SimpleIOSuite {
 
       } yield expect.all(
         // Agent is back to active
-        finalAgent.map(_.currentState).contains(StateId("active")),
-        finalAgent.flatMap(extractStrField(_, "status")).contains("active"),
+        finalAgent.map(_.currentState).contains(StateId("ACTIVE")),
+        finalAgent.flatMap(extractStrField(_, "status")).contains("ACTIVE"),
         // Reputation: 0 (after suspension) + 10 (probation attestations × 1 each) + 10 (completion bonus) = 20
         finalReputation.contains(BigInt(20)),
         // Stake restored to 1000
@@ -785,7 +785,7 @@ object AgentIdentityLifecycleSuite extends SimpleIOSuite {
             "stakeAmount"      -> IntValue(1000),
             "capabilities"     -> ArrayValue(List(StrValue("helpful"))),
             "registeredAt"     -> IntValue(100),
-            "status"           -> StrValue("registered"),
+            "status"           -> StrValue("REGISTERED"),
             "isGenesis"        -> BoolValue(true),
             "suspensionPeriod" -> IntValue(1000)
           )
@@ -797,7 +797,7 @@ object AgentIdentityLifecycleSuite extends SimpleIOSuite {
             "platformName" -> StrValue("Moltbook"),
             "platformType" -> StrValue("social"),
             "operatorId"   -> StrValue(registry.addresses(Bob).toString),
-            "status"       -> StrValue("pending")
+            "status"       -> StrValue("PENDING")
           )
         )
         platformHash <- (platformData: JsonLogicValue).computeDigest
@@ -806,7 +806,7 @@ object AgentIdentityLifecycleSuite extends SimpleIOSuite {
           agentfiberId,
           ordinal,
           agentDef,
-          "registered",
+          "REGISTERED",
           agentData,
           agentHash,
           Set(Alice).map(registry.addresses)
@@ -815,7 +815,7 @@ object AgentIdentityLifecycleSuite extends SimpleIOSuite {
           platformfiberId,
           ordinal,
           platformDef,
-          "pending",
+          "PENDING",
           platformData,
           platformHash,
           Set(Bob).map(registry.addresses)
@@ -861,7 +861,7 @@ object AgentIdentityLifecycleSuite extends SimpleIOSuite {
             .get(agentfiberId)
             .collect { case r: Records.StateMachineFiberRecord => r }
             .map(_.currentState)
-            .contains(StateId("challenged"))
+            .contains(StateId("CHALLENGED"))
         )
 
         // Dismiss the challenge (community votes to dismiss)
@@ -889,7 +889,7 @@ object AgentIdentityLifecycleSuite extends SimpleIOSuite {
 
       } yield expect.all(
         // Agent back to active with reputation bonus
-        finalAgent.map(_.currentState).contains(StateId("active")),
+        finalAgent.map(_.currentState).contains(StateId("ACTIVE")),
         // Reputation: 15 + 5 (vindication bonus) = 20
         finalReputation.contains(BigInt(20)),
         challengeResolution.contains("dismissed")
@@ -919,7 +919,7 @@ object AgentIdentityLifecycleSuite extends SimpleIOSuite {
             "stakeAmount"      -> IntValue(1000),
             "capabilities"     -> ArrayValue(List(StrValue("social"))),
             "registeredAt"     -> IntValue(100),
-            "status"           -> StrValue("registered"),
+            "status"           -> StrValue("REGISTERED"),
             "isGenesis"        -> BoolValue(false),
             "suspensionPeriod" -> IntValue(1000)
           )
@@ -931,7 +931,7 @@ object AgentIdentityLifecycleSuite extends SimpleIOSuite {
             "platformName" -> StrValue("Discord"),
             "platformType" -> StrValue("chat"),
             "operatorId"   -> StrValue(registry.addresses(Bob).toString),
-            "status"       -> StrValue("pending")
+            "status"       -> StrValue("PENDING")
           )
         )
         platformHash <- (platformData: JsonLogicValue).computeDigest
@@ -940,7 +940,7 @@ object AgentIdentityLifecycleSuite extends SimpleIOSuite {
           agentfiberId,
           ordinal,
           agentDef,
-          "registered",
+          "REGISTERED",
           agentData,
           agentHash,
           Set(Alice).map(registry.addresses)
@@ -949,7 +949,7 @@ object AgentIdentityLifecycleSuite extends SimpleIOSuite {
           platformfiberId,
           ordinal,
           platformDef,
-          "pending",
+          "PENDING",
           platformData,
           platformHash,
           Set(Bob).map(registry.addresses)
@@ -1023,7 +1023,7 @@ object AgentIdentityLifecycleSuite extends SimpleIOSuite {
 
       } yield expect.all(
         // Still active (violations don't auto-suspend)
-        agentAfterViolation.map(_.currentState).contains(StateId("active")),
+        agentAfterViolation.map(_.currentState).contains(StateId("ACTIVE")),
         // Reputation: 20 - 10 = 10
         repAfterViolation.contains(BigInt(10)),
         violationCount.contains(BigInt(1)),
@@ -1057,7 +1057,7 @@ object AgentIdentityLifecycleSuite extends SimpleIOSuite {
             "stakeAmount"      -> IntValue(1000),
             "capabilities"     -> ArrayValue(List(StrValue("data_analysis"))),
             "registeredAt"     -> IntValue(100),
-            "status"           -> StrValue("registered"),
+            "status"           -> StrValue("REGISTERED"),
             "isGenesis"        -> BoolValue(true),
             "suspensionPeriod" -> IntValue(1000)
           )
@@ -1069,7 +1069,7 @@ object AgentIdentityLifecycleSuite extends SimpleIOSuite {
             "platformName" -> StrValue("OpenClaw"),
             "platformType" -> StrValue("agent_framework"),
             "operatorId"   -> StrValue(registry.addresses(Bob).toString),
-            "status"       -> StrValue("pending")
+            "status"       -> StrValue("PENDING")
           )
         )
         platformHash <- (platformData: JsonLogicValue).computeDigest
@@ -1078,7 +1078,7 @@ object AgentIdentityLifecycleSuite extends SimpleIOSuite {
           agentfiberId,
           ordinal,
           agentDef,
-          "registered",
+          "REGISTERED",
           agentData,
           agentHash,
           Set(Alice).map(registry.addresses)
@@ -1087,7 +1087,7 @@ object AgentIdentityLifecycleSuite extends SimpleIOSuite {
           platformfiberId,
           ordinal,
           platformDef,
-          "pending",
+          "PENDING",
           platformData,
           platformHash,
           Set(Bob).map(registry.addresses)
@@ -1125,8 +1125,8 @@ object AgentIdentityLifecycleSuite extends SimpleIOSuite {
 
       } yield expect.all(
         // Final state is withdrawn (terminal)
-        finalAgent.map(_.currentState).contains(StateId("withdrawn")),
-        finalAgent.flatMap(extractStrField(_, "status")).contains("withdrawn"),
+        finalAgent.map(_.currentState).contains(StateId("WITHDRAWN")),
+        finalAgent.flatMap(extractStrField(_, "status")).contains("WITHDRAWN"),
         // History preserved in final state
         finalReputation.contains(BigInt(20)),
         finalAttestations.contains(BigInt(3)), // first_attestation + 2 more
@@ -1265,27 +1265,27 @@ object AgentIdentityLifecycleSuite extends SimpleIOSuite {
   private def agentIdentityDefinitionJson(platformfiberId: java.util.UUID): String =
     s"""{
       "states": {
-        "registered": { "id": { "value": "registered" }, "isFinal": false },
-        "active": { "id": { "value": "active" }, "isFinal": false },
-        "challenged": { "id": { "value": "challenged" }, "isFinal": false },
-        "suspended": { "id": { "value": "suspended" }, "isFinal": false },
-        "probation": { "id": { "value": "probation" }, "isFinal": false },
-        "withdrawn": { "id": { "value": "withdrawn" }, "isFinal": true }
+        "REGISTERED": { "id": { "value": "REGISTERED" }, "isFinal": false },
+        "ACTIVE": { "id": { "value": "ACTIVE" }, "isFinal": false },
+        "CHALLENGED": { "id": { "value": "CHALLENGED" }, "isFinal": false },
+        "SUSPENDED": { "id": { "value": "SUSPENDED" }, "isFinal": false },
+        "PROBATION": { "id": { "value": "PROBATION" }, "isFinal": false },
+        "WITHDRAWN": { "id": { "value": "WITHDRAWN" }, "isFinal": true }
       },
-      "initialState": { "value": "registered" },
+      "initialState": { "value": "REGISTERED" },
       "transitions": [
         {
-          "from": { "value": "registered" },
-          "to": { "value": "active" },
+          "from": { "value": "REGISTERED" },
+          "to": { "value": "ACTIVE" },
           "eventName": "first_attestation",
           "guard": {
             "and": [
-              { "===": [ { "var": "machines.${platformfiberId}.state.status" }, "verified" ] },
+              { "===": [ { "var": "machines.${platformfiberId}.state.status" }, "VERIFIED" ] },
               { ">": [ { "var": "state.stakeAmount" }, 0 ] }
             ]
           },
           "effect": [
-            ["status", "active"],
+            ["status", "ACTIVE"],
             ["activatedAt", { "var": "event.timestamp" }],
             ["attestationCount", 1],
             ["completionCount", { "if": [ { "===": [ { "var": "event.attestationType" }, "COMPLETION" ] }, 1, 0 ] }],
@@ -1299,12 +1299,12 @@ object AgentIdentityLifecycleSuite extends SimpleIOSuite {
           "dependencies": ["${platformfiberId}"]
         },
         {
-          "from": { "value": "active" },
-          "to": { "value": "active" },
+          "from": { "value": "ACTIVE" },
+          "to": { "value": "ACTIVE" },
           "eventName": "submit_attestation",
           "guard": {
             "and": [
-              { "===": [ { "var": "machines.${platformfiberId}.state.status" }, "verified" ] },
+              { "===": [ { "var": "machines.${platformfiberId}.state.status" }, "VERIFIED" ] },
               { "in": [ { "var": "event.attestationType" }, ["BEHAVIORAL", "COMPLETION", "VOUCH"] ] }
             ]
           },
@@ -1328,11 +1328,11 @@ object AgentIdentityLifecycleSuite extends SimpleIOSuite {
           "dependencies": ["${platformfiberId}"]
         },
         {
-          "from": { "value": "active" },
-          "to": { "value": "active" },
+          "from": { "value": "ACTIVE" },
+          "to": { "value": "ACTIVE" },
           "eventName": "submit_violation",
           "guard": {
-            "===": [ { "var": "machines.${platformfiberId}.state.status" }, "verified" ]
+            "===": [ { "var": "machines.${platformfiberId}.state.status" }, "VERIFIED" ]
           },
           "effect": [
             ["attestationCount", { "+": [ { "var": "state.attestationCount" }, 1 ] }],
@@ -1346,8 +1346,8 @@ object AgentIdentityLifecycleSuite extends SimpleIOSuite {
           "dependencies": ["${platformfiberId}"]
         },
         {
-          "from": { "value": "active" },
-          "to": { "value": "challenged" },
+          "from": { "value": "ACTIVE" },
+          "to": { "value": "CHALLENGED" },
           "eventName": "file_challenge",
           "guard": {
             "and": [
@@ -1356,7 +1356,7 @@ object AgentIdentityLifecycleSuite extends SimpleIOSuite {
             ]
           },
           "effect": [
-            ["status", "challenged"],
+            ["status", "CHALLENGED"],
             ["challengedAt", { "var": "event.timestamp" }],
             ["challengerId", { "var": "event.challengerId" }],
             ["challengerStake", { "var": "event.challengerStake" }],
@@ -1366,14 +1366,14 @@ object AgentIdentityLifecycleSuite extends SimpleIOSuite {
           "dependencies": []
         },
         {
-          "from": { "value": "challenged" },
-          "to": { "value": "active" },
+          "from": { "value": "CHALLENGED" },
+          "to": { "value": "ACTIVE" },
           "eventName": "dismiss_challenge",
           "guard": {
             ">=": [ { "var": "event.dismissalVotes" }, 3 ]
           },
           "effect": [
-            ["status", "active"],
+            ["status", "ACTIVE"],
             ["challengeResolution", "dismissed"],
             ["challengeResolvedAt", { "var": "event.timestamp" }],
             ["reputationScore", { "+": [ { "var": "state.reputationScore" }, 5 ] }]
@@ -1381,14 +1381,14 @@ object AgentIdentityLifecycleSuite extends SimpleIOSuite {
           "dependencies": []
         },
         {
-          "from": { "value": "challenged" },
-          "to": { "value": "suspended" },
+          "from": { "value": "CHALLENGED" },
+          "to": { "value": "SUSPENDED" },
           "eventName": "uphold_challenge",
           "guard": {
             ">=": [ { "var": "event.upholdVotes" }, 3 ]
           },
           "effect": [
-            ["status", "suspended"],
+            ["status", "SUSPENDED"],
             ["suspendedAt", { "var": "event.timestamp" }],
             ["challengeResolution", "upheld"],
             ["challengeResolvedAt", { "var": "event.timestamp" }],
@@ -1399,8 +1399,8 @@ object AgentIdentityLifecycleSuite extends SimpleIOSuite {
           "dependencies": []
         },
         {
-          "from": { "value": "suspended" },
-          "to": { "value": "probation" },
+          "from": { "value": "SUSPENDED" },
+          "to": { "value": "PROBATION" },
           "eventName": "begin_probation",
           "guard": {
             "and": [
@@ -1412,7 +1412,7 @@ object AgentIdentityLifecycleSuite extends SimpleIOSuite {
             ]
           },
           "effect": [
-            ["status", "probation"],
+            ["status", "PROBATION"],
             ["probationStartedAt", { "var": "event.timestamp" }],
             ["stakeAmount", { "+": [ { "var": "state.stakeAmount" }, { "var": "event.reinstateStake" } ] }],
             ["probationAttestationsRequired", 10]
@@ -1420,12 +1420,12 @@ object AgentIdentityLifecycleSuite extends SimpleIOSuite {
           "dependencies": []
         },
         {
-          "from": { "value": "probation" },
-          "to": { "value": "probation" },
+          "from": { "value": "PROBATION" },
+          "to": { "value": "PROBATION" },
           "eventName": "probation_attestation",
           "guard": {
             "and": [
-              { "===": [ { "var": "machines.${platformfiberId}.state.status" }, "verified" ] },
+              { "===": [ { "var": "machines.${platformfiberId}.state.status" }, "VERIFIED" ] },
               { ">": [ { "var": "state.probationAttestationsRequired" }, 0 ] }
             ]
           },
@@ -1438,26 +1438,26 @@ object AgentIdentityLifecycleSuite extends SimpleIOSuite {
           "dependencies": ["${platformfiberId}"]
         },
         {
-          "from": { "value": "probation" },
-          "to": { "value": "active" },
+          "from": { "value": "PROBATION" },
+          "to": { "value": "ACTIVE" },
           "eventName": "complete_probation",
           "guard": {
             "<=": [ { "var": "state.probationAttestationsRequired" }, 0 ]
           },
           "effect": [
-            ["status", "active"],
+            ["status", "ACTIVE"],
             ["probationCompletedAt", { "var": "event.timestamp" }],
             ["reputationScore", { "+": [ { "var": "state.reputationScore" }, 10 ] }]
           ],
           "dependencies": []
         },
         {
-          "from": { "value": "active" },
-          "to": { "value": "withdrawn" },
+          "from": { "value": "ACTIVE" },
+          "to": { "value": "WITHDRAWN" },
           "eventName": "withdraw",
           "guard": true,
           "effect": [
-            ["status", "withdrawn"],
+            ["status", "WITHDRAWN"],
             ["withdrawnAt", { "var": "event.timestamp" }],
             ["stakeReturned", { "var": "state.stakeAmount" }],
             ["finalReputationScore", { "var": "state.reputationScore" }],
@@ -1471,16 +1471,16 @@ object AgentIdentityLifecycleSuite extends SimpleIOSuite {
   private val platformRegistryDefinitionJson: String =
     """{
       "states": {
-        "pending": { "id": { "value": "pending" }, "isFinal": false },
-        "verified": { "id": { "value": "verified" }, "isFinal": false },
-        "suspended": { "id": { "value": "suspended" }, "isFinal": false },
+        "PENDING": { "id": { "value": "PENDING" }, "isFinal": false },
+        "VERIFIED": { "id": { "value": "VERIFIED" }, "isFinal": false },
+        "SUSPENDED": { "id": { "value": "SUSPENDED" }, "isFinal": false },
         "revoked": { "id": { "value": "revoked" }, "isFinal": true }
       },
-      "initialState": { "value": "pending" },
+      "initialState": { "value": "PENDING" },
       "transitions": [
         {
-          "from": { "value": "pending" },
-          "to": { "value": "verified" },
+          "from": { "value": "PENDING" },
+          "to": { "value": "VERIFIED" },
           "eventName": "verify_platform",
           "guard": {
             "and": [
@@ -1489,7 +1489,7 @@ object AgentIdentityLifecycleSuite extends SimpleIOSuite {
             ]
           },
           "effect": [
-            ["status", "verified"],
+            ["status", "VERIFIED"],
             ["verifiedAt", { "var": "event.timestamp" }],
             ["platformStake", { "var": "event.platformStake" }],
             ["verificationScore", { "var": "event.verificationScore" }],
@@ -1498,8 +1498,8 @@ object AgentIdentityLifecycleSuite extends SimpleIOSuite {
           "dependencies": []
         },
         {
-          "from": { "value": "verified" },
-          "to": { "value": "verified" },
+          "from": { "value": "VERIFIED" },
+          "to": { "value": "VERIFIED" },
           "eventName": "record_attestation_submitted",
           "guard": true,
           "effect": [
@@ -1509,30 +1509,30 @@ object AgentIdentityLifecycleSuite extends SimpleIOSuite {
           "dependencies": []
         },
         {
-          "from": { "value": "verified" },
-          "to": { "value": "suspended" },
+          "from": { "value": "VERIFIED" },
+          "to": { "value": "SUSPENDED" },
           "eventName": "suspend_platform",
           "guard": true,
           "effect": [
-            ["status", "suspended"],
+            ["status", "SUSPENDED"],
             ["suspendedAt", { "var": "event.timestamp" }],
             ["suspensionReason", { "var": "event.reason" }]
           ],
           "dependencies": []
         },
         {
-          "from": { "value": "suspended" },
-          "to": { "value": "verified" },
+          "from": { "value": "SUSPENDED" },
+          "to": { "value": "VERIFIED" },
           "eventName": "reinstate_platform",
           "guard": true,
           "effect": [
-            ["status", "verified"],
+            ["status", "VERIFIED"],
             ["reinstatedAt", { "var": "event.timestamp" }]
           ],
           "dependencies": []
         },
         {
-          "from": { "value": "suspended" },
+          "from": { "value": "SUSPENDED" },
           "to": { "value": "revoked" },
           "eventName": "revoke_platform",
           "guard": true,

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/examples/ClinicalTrialStateMachineSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/examples/ClinicalTrialStateMachineSuite.scala
@@ -46,20 +46,20 @@ object ClinicalTrialStateMachineSuite extends SimpleIOSuite {
           s"""{
           "states": {
             "recruiting": { "id": { "value": "recruiting" }, "isFinal": false },
-            "active": { "id": { "value": "active" }, "isFinal": false },
+            "ACTIVE": { "id": { "value": "ACTIVE" }, "isFinal": false },
             "phase_1": { "id": { "value": "phase_1" }, "isFinal": false },
             "phase_2": { "id": { "value": "phase_2" }, "isFinal": false },
             "phase_3": { "id": { "value": "phase_3" }, "isFinal": false },
             "under_review": { "id": { "value": "under_review" }, "isFinal": false },
-            "completed": { "id": { "value": "completed" }, "isFinal": true },
-            "suspended": { "id": { "value": "suspended" }, "isFinal": false },
+            "COMPLETED": { "id": { "value": "COMPLETED" }, "isFinal": true },
+            "SUSPENDED": { "id": { "value": "SUSPENDED" }, "isFinal": false },
             "terminated": { "id": { "value": "terminated" }, "isFinal": true }
           },
           "initialState": { "value": "recruiting" },
           "transitions": [
             {
               "from": { "value": "recruiting" },
-              "to": { "value": "active" },
+              "to": { "value": "ACTIVE" },
               "eventName": "start_trial",
               "guard": {
                 "and": [
@@ -68,13 +68,13 @@ object ClinicalTrialStateMachineSuite extends SimpleIOSuite {
                 ]
               },
               "effect": [
-                ["status", "active"],
+                ["status", "ACTIVE"],
                 ["startedAt", { "var": "event.timestamp" }]
               ],
               "dependencies": ["${regulatorfiberId}"]
             },
             {
-              "from": { "value": "active" },
+              "from": { "value": "ACTIVE" },
               "to": { "value": "phase_1" },
               "eventName": "advance_phase",
               "guard": {
@@ -132,7 +132,7 @@ object ClinicalTrialStateMachineSuite extends SimpleIOSuite {
               "guard": {
                 "and": [
                   { ">=": [{ "var": "state.completedVisits" }, 20] },
-                  { "===": [{ "var": "machines.${patientfiberId}.state.status" }, "completed"] }
+                  { "===": [{ "var": "machines.${patientfiberId}.state.status" }, "COMPLETED"] }
                 ]
               },
               "effect": [
@@ -154,34 +154,34 @@ object ClinicalTrialStateMachineSuite extends SimpleIOSuite {
             },
             {
               "from": { "value": "under_review" },
-              "to": { "value": "completed" },
+              "to": { "value": "COMPLETED" },
               "eventName": "finalize",
               "guard": {
                 "===": [{ "var": "machines.${regulatorfiberId}.state.reviewResult" }, "approved"]
               },
               "effect": [
-                ["status", "completed"],
+                ["status", "COMPLETED"],
                 ["completedAt", { "var": "event.timestamp" }]
               ],
               "dependencies": ["${regulatorfiberId}"]
             },
             {
-              "from": { "value": "active" },
-              "to": { "value": "suspended" },
+              "from": { "value": "ACTIVE" },
+              "to": { "value": "SUSPENDED" },
               "eventName": "suspend",
               "guard": {
                 "===": [{ "var": "machines.${adverseEventfiberId}.state.hasCriticalEvent" }, true]
               },
               "effect": [
-                ["status", "suspended"],
+                ["status", "SUSPENDED"],
                 ["suspendedAt", { "var": "event.timestamp" }],
                 ["suspensionReason", "critical_adverse_event"]
               ],
               "dependencies": ["${adverseEventfiberId}"]
             },
             {
-              "from": { "value": "suspended" },
-              "to": { "value": "active" },
+              "from": { "value": "SUSPENDED" },
+              "to": { "value": "ACTIVE" },
               "eventName": "resume",
               "guard": {
                 "and": [
@@ -190,13 +190,13 @@ object ClinicalTrialStateMachineSuite extends SimpleIOSuite {
                 ]
               },
               "effect": [
-                ["status", "active"],
+                ["status", "ACTIVE"],
                 ["resumedAt", { "var": "event.timestamp" }]
               ],
               "dependencies": ["${adverseEventfiberId}", "${regulatorfiberId}"]
             },
             {
-              "from": { "value": "suspended" },
+              "from": { "value": "SUSPENDED" },
               "to": { "value": "terminated" },
               "eventName": "terminate",
               "guard": {
@@ -218,13 +218,13 @@ object ClinicalTrialStateMachineSuite extends SimpleIOSuite {
           "states": {
             "screening": { "id": { "value": "screening" }, "isFinal": false },
             "enrolled": { "id": { "value": "enrolled" }, "isFinal": false },
-            "active": { "id": { "value": "active" }, "isFinal": false },
+            "ACTIVE": { "id": { "value": "ACTIVE" }, "isFinal": false },
             "paused": { "id": { "value": "paused" }, "isFinal": false },
             "visit_scheduled": { "id": { "value": "visit_scheduled" }, "isFinal": false },
             "visit_completed": { "id": { "value": "visit_completed" }, "isFinal": false },
             "adverse_event": { "id": { "value": "adverse_event" }, "isFinal": false },
-            "completed": { "id": { "value": "completed" }, "isFinal": true },
-            "withdrawn": { "id": { "value": "withdrawn" }, "isFinal": true }
+            "COMPLETED": { "id": { "value": "COMPLETED" }, "isFinal": true },
+            "WITHDRAWN": { "id": { "value": "WITHDRAWN" }, "isFinal": true }
           },
           "initialState": { "value": "screening" },
           "transitions": [
@@ -261,20 +261,20 @@ object ClinicalTrialStateMachineSuite extends SimpleIOSuite {
             },
             {
               "from": { "value": "enrolled" },
-              "to": { "value": "active" },
+              "to": { "value": "ACTIVE" },
               "eventName": "activate",
               "guard": {
-                "===": [{ "var": "machines.${trialfiberId}.state.status" }, "active"]
+                "===": [{ "var": "machines.${trialfiberId}.state.status" }, "ACTIVE"]
               },
               "effect": [
-                ["status", "active"],
+                ["status", "ACTIVE"],
                 ["activatedAt", { "var": "event.timestamp" }],
                 ["visitCount", 0]
               ],
               "dependencies": ["${trialfiberId}"]
             },
             {
-              "from": { "value": "active" },
+              "from": { "value": "ACTIVE" },
               "to": { "value": "paused" },
               "eventName": "pause",
               "guard": true,
@@ -287,22 +287,22 @@ object ClinicalTrialStateMachineSuite extends SimpleIOSuite {
             },
             {
               "from": { "value": "paused" },
-              "to": { "value": "active" },
+              "to": { "value": "ACTIVE" },
               "eventName": "resume",
               "guard": {
                 "and": [
-                  { "===": [{ "var": "machines.${trialfiberId}.state.status" }, "active"] },
+                  { "===": [{ "var": "machines.${trialfiberId}.state.status" }, "ACTIVE"] },
                   { "<": [{ "-": [{ "var": "event.timestamp" }, { "var": "state.pausedAt" }] }, 2592000] }
                 ]
               },
               "effect": [
-                ["status", "active"],
+                ["status", "ACTIVE"],
                 ["resumedAt", { "var": "event.timestamp" }]
               ],
               "dependencies": ["${trialfiberId}"]
             },
             {
-              "from": { "value": "active" },
+              "from": { "value": "ACTIVE" },
               "to": { "value": "visit_scheduled" },
               "eventName": "schedule_visit",
               "guard": {
@@ -341,7 +341,7 @@ object ClinicalTrialStateMachineSuite extends SimpleIOSuite {
             },
             {
               "from": { "value": "visit_completed" },
-              "to": { "value": "active" },
+              "to": { "value": "ACTIVE" },
               "eventName": "continue",
               "guard": {
                 "and": [
@@ -350,7 +350,7 @@ object ClinicalTrialStateMachineSuite extends SimpleIOSuite {
                 ]
               },
               "effect": [
-                ["status", "active"]
+                ["status", "ACTIVE"]
               ],
               "dependencies": ["${labfiberId}"]
             },
@@ -383,20 +383,20 @@ object ClinicalTrialStateMachineSuite extends SimpleIOSuite {
             },
             {
               "from": { "value": "adverse_event" },
-              "to": { "value": "active" },
+              "to": { "value": "ACTIVE" },
               "eventName": "resolve",
               "guard": {
                 "===": [{ "var": "machines.${adverseEventfiberId}.state.resolved" }, true]
               },
               "effect": [
-                ["status", "active"],
+                ["status", "ACTIVE"],
                 ["resolvedAt", { "var": "event.timestamp" }]
               ],
               "dependencies": ["${adverseEventfiberId}"]
             },
             {
               "from": { "value": "visit_completed" },
-              "to": { "value": "completed" },
+              "to": { "value": "COMPLETED" },
               "eventName": "complete_trial",
               "guard": {
                 "and": [
@@ -415,18 +415,18 @@ object ClinicalTrialStateMachineSuite extends SimpleIOSuite {
                     }
                   }
                 ]],
-                ["status", "completed"],
+                ["status", "COMPLETED"],
                 ["completedAt", { "var": "event.timestamp" }]
               ],
               "dependencies": ["${labfiberId}"]
             },
             {
               "from": { "value": "paused" },
-              "to": { "value": "withdrawn" },
+              "to": { "value": "WITHDRAWN" },
               "eventName": "withdraw",
               "guard": true,
               "effect": [
-                ["status", "withdrawn"],
+                ["status", "WITHDRAWN"],
                 ["withdrawnAt", { "var": "event.timestamp" }],
                 ["withdrawalReason", { "var": "event.reason" }]
               ],
@@ -434,13 +434,13 @@ object ClinicalTrialStateMachineSuite extends SimpleIOSuite {
             },
             {
               "from": { "value": "adverse_event" },
-              "to": { "value": "withdrawn" },
+              "to": { "value": "WITHDRAWN" },
               "eventName": "withdraw",
               "guard": {
                 "===": [{ "var": "machines.${adverseEventfiberId}.state.severity" }, "critical"]
               },
               "effect": [
-                ["status", "withdrawn"],
+                ["status", "WITHDRAWN"],
                 ["withdrawnAt", { "var": "event.timestamp" }],
                 ["withdrawalReason", "critical_adverse_event"]
               ],
@@ -733,7 +733,7 @@ object ClinicalTrialStateMachineSuite extends SimpleIOSuite {
             "monitoring": { "id": { "value": "monitoring" }, "isFinal": false },
             "reviewing": { "id": { "value": "reviewing" }, "isFinal": false },
             "final_approved": { "id": { "value": "final_approved" }, "isFinal": true },
-            "rejected": { "id": { "value": "rejected" }, "isFinal": true }
+            "REJECTED": { "id": { "value": "REJECTED" }, "isFinal": true }
           },
           "initialState": { "value": "approved" },
           "transitions": [
@@ -780,14 +780,14 @@ object ClinicalTrialStateMachineSuite extends SimpleIOSuite {
             },
             {
               "from": { "value": "reviewing" },
-              "to": { "value": "rejected" },
+              "to": { "value": "REJECTED" },
               "eventName": "approve",
               "guard": {
                 "<": [{ "var": "event.complianceScore" }, 90]
               },
               "effect": [
-                ["reviewResult", "rejected"],
-                ["status", "rejected"],
+                ["reviewResult", "REJECTED"],
+                ["status", "REJECTED"],
                 ["rejectedAt", { "var": "event.timestamp" }],
                 ["complianceScore", { "var": "event.complianceScore" }],
                 ["rejectionReason", { "var": "event.reason" }]
@@ -801,16 +801,16 @@ object ClinicalTrialStateMachineSuite extends SimpleIOSuite {
         insuranceJson =
           """{
           "states": {
-            "active": { "id": { "value": "active" }, "isFinal": false },
+            "ACTIVE": { "id": { "value": "ACTIVE" }, "isFinal": false },
             "claim_filed": { "id": { "value": "claim_filed" }, "isFinal": false },
             "claim_processing": { "id": { "value": "claim_processing" }, "isFinal": false },
             "claim_approved": { "id": { "value": "claim_approved" }, "isFinal": false },
             "claim_paid": { "id": { "value": "claim_paid" }, "isFinal": false }
           },
-          "initialState": { "value": "active" },
+          "initialState": { "value": "ACTIVE" },
           "transitions": [
             {
-              "from": { "value": "active" },
+              "from": { "value": "ACTIVE" },
               "to": { "value": "claim_filed" },
               "eventName": "file_claim",
               "guard": {
@@ -859,11 +859,11 @@ object ClinicalTrialStateMachineSuite extends SimpleIOSuite {
             },
             {
               "from": { "value": "claim_paid" },
-              "to": { "value": "active" },
+              "to": { "value": "ACTIVE" },
               "eventName": "reset",
               "guard": true,
               "effect": [
-                ["status", "active"]
+                ["status", "ACTIVE"]
               ],
               "dependencies": []
             }
@@ -956,12 +956,12 @@ object ClinicalTrialStateMachineSuite extends SimpleIOSuite {
           .build[IO]
 
         insuranceFiber <- FiberBuilder(insurancefiberId, ordinal, insuranceDef)
-          .withState("active")
+          .withState("ACTIVE")
           .withData(
             "policyNumber"   -> StrValue("POL-123456"),
             "coverage"       -> IntValue(100000),
             "coverageActive" -> BoolValue(true),
-            "status"         -> StrValue("active")
+            "status"         -> StrValue("ACTIVE")
           )
           .ownedBy(registry, Alice, Bob)
           .build[IO]
@@ -1074,9 +1074,9 @@ object ClinicalTrialStateMachineSuite extends SimpleIOSuite {
         // Verify patient enrollment succeeded
         state1.fiberRecord(patientfiberId).map(_.currentState).contains(StateId("enrolled")),
         // Verify trial started
-        state2.fiberRecord(trialfiberId).map(_.currentState).contains(StateId("active")),
+        state2.fiberRecord(trialfiberId).map(_.currentState).contains(StateId("ACTIVE")),
         // Verify patient activated
-        state3.fiberRecord(patientfiberId).map(_.currentState).contains(StateId("active")),
+        state3.fiberRecord(patientfiberId).map(_.currentState).contains(StateId("ACTIVE")),
         // Verify visit scheduled
         state4.fiberRecord(patientfiberId).map(_.currentState).contains(StateId("visit_scheduled")),
         // Verify lab received sample
@@ -1091,12 +1091,12 @@ object ClinicalTrialStateMachineSuite extends SimpleIOSuite {
         labResult.contains("passed"),
         // Verify patient continued and is back to active
         patientAfterContinue.isDefined,
-        patientAfterContinue.map(_.currentState).contains(StateId("active")),
-        patientStatus.contains("active"),
+        patientAfterContinue.map(_.currentState).contains(StateId("ACTIVE")),
+        patientStatus.contains("ACTIVE"),
         patientVisitCount.contains(BigInt(1)),
         // Verify trial is still active
         trialAfterVisit.isDefined,
-        trialStatus.contains("active")
+        trialStatus.contains("ACTIVE")
       )
     }
   }

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/examples/FuelLogisticsStateMachineSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/examples/FuelLogisticsStateMachineSuite.scala
@@ -55,7 +55,7 @@ object FuelLogisticsStateMachineSuite extends SimpleIOSuite {
             "inspected": { "id": { "value": "inspected" }, "isFinal": false },
             "settling": { "id": { "value": "settling" }, "isFinal": false },
             "settled": { "id": { "value": "settled" }, "isFinal": true },
-            "rejected": { "id": { "value": "rejected" }, "isFinal": true }
+            "REJECTED": { "id": { "value": "REJECTED" }, "isFinal": true }
           },
           "initialState": { "value": "draft" },
           "transitions": [
@@ -99,7 +99,7 @@ object FuelLogisticsStateMachineSuite extends SimpleIOSuite {
               "guard": {
                 "===": [
                   { "var": "machines.${gpsTrackerfiberId}.state.status" },
-                  "active"
+                  "ACTIVE"
                 ]
               },
               "effect": [
@@ -211,7 +211,7 @@ object FuelLogisticsStateMachineSuite extends SimpleIOSuite {
             },
             {
               "from": { "value": "quality_check" },
-              "to": { "value": "rejected" },
+              "to": { "value": "REJECTED" },
               "eventName": "inspection_complete",
               "guard": {
                 "or": [
@@ -230,7 +230,7 @@ object FuelLogisticsStateMachineSuite extends SimpleIOSuite {
                 ]
               },
               "effect": [
-                ["status", "rejected"],
+                ["status", "REJECTED"],
                 ["rejectedAt", { "var": "event.timestamp" }],
                 ["rejectionReason", "quality inspection failed"],
                 ["qualityScore", { "var": "machines.${inspectionfiberId}.state.qualityScore" }]
@@ -276,7 +276,7 @@ object FuelLogisticsStateMachineSuite extends SimpleIOSuite {
           """{
           "states": {
             "inactive": { "id": { "value": "inactive" }, "isFinal": false },
-            "active": { "id": { "value": "active" }, "isFinal": false },
+            "ACTIVE": { "id": { "value": "ACTIVE" }, "isFinal": false },
             "tracking": { "id": { "value": "tracking" }, "isFinal": false },
             "stopped": { "id": { "value": "stopped" }, "isFinal": false },
             "archived": { "id": { "value": "archived" }, "isFinal": true }
@@ -285,11 +285,11 @@ object FuelLogisticsStateMachineSuite extends SimpleIOSuite {
           "transitions": [
             {
               "from": { "value": "inactive" },
-              "to": { "value": "active" },
+              "to": { "value": "ACTIVE" },
               "eventName": "activate",
               "guard": true,
               "effect": [
-                ["status", "active"],
+                ["status", "ACTIVE"],
                 ["activatedAt", { "var": "event.timestamp" }],
                 ["vehicleId", { "var": "event.vehicleId" }],
                 ["dataPointCount", 0],
@@ -298,7 +298,7 @@ object FuelLogisticsStateMachineSuite extends SimpleIOSuite {
               "dependencies": []
             },
             {
-              "from": { "value": "active" },
+              "from": { "value": "ACTIVE" },
               "to": { "value": "tracking" },
               "eventName": "start_tracking",
               "guard": true,
@@ -369,15 +369,15 @@ object FuelLogisticsStateMachineSuite extends SimpleIOSuite {
         supplierApprovalJson =
           """{
           "states": {
-            "pending": { "id": { "value": "pending" }, "isFinal": false },
+            "PENDING": { "id": { "value": "PENDING" }, "isFinal": false },
             "reviewing": { "id": { "value": "reviewing" }, "isFinal": false },
             "approved": { "id": { "value": "approved" }, "isFinal": false },
-            "rejected": { "id": { "value": "rejected" }, "isFinal": true }
+            "REJECTED": { "id": { "value": "REJECTED" }, "isFinal": true }
           },
-          "initialState": { "value": "pending" },
+          "initialState": { "value": "PENDING" },
           "transitions": [
             {
-              "from": { "value": "pending" },
+              "from": { "value": "PENDING" },
               "to": { "value": "reviewing" },
               "eventName": "begin_review",
               "guard": true,
@@ -408,7 +408,7 @@ object FuelLogisticsStateMachineSuite extends SimpleIOSuite {
             },
             {
               "from": { "value": "reviewing" },
-              "to": { "value": "rejected" },
+              "to": { "value": "REJECTED" },
               "eventName": "approve",
               "guard": {
                 "or": [
@@ -417,7 +417,7 @@ object FuelLogisticsStateMachineSuite extends SimpleIOSuite {
                 ]
               },
               "effect": [
-                ["status", "rejected"],
+                ["status", "REJECTED"],
                 ["rejectedAt", { "var": "event.timestamp" }],
                 ["rejectionReason", "compliance or licensing issues"]
               ],
@@ -431,16 +431,16 @@ object FuelLogisticsStateMachineSuite extends SimpleIOSuite {
         qualityInspectionJson =
           """{
           "states": {
-            "pending": { "id": { "value": "pending" }, "isFinal": false },
+            "PENDING": { "id": { "value": "PENDING" }, "isFinal": false },
             "scheduled": { "id": { "value": "scheduled" }, "isFinal": false },
             "inspecting": { "id": { "value": "inspecting" }, "isFinal": false },
             "passed": { "id": { "value": "passed" }, "isFinal": true },
             "failed": { "id": { "value": "failed" }, "isFinal": true }
           },
-          "initialState": { "value": "pending" },
+          "initialState": { "value": "PENDING" },
           "transitions": [
             {
-              "from": { "value": "pending" },
+              "from": { "value": "PENDING" },
               "to": { "value": "scheduled" },
               "eventName": "schedule",
               "guard": true,
@@ -541,13 +541,13 @@ object FuelLogisticsStateMachineSuite extends SimpleIOSuite {
           .withData(
             "supplierName" -> StrValue("Global Fuel Co"),
             "supplierId"   -> StrValue("SUP-001"),
-            "status"       -> StrValue("pending")
+            "status"       -> StrValue("PENDING")
           )
           .ownedBy(registry, Bob)
           .build[IO]
 
         inspectionFiber <- FiberBuilder(inspectionfiberId, ordinal, inspectionDef)
-          .withData("contractRef" -> StrValue("FC-2025-001"), "status" -> StrValue("pending"))
+          .withData("contractRef" -> StrValue("FC-2025-001"), "status" -> StrValue("PENDING"))
           .ownedBy(registry, Charlie)
           .build[IO]
 

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/examples/JsonEncodedStateMachineSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/examples/JsonEncodedStateMachineSuite.scala
@@ -154,8 +154,8 @@ object JsonEncodedStateMachineSuite extends SimpleIOSuite {
         htlcJson =
           """{
           "states": {
-            "pending": {
-              "id": { "value": "pending" },
+            "PENDING": {
+              "id": { "value": "PENDING" },
               "isFinal": false
             },
             "claimed": {
@@ -167,10 +167,10 @@ object JsonEncodedStateMachineSuite extends SimpleIOSuite {
               "isFinal": true
             }
           },
-          "initialState": { "value": "pending" },
+          "initialState": { "value": "PENDING" },
           "transitions": [
             {
-              "from": { "value": "pending" },
+              "from": { "value": "PENDING" },
               "to": { "value": "claimed" },
               "eventName": "claim",
               "guard": {
@@ -198,7 +198,7 @@ object JsonEncodedStateMachineSuite extends SimpleIOSuite {
               "dependencies": []
             },
             {
-              "from": { "value": "pending" },
+              "from": { "value": "PENDING" },
               "to": { "value": "refunded" },
               "eventName": "refund",
               "guard": {
@@ -248,7 +248,7 @@ object JsonEncodedStateMachineSuite extends SimpleIOSuite {
         )
 
         htlcFiber <- FiberBuilder(htlcfiberId, ordinal, parsedDef)
-          .withState("pending")
+          .withState("PENDING")
           .withDataValue(htlcData)
           .ownedBy(registry, Alice, Bob)
           .build[IO]
@@ -313,7 +313,7 @@ object JsonEncodedStateMachineSuite extends SimpleIOSuite {
         )
 
         htlcFiber2 <- FiberBuilder(htlcCid2, ordinal, parsedDef)
-          .withState("pending")
+          .withState("PENDING")
           .withDataValue(htlcData2)
           .ownedBy(registry, Alice, Bob)
           .build[IO]
@@ -395,8 +395,8 @@ object JsonEncodedStateMachineSuite extends SimpleIOSuite {
             "in_transit": { "id": { "value": "in_transit" }, "isFinal": false },
             "delivered": { "id": { "value": "delivered" }, "isFinal": false },
             "inspecting": { "id": { "value": "inspecting" }, "isFinal": false },
-            "completed": { "id": { "value": "completed" }, "isFinal": true },
-            "disputed": { "id": { "value": "disputed" }, "isFinal": true }
+            "COMPLETED": { "id": { "value": "COMPLETED" }, "isFinal": true },
+            "DISPUTED": { "id": { "value": "DISPUTED" }, "isFinal": true }
           },
           "initialState": { "value": "placed" },
           "transitions": [
@@ -477,7 +477,7 @@ object JsonEncodedStateMachineSuite extends SimpleIOSuite {
             },
             {
               "from": { "value": "inspecting" },
-              "to": { "value": "completed" },
+              "to": { "value": "COMPLETED" },
               "eventName": "complete_order",
               "guard": {
                 "and": [
@@ -496,14 +496,14 @@ object JsonEncodedStateMachineSuite extends SimpleIOSuite {
                 ]
               },
               "effect": [
-                ["status", "completed"],
+                ["status", "COMPLETED"],
                 ["completedAt", { "var": "event.timestamp" }]
               ],
               "dependencies": ["${inspectionfiberId}", "${escrowfiberId}"]
             },
             {
               "from": { "value": "inspecting" },
-              "to": { "value": "disputed" },
+              "to": { "value": "DISPUTED" },
               "eventName": "dispute",
               "guard": {
                 "===": [
@@ -512,7 +512,7 @@ object JsonEncodedStateMachineSuite extends SimpleIOSuite {
                 ]
               },
               "effect": [
-                ["status", "disputed"],
+                ["status", "DISPUTED"],
                 ["disputedAt", { "var": "event.timestamp" }]
               ],
               "dependencies": ["${inspectionfiberId}"]
@@ -664,7 +664,7 @@ object JsonEncodedStateMachineSuite extends SimpleIOSuite {
         shippingJson =
           s"""{
           "states": {
-            "pending": { "id": { "value": "pending" }, "isFinal": false },
+            "PENDING": { "id": { "value": "PENDING" }, "isFinal": false },
             "picked_up": { "id": { "value": "picked_up" }, "isFinal": false },
             "in_transit": { "id": { "value": "in_transit" }, "isFinal": false },
             "customs": { "id": { "value": "customs" }, "isFinal": false },
@@ -673,10 +673,10 @@ object JsonEncodedStateMachineSuite extends SimpleIOSuite {
             "lost": { "id": { "value": "lost" }, "isFinal": true },
             "damaged": { "id": { "value": "damaged" }, "isFinal": true }
           },
-          "initialState": { "value": "pending" },
+          "initialState": { "value": "PENDING" },
           "transitions": [
             {
-              "from": { "value": "pending" },
+              "from": { "value": "PENDING" },
               "to": { "value": "picked_up" },
               "eventName": "pickup",
               "guard": true,
@@ -717,7 +717,7 @@ object JsonEncodedStateMachineSuite extends SimpleIOSuite {
               "guard": {
                 "===": [
                   { "var": "machines.${insurancefiberId}.state.status" },
-                  "active"
+                  "ACTIVE"
                 ]
               },
               "effect": [
@@ -869,17 +869,17 @@ object JsonEncodedStateMachineSuite extends SimpleIOSuite {
         insuranceJson =
           s"""{
           "states": {
-            "active": { "id": { "value": "active" }, "isFinal": false },
+            "ACTIVE": { "id": { "value": "ACTIVE" }, "isFinal": false },
             "claim_filed": { "id": { "value": "claim_filed" }, "isFinal": false },
             "investigating": { "id": { "value": "investigating" }, "isFinal": false },
             "approved": { "id": { "value": "approved" }, "isFinal": false },
             "denied": { "id": { "value": "denied" }, "isFinal": true },
             "settled": { "id": { "value": "settled" }, "isFinal": true }
           },
-          "initialState": { "value": "active" },
+          "initialState": { "value": "ACTIVE" },
           "transitions": [
             {
-              "from": { "value": "active" },
+              "from": { "value": "ACTIVE" },
               "to": { "value": "claim_filed" },
               "eventName": "file_claim",
               "guard": {
@@ -1080,11 +1080,11 @@ object JsonEncodedStateMachineSuite extends SimpleIOSuite {
           .build[IO]
 
         shippingFiber <- FiberBuilder(shippingfiberId, ordinal, shippingDef)
-          .withState("pending")
+          .withState("PENDING")
           .withData(
             "trackingNumber" -> StrValue("TRACK-12345"),
             "carrier"        -> StrValue("FastShip"),
-            "status"         -> StrValue("pending")
+            "status"         -> StrValue("PENDING")
           )
           .ownedBy(registry, Alice)
           .build[IO]
@@ -1099,11 +1099,11 @@ object JsonEncodedStateMachineSuite extends SimpleIOSuite {
           .build[IO]
 
         insuranceFiber <- FiberBuilder(insurancefiberId, ordinal, insuranceDef)
-          .withState("active")
+          .withState("ACTIVE")
           .withData(
             "policyNumber"   -> StrValue("INS-999"),
             "coverageAmount" -> IntValue(5000),
-            "status"         -> StrValue("active"),
+            "status"         -> StrValue("ACTIVE"),
             "hasClaim"       -> BoolValue(false)
           )
           .ownedBy(registry, Alice, Bob)
@@ -1277,8 +1277,8 @@ object JsonEncodedStateMachineSuite extends SimpleIOSuite {
 
       } yield expect.all(
         finalOrder.isDefined,
-        finalOrder.map(_.currentState).contains(StateId("completed")),
-        finalOrder.extractString("status").contains("completed"),
+        finalOrder.map(_.currentState).contains(StateId("COMPLETED")),
+        finalOrder.extractString("status").contains("COMPLETED"),
         finalEscrow.isDefined,
         finalEscrow.map(_.currentState).contains(StateId("released")),
         finalEscrow.extractString("status").contains("released"),
@@ -1288,7 +1288,7 @@ object JsonEncodedStateMachineSuite extends SimpleIOSuite {
         finalInspection.map(_.currentState).contains(StateId("passed")),
         finalInspection.extractString("result").contains("passed"),
         finalInsurance.isDefined,
-        finalInsurance.map(_.currentState).contains(StateId("active"))
+        finalInsurance.map(_.currentState).contains(StateId("ACTIVE"))
       )
     }
   }
@@ -1310,8 +1310,8 @@ object JsonEncodedStateMachineSuite extends SimpleIOSuite {
         proposalJson =
           """{
           "states": {
-            "proposed": {
-              "id": { "value": "proposed" },
+            "PROPOSED": {
+              "id": { "value": "PROPOSED" },
               "isFinal": false
             },
             "open": {
@@ -1331,10 +1331,10 @@ object JsonEncodedStateMachineSuite extends SimpleIOSuite {
               "isFinal": true
             }
           },
-          "initialState": { "value": "proposed" },
+          "initialState": { "value": "PROPOSED" },
           "transitions": [
             {
-              "from": { "value": "proposed" },
+              "from": { "value": "PROPOSED" },
               "to": { "value": "open" },
               "eventName": "collect",
               "guard": { "var": "state.hasQuorum" },
@@ -1378,7 +1378,7 @@ object JsonEncodedStateMachineSuite extends SimpleIOSuite {
               "dependencies": []
             },
             {
-              "from": { "value": "proposed" },
+              "from": { "value": "PROPOSED" },
               "to": { "value": "aborted" },
               "eventName": "abort",
               "guard": true,
@@ -1395,23 +1395,23 @@ object JsonEncodedStateMachineSuite extends SimpleIOSuite {
         actionJson =
           s"""{
           "states": {
-            "pending": {
-              "id": { "value": "pending" },
+            "PENDING": {
+              "id": { "value": "PENDING" },
               "isFinal": false
             },
             "submitted": {
               "id": { "value": "submitted" },
               "isFinal": false
             },
-            "rejected": {
-              "id": { "value": "rejected" },
+            "REJECTED": {
+              "id": { "value": "REJECTED" },
               "isFinal": true
             }
           },
-          "initialState": { "value": "pending" },
+          "initialState": { "value": "PENDING" },
           "transitions": [
             {
-              "from": { "value": "pending" },
+              "from": { "value": "PENDING" },
               "to": { "value": "submitted" },
               "eventName": "submit",
               "guard": {
@@ -1429,8 +1429,8 @@ object JsonEncodedStateMachineSuite extends SimpleIOSuite {
               "dependencies": ["${proposalfiberId}"]
             },
             {
-              "from": { "value": "pending" },
-              "to": { "value": "rejected" },
+              "from": { "value": "PENDING" },
+              "to": { "value": "REJECTED" },
               "eventName": "submit",
               "guard": {
                 "!==": [
@@ -1494,7 +1494,7 @@ object JsonEncodedStateMachineSuite extends SimpleIOSuite {
         )
 
         proposalFiber <- FiberBuilder(proposalfiberId, ordinal, proposalDef)
-          .withState("proposed")
+          .withState("PROPOSED")
           .withData(
             "title"          -> StrValue("Increase treasury allocation"),
             "hasQuorum"      -> BoolValue(true),
@@ -1502,7 +1502,7 @@ object JsonEncodedStateMachineSuite extends SimpleIOSuite {
             "requiredVotes"  -> IntValue(2),
             "yesVotes"       -> IntValue(0),
             "noVotes"        -> IntValue(0),
-            "status"         -> StrValue("proposed")
+            "status"         -> StrValue("PROPOSED")
           )
           .ownedBy(registry, Alice)
           .build[IO]
@@ -1545,7 +1545,7 @@ object JsonEncodedStateMachineSuite extends SimpleIOSuite {
         earlyActionfiberId <- UUIDGen.randomUUID[IO]
 
         earlyActionFiber <- FiberBuilder(earlyActionfiberId, ordinal, actionDef)
-          .withState("pending")
+          .withState("PENDING")
           .withData(
             "proposalId" -> StrValue(proposalfiberId.toString),
             "submitter"  -> StrValue(registry.addresses(Charlie).toString)
@@ -1557,7 +1557,7 @@ object JsonEncodedStateMachineSuite extends SimpleIOSuite {
         validActionfiberId <- UUIDGen.randomUUID[IO]
 
         validActionFiberInit <- FiberBuilder(validActionfiberId, ordinal, actionDef)
-          .withState("pending")
+          .withState("PENDING")
           .withData(
             "proposalId" -> StrValue(proposalfiberId.toString),
             "submitter"  -> StrValue(registry.addresses(Charlie).toString)
@@ -1596,7 +1596,7 @@ object JsonEncodedStateMachineSuite extends SimpleIOSuite {
         // Verify early submission was rejected
         _ = expect.all(
           earlyActionFiberResult.isDefined,
-          earlyActionFiberResult.map(_.currentState).contains(StateId("rejected")),
+          earlyActionFiberResult.map(_.currentState).contains(StateId("REJECTED")),
           earlyActionFiberResult.extractBool("rejected").contains(true),
           earlyActionFiberResult.extractString("reason").contains("proposal not open")
         )

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/examples/NftMarketplaceSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/examples/NftMarketplaceSuite.scala
@@ -120,8 +120,8 @@ object NftMarketplaceSuite extends SimpleIOSuite {
               "isFinal": true,
               "metadata": "NFT has been sold"
             },
-            "cancelled": {
-              "id": { "value": "cancelled" },
+            "CANCELLED": {
+              "id": { "value": "CANCELLED" },
               "isFinal": true,
               "metadata": "Listing was cancelled"
             }
@@ -170,7 +170,7 @@ object NftMarketplaceSuite extends SimpleIOSuite {
             },
             {
               "from": { "value": "listed" },
-              "to": { "value": "cancelled" },
+              "to": { "value": "CANCELLED" },
               "eventName": "cancel",
               "guard": {
                 "===": [
@@ -195,17 +195,17 @@ object NftMarketplaceSuite extends SimpleIOSuite {
         marketplaceJson =
           s"""{
           "states": {
-            "active": {
-              "id": { "value": "active" },
+            "ACTIVE": {
+              "id": { "value": "ACTIVE" },
               "isFinal": false,
               "metadata": "Marketplace is active"
             }
           },
-          "initialState": { "value": "active" },
+          "initialState": { "value": "ACTIVE" },
           "transitions": [
             {
-              "from": { "value": "active" },
-              "to": { "value": "active" },
+              "from": { "value": "ACTIVE" },
+              "to": { "value": "ACTIVE" },
               "eventName": "createListing",
               "guard": true,
               "effect": {
@@ -236,8 +236,8 @@ object NftMarketplaceSuite extends SimpleIOSuite {
                           "isFinal": true,
                           "metadata": "NFT has been sold"
                         },
-                        "cancelled": {
-                          "id": { "value": "cancelled" },
+                        "CANCELLED": {
+                          "id": { "value": "CANCELLED" },
                           "isFinal": true,
                           "metadata": "Listing was cancelled"
                         }
@@ -286,7 +286,7 @@ object NftMarketplaceSuite extends SimpleIOSuite {
                         },
                         {
                           "from": { "value": "listed" },
-                          "to": { "value": "cancelled" },
+                          "to": { "value": "CANCELLED" },
                           "eventName": "cancel",
                           "guard": {
                             "===": [
@@ -332,7 +332,7 @@ object NftMarketplaceSuite extends SimpleIOSuite {
         )
 
         marketplaceFiber <- FiberBuilder(marketplacefiberId, ordinal, marketplaceDef)
-          .withState("active")
+          .withState("ACTIVE")
           .withDataValue(marketplaceData)
           .ownedBy(registry, Alice)
           .build[IO]

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/examples/PredictionMarketSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/examples/PredictionMarketSuite.scala
@@ -43,17 +43,17 @@ object PredictionMarketSuite extends SimpleIOSuite {
   private val predictionMarketMachine =
     """|{
        |  "states": {
-       |    "proposed": { "id": { "value": "proposed" }, "isFinal": false, "metadata": null },
+       |    "PROPOSED": { "id": { "value": "PROPOSED" }, "isFinal": false, "metadata": null },
        |    "open": { "id": { "value": "open" }, "isFinal": false, "metadata": null },
        |    "closed": { "id": { "value": "closed" }, "isFinal": false, "metadata": null },
        |    "resolving": { "id": { "value": "resolving" }, "isFinal": false, "metadata": null },
        |    "resolved": { "id": { "value": "resolved" }, "isFinal": true, "metadata": null },
-       |    "cancelled": { "id": { "value": "cancelled" }, "isFinal": true, "metadata": null }
+       |    "CANCELLED": { "id": { "value": "CANCELLED" }, "isFinal": true, "metadata": null }
        |  },
-       |  "initialState": { "value": "proposed" },
+       |  "initialState": { "value": "PROPOSED" },
        |  "transitions": [
        |    {
-       |      "from": { "value": "proposed" },
+       |      "from": { "value": "PROPOSED" },
        |      "to": { "value": "open" },
        |      "eventName": "fund",
        |      "guard": { "==": [1, 1] },
@@ -66,8 +66,8 @@ object PredictionMarketSuite extends SimpleIOSuite {
        |      "dependencies": []
        |    },
        |    {
-       |      "from": { "value": "proposed" },
-       |      "to": { "value": "cancelled" },
+       |      "from": { "value": "PROPOSED" },
+       |      "to": { "value": "CANCELLED" },
        |      "eventName": "cancel",
        |      "guard": { "==": [1, 1] },
        |      "effect": { "var": "state" },
@@ -289,7 +289,7 @@ object PredictionMarketSuite extends SimpleIOSuite {
         )
 
         market1 = state1.calculated.stateMachines.get(marketId)
-        _ = expect(market1.exists(_.currentState == StateId("proposed")))
+        _ = expect(market1.exists(_.currentState == StateId("PROPOSED")))
 
         // Fund market (transition to open)
         fundOp = Updates.TransitionStateMachine(

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/examples/RealEstateStateMachineSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/examples/RealEstateStateMachineSuite.scala
@@ -347,7 +347,7 @@ object RealEstateStateMachineSuite extends SimpleIOSuite {
               "guard": {
                 "or": [
                   { "===": [{ "var": "machines.${inspectionfiberId}.state.result" }, "failed"] },
-                  { "===": [{ "var": "machines.${appraisalfiberId}.state.result" }, "rejected"] },
+                  { "===": [{ "var": "machines.${appraisalfiberId}.state.result" }, "REJECTED"] },
                   { "===": [{ "var": "machines.${mortgagefiberId}.state.status" }, "denied"] }
                 ]
               },
@@ -545,17 +545,17 @@ object RealEstateStateMachineSuite extends SimpleIOSuite {
         inspectionJson =
           """{
           "states": {
-            "pending": { "id": { "value": "pending" }, "isFinal": false },
+            "PENDING": { "id": { "value": "PENDING" }, "isFinal": false },
             "scheduled": { "id": { "value": "scheduled" }, "isFinal": false },
-            "completed": { "id": { "value": "completed" }, "isFinal": false },
+            "COMPLETED": { "id": { "value": "COMPLETED" }, "isFinal": false },
             "passed": { "id": { "value": "passed" }, "isFinal": true },
             "failed": { "id": { "value": "failed" }, "isFinal": true },
             "passed_with_repairs": { "id": { "value": "passed_with_repairs" }, "isFinal": true }
           },
-          "initialState": { "value": "pending" },
+          "initialState": { "value": "PENDING" },
           "transitions": [
             {
-              "from": { "value": "pending" },
+              "from": { "value": "PENDING" },
               "to": { "value": "scheduled" },
               "eventName": "schedule",
               "guard": true,
@@ -567,18 +567,18 @@ object RealEstateStateMachineSuite extends SimpleIOSuite {
             },
             {
               "from": { "value": "scheduled" },
-              "to": { "value": "completed" },
+              "to": { "value": "COMPLETED" },
               "eventName": "complete",
               "guard": true,
               "effect": [
-                ["status", "completed"],
+                ["status", "COMPLETED"],
                 ["completedAt", { "var": "event.timestamp" }],
                 ["issues", { "var": "event.issues" }]
               ],
               "dependencies": []
             },
             {
-              "from": { "value": "completed" },
+              "from": { "value": "COMPLETED" },
               "to": { "value": "passed" },
               "eventName": "approve",
               "guard": {
@@ -591,7 +591,7 @@ object RealEstateStateMachineSuite extends SimpleIOSuite {
               "dependencies": []
             },
             {
-              "from": { "value": "completed" },
+              "from": { "value": "COMPLETED" },
               "to": { "value": "passed_with_repairs" },
               "eventName": "approve",
               "guard": {
@@ -609,7 +609,7 @@ object RealEstateStateMachineSuite extends SimpleIOSuite {
               "dependencies": []
             },
             {
-              "from": { "value": "completed" },
+              "from": { "value": "COMPLETED" },
               "to": { "value": "failed" },
               "eventName": "reject",
               "guard": {
@@ -628,16 +628,16 @@ object RealEstateStateMachineSuite extends SimpleIOSuite {
         appraisalJson =
           """{
           "states": {
-            "pending": { "id": { "value": "pending" }, "isFinal": false },
+            "PENDING": { "id": { "value": "PENDING" }, "isFinal": false },
             "ordered": { "id": { "value": "ordered" }, "isFinal": false },
-            "completed": { "id": { "value": "completed" }, "isFinal": false },
+            "COMPLETED": { "id": { "value": "COMPLETED" }, "isFinal": false },
             "approved": { "id": { "value": "approved" }, "isFinal": true },
-            "rejected": { "id": { "value": "rejected" }, "isFinal": true }
+            "REJECTED": { "id": { "value": "REJECTED" }, "isFinal": true }
           },
-          "initialState": { "value": "pending" },
+          "initialState": { "value": "PENDING" },
           "transitions": [
             {
-              "from": { "value": "pending" },
+              "from": { "value": "PENDING" },
               "to": { "value": "ordered" },
               "eventName": "order",
               "guard": true,
@@ -650,18 +650,18 @@ object RealEstateStateMachineSuite extends SimpleIOSuite {
             },
             {
               "from": { "value": "ordered" },
-              "to": { "value": "completed" },
+              "to": { "value": "COMPLETED" },
               "eventName": "complete",
               "guard": true,
               "effect": [
-                ["status", "completed"],
+                ["status", "COMPLETED"],
                 ["appraisedValue", { "var": "event.appraisedValue" }],
                 ["completedAt", { "var": "event.timestamp" }]
               ],
               "dependencies": []
             },
             {
-              "from": { "value": "completed" },
+              "from": { "value": "COMPLETED" },
               "to": { "value": "approved" },
               "eventName": "review",
               "guard": {
@@ -674,14 +674,14 @@ object RealEstateStateMachineSuite extends SimpleIOSuite {
               "dependencies": []
             },
             {
-              "from": { "value": "completed" },
-              "to": { "value": "rejected" },
+              "from": { "value": "COMPLETED" },
+              "to": { "value": "REJECTED" },
               "eventName": "review",
               "guard": {
                 "<": [{ "var": "state.appraisedValue" }, { "var": "state.expectedValue" }]
               },
               "effect": [
-                ["result", "rejected"],
+                ["result", "REJECTED"],
                 ["rejectedAt", { "var": "event.timestamp" }],
                 ["shortfall", { "-": [{ "var": "state.expectedValue" }, { "var": "state.appraisedValue" }] }]
               ],
@@ -698,7 +698,7 @@ object RealEstateStateMachineSuite extends SimpleIOSuite {
             "underwriting": { "id": { "value": "underwriting" }, "isFinal": false },
             "approved": { "id": { "value": "approved" }, "isFinal": false },
             "denied": { "id": { "value": "denied" }, "isFinal": true },
-            "active": { "id": { "value": "active" }, "isFinal": false },
+            "ACTIVE": { "id": { "value": "ACTIVE" }, "isFinal": false },
             "current": { "id": { "value": "current" }, "isFinal": false },
             "delinquent_30": { "id": { "value": "delinquent_30" }, "isFinal": false },
             "delinquent_60": { "id": { "value": "delinquent_60" }, "isFinal": false },
@@ -761,11 +761,11 @@ object RealEstateStateMachineSuite extends SimpleIOSuite {
             },
             {
               "from": { "value": "approved" },
-              "to": { "value": "active" },
+              "to": { "value": "ACTIVE" },
               "eventName": "activate",
               "guard": true,
               "effect": [
-                ["status", "active"],
+                ["status", "ACTIVE"],
                 ["originationDate", { "var": "event.closingDate" }],
                 ["servicer", { "var": "state.lender" }],
                 ["owner", { "var": "state.lender" }],
@@ -775,7 +775,7 @@ object RealEstateStateMachineSuite extends SimpleIOSuite {
               "dependencies": []
             },
             {
-              "from": { "value": "active" },
+              "from": { "value": "ACTIVE" },
               "to": { "value": "current" },
               "eventName": "first_payment",
               "guard": true,
@@ -988,17 +988,17 @@ object RealEstateStateMachineSuite extends SimpleIOSuite {
         titleJson =
           """{
           "states": {
-            "pending": { "id": { "value": "pending" }, "isFinal": false },
+            "PENDING": { "id": { "value": "PENDING" }, "isFinal": false },
             "searching": { "id": { "value": "searching" }, "isFinal": false },
             "clear": { "id": { "value": "clear" }, "isFinal": false },
             "issues_found": { "id": { "value": "issues_found" }, "isFinal": false },
             "insured": { "id": { "value": "insured" }, "isFinal": false },
             "transferred": { "id": { "value": "transferred" }, "isFinal": true }
           },
-          "initialState": { "value": "pending" },
+          "initialState": { "value": "PENDING" },
           "transitions": [
             {
-              "from": { "value": "pending" },
+              "from": { "value": "PENDING" },
               "to": { "value": "searching" },
               "eventName": "search",
               "guard": true,
@@ -1262,13 +1262,13 @@ object RealEstateStateMachineSuite extends SimpleIOSuite {
 
         inspectionData = MapValue(
           Map(
-            "status" -> StrValue("pending")
+            "status" -> StrValue("PENDING")
           )
         )
 
         appraisalData = MapValue(
           Map(
-            "status" -> StrValue("pending")
+            "status" -> StrValue("PENDING")
           )
         )
 
@@ -1280,7 +1280,7 @@ object RealEstateStateMachineSuite extends SimpleIOSuite {
 
         titleData = MapValue(
           Map(
-            "status" -> StrValue("pending")
+            "status" -> StrValue("PENDING")
           )
         )
 
@@ -1310,13 +1310,13 @@ object RealEstateStateMachineSuite extends SimpleIOSuite {
           .build[IO]
 
         inspectionFiber <- FiberBuilder(inspectionfiberId, ordinal, inspectionDef)
-          .withState("pending")
+          .withState("PENDING")
           .withDataValue(inspectionData)
           .ownedBy(registry, Dave)
           .build[IO]
 
         appraisalFiber <- FiberBuilder(appraisalfiberId, ordinal, appraisalDef)
-          .withState("pending")
+          .withState("PENDING")
           .withDataValue(appraisalData)
           .ownedBy(registry, Eve)
           .build[IO]
@@ -1328,7 +1328,7 @@ object RealEstateStateMachineSuite extends SimpleIOSuite {
           .build[IO]
 
         titleFiber <- FiberBuilder(titlefiberId, ordinal, titleDef)
-          .withState("pending")
+          .withState("PENDING")
           .withDataValue(titleData)
           .ownedBy(registry, Grace)
           .build[IO]
@@ -1646,7 +1646,7 @@ object RealEstateStateMachineSuite extends SimpleIOSuite {
         propertyStatus.contains("owned"),
         // Verify mortgage activated by trigger from property close
         mortgageAfterClose.isDefined,
-        mortgageStatus.contains("active"),
+        mortgageStatus.contains("ACTIVE"),
         // Verify mortgage is now current after first payment
         mortgageAfterFirstPayment.isDefined,
         mortgageAfterFirstPayment.map(_.currentState).contains(StateId("current")),

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/examples/RiverdaleEconomyStateMachineSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/examples/RiverdaleEconomyStateMachineSuite.scala
@@ -367,7 +367,7 @@ object RiverdaleEconomyStateMachineSuite extends SimpleIOSuite with Checkers {
           "guard": {
             "and": [
               { ">=": [{ "var": "state.stock" }, { "var": "event.quantity" }] },
-              { "===": [{ "var": "machines.$paymentProcessorfiberId.state.status" }, "active"] }
+              { "===": [{ "var": "machines.$paymentProcessorfiberId.state.status" }, "ACTIVE"] }
             ]
           },
           "effect": [
@@ -387,7 +387,7 @@ object RiverdaleEconomyStateMachineSuite extends SimpleIOSuite with Checkers {
           "guard": {
             "and": [
               { ">=": [{ "var": "state.stock" }, { "var": "event.quantity" }] },
-              { "===": [{ "var": "machines.$paymentProcessorfiberId.state.status" }, "active"] }
+              { "===": [{ "var": "machines.$paymentProcessorfiberId.state.status" }, "ACTIVE"] }
             ]
           },
           "effect": [
@@ -723,7 +723,7 @@ object RiverdaleEconomyStateMachineSuite extends SimpleIOSuite with Checkers {
   def consumerStateMachineJson(): String =
     """{
       "states": {
-        "active": { "id": { "value": "active" }, "isFinal": false },
+        "ACTIVE": { "id": { "value": "ACTIVE" }, "isFinal": false },
         "shopping": { "id": { "value": "shopping" }, "isFinal": false },
         "service_providing": { "id": { "value": "service_providing" }, "isFinal": false },
         "marketplace_selling": { "id": { "value": "marketplace_selling" }, "isFinal": false },
@@ -731,11 +731,11 @@ object RiverdaleEconomyStateMachineSuite extends SimpleIOSuite with Checkers {
         "debt_current": { "id": { "value": "debt_current" }, "isFinal": false },
         "debt_delinquent": { "id": { "value": "debt_delinquent" }, "isFinal": false }
       },
-      "initialState": { "value": "active" },
+      "initialState": { "value": "ACTIVE" },
       "transitions": [
         {
-          "from": { "value": "active" },
-          "to": { "value": "active" },
+          "from": { "value": "ACTIVE" },
+          "to": { "value": "ACTIVE" },
           "eventName": "browse_products",
           "guard": { ">=": [{ "var": "state.balance" }, { "var": "event.expectedCost" }] },
           "effect": {
@@ -756,8 +756,8 @@ object RiverdaleEconomyStateMachineSuite extends SimpleIOSuite with Checkers {
           "dependencies": []
         },
         {
-          "from": { "value": "active" },
-          "to": { "value": "active" },
+          "from": { "value": "ACTIVE" },
+          "to": { "value": "ACTIVE" },
           "eventName": "provide_service",
           "guard": { "===": [{ "var": "state.serviceType" }, { "var": "event.requestedService" }] },
           "effect": [
@@ -768,7 +768,7 @@ object RiverdaleEconomyStateMachineSuite extends SimpleIOSuite with Checkers {
           "dependencies": []
         },
         {
-          "from": { "value": "active" },
+          "from": { "value": "ACTIVE" },
           "to": { "value": "debt_current" },
           "eventName": "loan_funded",
           "guard": true,
@@ -868,7 +868,7 @@ object RiverdaleEconomyStateMachineSuite extends SimpleIOSuite with Checkers {
           "dependencies": []
         },
         {
-          "from": { "value": "active" },
+          "from": { "value": "ACTIVE" },
           "to": { "value": "marketplace_selling" },
           "eventName": "list_item",
           "guard": true,
@@ -937,14 +937,14 @@ object RiverdaleEconomyStateMachineSuite extends SimpleIOSuite with Checkers {
         },
         {
           "from": { "value": "marketplace_selling" },
-          "to": { "value": "active" },
+          "to": { "value": "ACTIVE" },
           "eventName": "sale_completed",
           "guard": true,
           "effect": [
             ["balance", { "+": [{ "var": "state.balance" }, { "var": "event.amount" }] }],
             ["activeListings", { "-": [{ "var": "state.activeListings" }, 1] }],
             ["marketplaceSales", { "+": [{ "var": "state.marketplaceSales" }, 1] }],
-            ["status", "active"]
+            ["status", "ACTIVE"]
           ],
           "dependencies": []
         },
@@ -1028,8 +1028,8 @@ object RiverdaleEconomyStateMachineSuite extends SimpleIOSuite with Checkers {
           "dependencies": []
         },
         {
-          "from": { "value": "active" },
-          "to": { "value": "active" },
+          "from": { "value": "ACTIVE" },
+          "to": { "value": "ACTIVE" },
           "eventName": "pay_taxes",
           "guard": true,
           "effect": {
@@ -1464,7 +1464,7 @@ object RiverdaleEconomyStateMachineSuite extends SimpleIOSuite with Checkers {
               "responseTime" -> IntValue(100),
               "capacity"     -> IntValue(1000),
               "transactions" -> IntValue(0),
-              "status"       -> StrValue("active")
+              "status"       -> StrValue("ACTIVE")
             )
           )
 
@@ -1499,7 +1499,7 @@ object RiverdaleEconomyStateMachineSuite extends SimpleIOSuite with Checkers {
               "missedPayments"    -> IntValue(0),
               "paymentsRemaining" -> IntValue(36),
               "taxesPaid"         -> FloatValue(0.0),
-              "status"            -> StrValue("active")
+              "status"            -> StrValue("ACTIVE")
             )
           )
 
@@ -1618,7 +1618,7 @@ object RiverdaleEconomyStateMachineSuite extends SimpleIOSuite with Checkers {
 
           // Initialize consumer fibers
           ruthFiber <- FiberBuilder(ruthfiberId, ordinal, consumerDef)
-            .withState("active")
+            .withState("ACTIVE")
             .withDataValue(
               consumerInitialData
                 .copy(value = consumerInitialData.value + ("name" -> StrValue("Ruth - Software Developer")))
@@ -1633,7 +1633,7 @@ object RiverdaleEconomyStateMachineSuite extends SimpleIOSuite with Checkers {
             )
           )
           sybilFiber <- FiberBuilder(sybilfiberId, ordinal, consumerDef)
-            .withState("active")
+            .withState("ACTIVE")
             .withDataValue(sybilInitialData)
             .ownedBy(registry, Sybil)
             .build[IO]
@@ -1645,7 +1645,7 @@ object RiverdaleEconomyStateMachineSuite extends SimpleIOSuite with Checkers {
             )
           )
           victorFiber <- FiberBuilder(victorfiberId, ordinal, consumerDef)
-            .withState("active")
+            .withState("ACTIVE")
             .withDataValue(victorInitialData)
             .ownedBy(registry, Victor)
             .build[IO]
@@ -2371,7 +2371,7 @@ object RiverdaleEconomyStateMachineSuite extends SimpleIOSuite with Checkers {
           finalNiajFiber.extractInt("transactions").exists(_ == 0),
 
           // Verify Niaj's status is still active
-          finalNiajFiber.extractString("status").contains("active"),
+          finalNiajFiber.extractString("status").contains("ACTIVE"),
 
           // Verify state transitions
           finalAliceFiber.map(_.sequenceNumber).exists(_ > FiberOrdinal.MinValue),
@@ -2518,7 +2518,7 @@ object RiverdaleEconomyStateMachineSuite extends SimpleIOSuite with Checkers {
 
           // Verify Victor still exists in active state
           finalVictorFiber.isDefined,
-          finalVictorFiber.map(_.currentState).contains(StateId("active")),
+          finalVictorFiber.map(_.currentState).contains(StateId("ACTIVE")),
 
           // ========================================
           // AUCTION 2 (VICTOR'S AUCTION) VALIDATIONS

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/examples/ScriptEscrowSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/examples/ScriptEscrowSuite.scala
@@ -42,14 +42,14 @@ object OracleEscrowSuite extends SimpleIOSuite {
         machineJson = """
         {
           "states": {
-            "pending": { "id": { "value": "pending" }, "isFinal": false, "metadata": null },
+            "PENDING": { "id": { "value": "PENDING" }, "isFinal": false, "metadata": null },
             "funded": { "id": { "value": "funded" }, "isFinal": false, "metadata": null },
             "released": { "id": { "value": "released" }, "isFinal": true, "metadata": null }
           },
-          "initialState": { "value": "pending" },
+          "initialState": { "value": "PENDING" },
           "transitions": [
             {
-              "from": { "value": "pending" },
+              "from": { "value": "PENDING" },
               "to": { "value": "funded" },
               "eventName": "fund",
               "guard": { "==": [1, 1] },
@@ -160,15 +160,15 @@ object OracleEscrowSuite extends SimpleIOSuite {
         machineJson = """
         {
           "states": {
-            "pending": { "id": { "value": "pending" }, "isFinal": false, "metadata": null },
+            "PENDING": { "id": { "value": "PENDING" }, "isFinal": false, "metadata": null },
             "funded": { "id": { "value": "funded" }, "isFinal": false, "metadata": null },
             "released": { "id": { "value": "released" }, "isFinal": true, "metadata": null },
             "refunded": { "id": { "value": "refunded" }, "isFinal": true, "metadata": null }
           },
-          "initialState": { "value": "pending" },
+          "initialState": { "value": "PENDING" },
           "transitions": [
             {
-              "from": { "value": "pending" },
+              "from": { "value": "PENDING" },
               "to": { "value": "funded" },
               "eventName": "fund",
               "guard": { "==": [1, 1] },

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/examples/TicTacToeGameSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/examples/TicTacToeGameSuite.scala
@@ -36,7 +36,7 @@ object TicTacToeGameSuite extends SimpleIOSuite {
       "setup": { "id": {"value": "setup"}, "isFinal": false },
       "playing": { "id": {"value": "playing"}, "isFinal": false },
       "finished": { "id": {"value": "finished"}, "isFinal": true },
-      "cancelled": { "id": {"value": "cancelled"}, "isFinal": true }
+      "CANCELLED": { "id": {"value": "CANCELLED"}, "isFinal": true }
     },
     "initialState": {"value": "setup"},
     "transitions": [
@@ -149,7 +149,7 @@ object TicTacToeGameSuite extends SimpleIOSuite {
       },
       {
         "from": {"value": "playing"},
-        "to": {"value": "cancelled"},
+        "to": {"value": "CANCELLED"},
         "eventName": "cancel_game",
         "guard": {"==": [1, 1]},
         "effect": {
@@ -168,7 +168,7 @@ object TicTacToeGameSuite extends SimpleIOSuite {
       },
       {
         "from": {"value": "setup"},
-        "to": {"value": "cancelled"},
+        "to": {"value": "CANCELLED"},
         "eventName": "cancel_game",
         "guard": {"==": [1, 1]},
         "effect": {

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/examples/TokenEscrowSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/examples/TokenEscrowSuite.scala
@@ -40,15 +40,15 @@ object TokenEscrowSuite extends SimpleIOSuite {
         machineJson = """
         {
           "states": {
-            "pending": { "id": { "value": "pending" }, "isFinal": false, "metadata": null },
+            "PENDING": { "id": { "value": "PENDING" }, "isFinal": false, "metadata": null },
             "funded": { "id": { "value": "funded" }, "isFinal": false, "metadata": null },
             "released": { "id": { "value": "released" }, "isFinal": true, "metadata": null },
             "refunded": { "id": { "value": "refunded" }, "isFinal": true, "metadata": null }
           },
-          "initialState": { "value": "pending" },
+          "initialState": { "value": "PENDING" },
           "transitions": [
             {
-              "from": { "value": "pending" },
+              "from": { "value": "PENDING" },
               "to": { "value": "funded" },
               "eventName": "fund",
               "guard": { "==": [1, 1] },
@@ -150,15 +150,15 @@ object TokenEscrowSuite extends SimpleIOSuite {
         machineJson = """
         {
           "states": {
-            "pending": { "id": { "value": "pending" }, "isFinal": false, "metadata": null },
+            "PENDING": { "id": { "value": "PENDING" }, "isFinal": false, "metadata": null },
             "funded": { "id": { "value": "funded" }, "isFinal": false, "metadata": null },
             "released": { "id": { "value": "released" }, "isFinal": true, "metadata": null },
             "refunded": { "id": { "value": "refunded" }, "isFinal": true, "metadata": null }
           },
-          "initialState": { "value": "pending" },
+          "initialState": { "value": "PENDING" },
           "transitions": [
             {
-              "from": { "value": "pending" },
+              "from": { "value": "PENDING" },
               "to": { "value": "funded" },
               "eventName": "fund",
               "guard": { "==": [1, 1] },
@@ -240,15 +240,15 @@ object TokenEscrowSuite extends SimpleIOSuite {
         machineJson = """
         {
           "states": {
-            "pending": { "id": { "value": "pending" }, "isFinal": false, "metadata": null },
+            "PENDING": { "id": { "value": "PENDING" }, "isFinal": false, "metadata": null },
             "funded": { "id": { "value": "funded" }, "isFinal": false, "metadata": null },
             "released": { "id": { "value": "released" }, "isFinal": true, "metadata": null },
             "refunded": { "id": { "value": "refunded" }, "isFinal": true, "metadata": null }
           },
-          "initialState": { "value": "pending" },
+          "initialState": { "value": "PENDING" },
           "transitions": [
             {
-              "from": { "value": "pending" },
+              "from": { "value": "PENDING" },
               "to": { "value": "funded" },
               "eventName": "fund",
               "guard": { "==": [1, 1] },

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/examples/VotingSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/examples/VotingSuite.scala
@@ -40,14 +40,14 @@ object VotingSuite extends SimpleIOSuite {
         machineJson = """
         {
           "states": {
-            "pending": { "id": { "value": "pending" }, "isFinal": false, "metadata": null },
+            "PENDING": { "id": { "value": "PENDING" }, "isFinal": false, "metadata": null },
             "voting": { "id": { "value": "voting" }, "isFinal": false, "metadata": null },
-            "completed": { "id": { "value": "completed" }, "isFinal": true, "metadata": null }
+            "COMPLETED": { "id": { "value": "COMPLETED" }, "isFinal": true, "metadata": null }
           },
-          "initialState": { "value": "pending" },
+          "initialState": { "value": "PENDING" },
           "transitions": [
             {
-              "from": { "value": "pending" },
+              "from": { "value": "PENDING" },
               "to": { "value": "voting" },
               "eventName": "startVoting",
               "guard": { "==": [1, 1] },
@@ -56,7 +56,7 @@ object VotingSuite extends SimpleIOSuite {
             },
             {
               "from": { "value": "voting" },
-              "to": { "value": "completed" },
+              "to": { "value": "COMPLETED" },
               "eventName": "endVoting",
               "guard": { "==": [1, 1] },
               "effect": { "var": "state" },
@@ -104,7 +104,7 @@ object VotingSuite extends SimpleIOSuite {
           .collect { case r: Records.StateMachineFiberRecord => r }
 
       } yield expect(finalMachine.isDefined) and
-      expect(finalMachine.map(_.currentState).contains(StateId("completed")))
+      expect(finalMachine.map(_.currentState).contains(StateId("COMPLETED")))
     }
   }
 

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/testkit/FiberBuilder.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/testkit/FiberBuilder.scala
@@ -30,7 +30,7 @@ import xyz.kd5ujc.shared_test.Participant.ParticipantRegistry
  *
  * // With pre-built MapValue:
  * val fiber <- FiberBuilder(fiberId, ordinal, definition)
- *   .withState("active")
+ *   .withState("ACTIVE")
  *   .withDataValue(myMapValue)
  *   .withOwners(Set(aliceAddr, bobAddr))
  *   .build[IO]

--- a/sdk/bootstrap-currency.js
+++ b/sdk/bootstrap-currency.js
@@ -1,0 +1,42 @@
+// Bootstrap script to kickstart CL1 block production
+const { dag4 } = require('@stardust-collective/dag4');
+
+const SEED_PHRASE = 'right off artist rare copy zebra shuffle excite evidence mercy isolate raise';
+const DEST_ADDRESS = 'DAG87hragrbzrEQEz6VC5B7hvtm4wAemS7Zg8KFj';
+
+async function main() {
+  const cl1Url = process.argv[2] || 'http://localhost:9300';
+  const gl0Url = process.argv[3] || 'http://localhost:9000';
+  
+  console.log(`Connecting to CL1: ${cl1Url}`);
+  console.log(`Connecting to GL0: ${gl0Url}`);
+  
+  dag4.account.connect({
+    networkVersion: '2.0',
+    l0Url: gl0Url,
+    l1Url: cl1Url,
+  });
+  
+  await dag4.account.loginSeedPhrase(SEED_PHRASE);
+  console.log(`Wallet: ${dag4.account.address}`);
+  
+  // Get balance from GL0
+  try {
+    const balance = await dag4.network.getAddressBalance(dag4.account.address);
+    console.log(`Balance: ${balance?.balance || 0}`);
+  } catch (e) {
+    console.log(`Balance check failed: ${e.message}`);
+  }
+  
+  // Send transaction
+  console.log(`Sending 1 DATUM to ${DEST_ADDRESS}...`);
+  try {
+    const txHash = await dag4.account.transferDag(DEST_ADDRESS, 1, 0);
+    console.log(`Transaction hash: ${JSON.stringify(txHash)}`);
+    console.log('\nWait ~30s for CL1 to produce a currency block...');
+  } catch (e) {
+    console.log(`Transaction failed: ${e.message}`);
+  }
+}
+
+main().catch(console.error);

--- a/sdk/send-dag-tx.js
+++ b/sdk/send-dag-tx.js
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+// Quick script to send a DAG transaction to kickstart CL1 block production
+// This unblocks DL1 nodes stuck in SessionStarted state
+
+const { dag4 } = require('@stardust-collective/dag4');
+
+// Test wallet from tessellation genesis.csv
+const FIRST_WALLET_SEED_PHRASE = 'right off artist rare copy zebra shuffle excite evidence mercy isolate raise';
+const SECOND_WALLET_ADDRESS = 'DAG87hragrbzrEQEz6VC5B7hvtm4wAemS7Zg8KFj';
+
+async function main() {
+  const cl1Url = process.argv[2] || 'http://localhost:9300';
+  
+  console.log(`Connecting to CL1 at ${cl1Url}`);
+  
+  // Initialize dag4 with CL1 endpoint
+  dag4.account.connect({
+    networkVersion: '2.0',
+    l1Url: cl1Url,
+  });
+  
+  // Login with seed phrase
+  await dag4.account.loginSeedPhrase(FIRST_WALLET_SEED_PHRASE);
+  console.log(`Logged in as: ${dag4.account.address}`);
+  
+  // Check balance
+  const balance = await dag4.account.getBalance();
+  console.log(`Balance: ${balance}`);
+  
+  // Send a small transaction
+  const amount = 1; // 1 DATUM (smallest unit)
+  const fee = 0;
+  
+  console.log(`Sending ${amount} DATUM to ${SECOND_WALLET_ADDRESS}...`);
+  
+  const txHash = await dag4.account.transferDag(SECOND_WALLET_ADDRESS, amount, fee);
+  console.log(`Transaction sent! Hash: ${txHash}`);
+  
+  console.log('\nThis should trigger CL1 block production, which creates currency snapshots for ML0.');
+  console.log('DL1 nodes should then be able to transition from SessionStarted to ReadyToJoin.');
+}
+
+main().catch(err => {
+  console.error('Error:', err.message);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Implements multi-party transition signing for OttoChain fibers, allowing contract counterparties to sign fiber state transitions alongside or instead of the fiber owner.

Trello: [[A2] Tests: Multi-Party Transition Signing](https://trello.com/c/699ce20f68cda20522dc3c05)

---

## Changes

### Schema (`modules/models`)
- `Updates.CreateStateMachine`: add optional `participants` field (set of addresses authorized to sign transitions)
- `Records.StateMachineFiberRecord`: add `authorizedSigners` field (populated from participants at creation time)

### Validation (`modules/shared-data`)
- `FiberRules.L0`: add `updateSignedByOwnerOrParticipant` rule — accepts signatures from either owner OR authorized signers
- `FiberValidator.L0Validator.processEvent`: use relaxed signer check (owner OR participant)
- Archive remains owner-only (strict) — participants cannot archive

### Combiner (`modules/shared-data`)
- `FiberCombiner`: populate `authorizedSigners` from `participants` at creation time

### Tests
11 new integration tests in `MultiPartySigningSuite`:

| Group | Tests |
|-------|-------|
| T1: Backward Compatibility | single-owner works, non-owner rejected, archive still owner-only |
| T2: Multi-Party Transitions | participant can transition, any-of-N works, non-participant rejected, owner still works |
| T3: Record Fields | authorizedSigners populated correctly, empty when no participants |
| T4: Integration | two-party contract lifecycle, owner-also-participant no double-counting |

All 11 tests pass. All 257 existing tests continue to pass.

---

## Testing

```bash
sbt "sharedData/testOnly *MultiPartySigningSuite"
# Passed: Total 11, Failed 0, Errors 0, Passed 11
```

---

## Notes

- This PR combines A2 (TDD tests) and A3 (implementation) since both were developed together on the branch
- Backward compatible: existing fibers with no `participants` behave identically to before
- Archive is intentionally kept owner-only for security