### PR TITLE
fix(docker): pass --l0-token-identifier to ML0 validators

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -214,9 +214,15 @@ case "${LAYER,,}" in
       fi
     fi
     
-    # Token ID for L1 layers only (CL1, DL1) — ML0 doesn't accept --l0-token-identifier
-    if [ "${LAYER,,}" != "ml0" ] && [ -n "${CL_TOKEN_ID}" ]; then
-      ARGS="${ARGS} --l0-token-identifier ${CL_TOKEN_ID}"
+    # Token ID for metagraph layers
+    # ML0 run-genesis does NOT accept --l0-token-identifier, but run-validator REQUIRES it.
+    # CL1/DL1 always need it.
+    if [ -n "${CL_TOKEN_ID}" ]; then
+      if [ "${LAYER,,}" = "ml0" ] && [ "${RUN_MODE}" = "run-genesis" ]; then
+        echo "Skipping --l0-token-identifier for ML0 genesis mode"
+      else
+        ARGS="${ARGS} --l0-token-identifier ${CL_TOKEN_ID}"
+      fi
     fi
     ;;
 esac


### PR DESCRIPTION
## Problem

PR #136 fixed the ML0 genesis crash by removing `--l0-token-identifier` for ML0. But this overcorrected — ML0 `run-validator` **requires** the flag. Without it:

```
Missing expected flag --l0-token-identifier, or environment variable (CL_L0_TOKEN_IDENTIFIER)!
```

This caused the March 12 scratch deploy failure: node 1 (genesis) worked fine, nodes 2+3 (validators) crash-looped.

## Root Cause

| Mode | Needs --l0-token-identifier? |
|------|------------------------------|
| ML0 run-genesis | ❌ No (crashes if present) |
| ML0 run-validator | ✅ Yes (crashes if absent) |
| ML0 run-rollback | ✅ Yes |
| CL1/DL1 (all modes) | ✅ Yes |

v0.7.9 passed it to all metagraph layers → worked.
v0.7.12 (#136) removed it for all ML0 modes → broke validators.

## Fix

Only skip the flag for `ML0 run-genesis`. All other modes receive it.