### PR TITLE
test(e2e): versionable-contracts lifecycle (registry/schema/fiber) [WIP]

### DIFF
--- a/.github/templates/actions/metagraph/data_l1/initial_validator/action.yml
+++ b/.github/templates/actions/metagraph/data_l1/initial_validator/action.yml
@@ -33,6 +33,8 @@ runs:
         CL_P2P_HTTP_PORT: ${{ inputs.CL_P2P_HTTP_PORT }}
         CL_CLI_HTTP_PORT: ${{ inputs.CL_CLI_HTTP_PORT }}
         CL_APP_ENV: dev
+        # 3 DL1 nodes -> peers-count = N-1 = 2 so every data round includes ALL nodes (no stale lingering copy)
+        DATA_PEERS_COUNT: "2"
         CL_COLLATERAL: 0
         CL_GLOBAL_L0_PEER_HTTP_HOST: 127.0.0.1
         CL_GLOBAL_L0_PEER_HTTP_PORT: ${{ inputs.CL_GLOBAL_L0_PEER_HTTP_PORT }}

--- a/.github/templates/actions/metagraph/data_l1/validator/action.yml
+++ b/.github/templates/actions/metagraph/data_l1/validator/action.yml
@@ -37,6 +37,8 @@ runs:
         CL_P2P_HTTP_PORT: ${{ inputs.CL_P2P_HTTP_PORT }}
         CL_CLI_HTTP_PORT: ${{ inputs.CL_CLI_HTTP_PORT }}
         CL_APP_ENV: dev
+        # 3 DL1 nodes -> peers-count = N-1 = 2 so every data round includes ALL nodes (no stale lingering copy)
+        DATA_PEERS_COUNT: "2"
         CL_COLLATERAL: 0
         CL_GLOBAL_L0_PEER_HTTP_HOST: 127.0.0.1
         CL_GLOBAL_L0_PEER_HTTP_PORT: ${{ inputs.CL_GLOBAL_L0_PEER_HTTP_PORT }}

--- a/e2e-test/examples/versionable-lifecycle/event-confirm.json
+++ b/e2e-test/examples/versionable-lifecycle/event-confirm.json
@@ -1,0 +1,4 @@
+{
+  "eventName": "confirm",
+  "payload": {}
+}

--- a/e2e-test/examples/versionable-lifecycle/event-expedite.json
+++ b/e2e-test/examples/versionable-lifecycle/event-expedite.json
@@ -1,0 +1,4 @@
+{
+  "eventName": "expedite",
+  "payload": {}
+}

--- a/e2e-test/examples/versionable-lifecycle/event-ship.json
+++ b/e2e-test/examples/versionable-lifecycle/event-ship.json
@@ -1,0 +1,4 @@
+{
+  "eventName": "ship",
+  "payload": { "trackingNumber": "TRK-1Z999AA10123456784" }
+}

--- a/e2e-test/examples/versionable-lifecycle/example.ts
+++ b/e2e-test/examples/versionable-lifecycle/example.ts
@@ -53,8 +53,10 @@ export default {
         { action: 'publishVersion', name: 'rejects.package', version: '1.0.0', definition: 'order-v1.definition.json', schemaShape: 'order-v1.schema.json' },
         // reserved label -> DL1 structural reject (HTTP 400)
         { action: 'publishVersion', name: 'std.package', version: '1.0.0', definition: 'order-v1.definition.json', schemaShape: 'order-v1.schema.json', expectRejected: 'dl1' },
-        // non-monotonic: re-publish an existing/older version -> ML0 stateful reject, lineage unchanged
-        { action: 'publishVersion', name: 'rejects.package', version: '1.0.0', definition: 'order-v1.definition.json', schemaShape: 'order-v1.schema.json', expectRejected: 'ml0' },
+        // non-monotonic: publish a LOWER version than the current max -> ML0 stateful reject. Use 0.9.0
+        // (NOT already in the lineage) so "did not land" is observable — re-publishing the existing 1.0.0
+        // is indistinguishable from idempotence since it is already present.
+        { action: 'publishVersion', name: 'rejects.package', version: '0.9.0', definition: 'order-v1.definition.json', schemaShape: 'order-v1.schema.json', expectRejected: 'ml0' },
       ],
     },
   ],

--- a/e2e-test/examples/versionable-lifecycle/example.ts
+++ b/e2e-test/examples/versionable-lifecycle/example.ts
@@ -1,0 +1,61 @@
+/**
+ * Versionable-contracts lifecycle e2e.
+ *
+ * Exercises the full registry / schema / fiber lifecycle on a SELF-CONTAINED state machine
+ * (an order machine — no script coupling, so it is a clean reusable package):
+ *   publish v1 + v2  ->  verified-bound create  ->  transition  ->  UPGRADE across schema versions
+ *   (with a migration)  ->  v2-only transition  ->  deprecate v1  ->  alias  ->  archive.
+ *
+ * Plus the negative cases that demonstrate the validation split:
+ *   - reserved name        -> rejected at DL1 (structural)          -> HTTP 400 on submit
+ *   - non-monotonic version-> rejected at ML0 (stateful)            -> state unchanged
+ *   - non-owner publish    -> rejected at ML0 (stateful)            -> state unchanged
+ *   - upgrade hash-mismatch-> rejected at ML0 (verified-binding)    -> fiber stays on v1
+ *
+ * Step fields consumed by the runner (see runner.ts):
+ *   publishVersion   : { name, version, definition, schemaShape, strict?, metadata? }
+ *   setVersionStatus : { name, version, status }
+ *   registerAlias    : { name }                      (targetFiberId = the session fiber)
+ *   createStateMachine: { definition, initialData, schemaRef?: { name, version } }
+ *   upgradeFiber     : { targetRef: { name, version }, newDefinition, migration? }
+ *   processEvent     : { event, expectedState? }
+ *   archiveStateMachine: { }
+ * Negative steps add { expectRejected: 'dl1' | 'ml0' } and the runner asserts the rejection
+ * instead of success (HTTP 400 for 'dl1'; op-did-not-apply for 'ml0').
+ */
+const PKG = 'order.package';
+
+export default {
+  name: 'Versionable Lifecycle',
+  description: 'Registry publish/version, verified-bound fiber, upgrade across schema versions, status, alias, archive',
+  type: 'state-machine',
+  testFlows: [
+    {
+      name: 'order package v1 to v2 lifecycle',
+      description: 'Publish two versions, bind a fiber to v1, upgrade it across schema versions, then deprecate/alias/archive',
+      steps: [
+        { action: 'publishVersion', name: PKG, version: '1.0.0', definition: 'order-v1.definition.json', schemaShape: 'order-v1.schema.json' },
+        { action: 'publishVersion', name: PKG, version: '2.0.0', definition: 'order-v2.definition.json', schemaShape: 'order-v2.schema.json' },
+        { action: 'createStateMachine', definition: 'order-v1.definition.json', initialData: 'initial-data.json', schemaRef: { name: PKG, version: '1.0.0' } },
+        { action: 'processEvent', event: 'event-confirm.json', expectedState: 'confirmed' },
+        { action: 'upgradeFiber', targetRef: { name: PKG, version: '2.0.0' }, newDefinition: 'order-v2.definition.json', migration: 'migration-v1-to-v2.json' },
+        { action: 'processEvent', event: 'event-expedite.json', expectedState: 'confirmed' },
+        { action: 'processEvent', event: 'event-ship.json', expectedState: 'shipped' },
+        { action: 'setVersionStatus', name: PKG, version: '1.0.0', status: 'DEPRECATED' },
+        { action: 'registerAlias', name: 'my-order.machine' },
+        { action: 'archiveStateMachine' },
+      ],
+    },
+    {
+      name: 'registry rejections',
+      description: 'Structural reject at DL1; stateful rejects at ML0 leave state unchanged',
+      steps: [
+        { action: 'publishVersion', name: 'rejects.package', version: '1.0.0', definition: 'order-v1.definition.json', schemaShape: 'order-v1.schema.json' },
+        // reserved label -> DL1 structural reject (HTTP 400)
+        { action: 'publishVersion', name: 'std.package', version: '1.0.0', definition: 'order-v1.definition.json', schemaShape: 'order-v1.schema.json', expectRejected: 'dl1' },
+        // non-monotonic: re-publish an existing/older version -> ML0 stateful reject, lineage unchanged
+        { action: 'publishVersion', name: 'rejects.package', version: '1.0.0', definition: 'order-v1.definition.json', schemaShape: 'order-v1.schema.json', expectRejected: 'ml0' },
+      ],
+    },
+  ],
+};

--- a/e2e-test/examples/versionable-lifecycle/initial-data.json
+++ b/e2e-test/examples/versionable-lifecycle/initial-data.json
@@ -1,0 +1,5 @@
+{
+  "orderId": "ORD-1",
+  "customer": "alice@example.com",
+  "total": 100
+}

--- a/e2e-test/examples/versionable-lifecycle/migration-v1-to-v2.json
+++ b/e2e-test/examples/versionable-lifecycle/migration-v1-to-v2.json
@@ -1,0 +1,3 @@
+{
+  "merge": [{ "var": "" }, { "priority": "standard" }]
+}

--- a/e2e-test/examples/versionable-lifecycle/order-v1.definition.json
+++ b/e2e-test/examples/versionable-lifecycle/order-v1.definition.json
@@ -1,0 +1,44 @@
+{
+  "states": {
+    "pending": { "id": "pending" },
+    "confirmed": { "id": "confirmed" },
+    "shipped": { "id": "shipped" },
+    "delivered": { "id": "delivered", "isFinal": true },
+    "cancelled": { "id": "cancelled", "isFinal": true }
+  },
+  "initialState": "pending",
+  "transitions": [
+    {
+      "from": "pending",
+      "to": "confirmed",
+      "eventName": "confirm",
+      "guard": { "==": [1, 1] },
+      "effect": {},
+      "dependencies": []
+    },
+    {
+      "from": "confirmed",
+      "to": "shipped",
+      "eventName": "ship",
+      "guard": { "==": [1, 1] },
+      "effect": { "trackingNumber": { "var": "event.trackingNumber" } },
+      "dependencies": []
+    },
+    {
+      "from": "shipped",
+      "to": "delivered",
+      "eventName": "deliver",
+      "guard": { "==": [1, 1] },
+      "effect": { "deliveredAt": { "var": "event.timestamp" } },
+      "dependencies": []
+    },
+    {
+      "from": "pending",
+      "to": "cancelled",
+      "eventName": "cancel",
+      "guard": { "==": [1, 1] },
+      "effect": { "cancelReason": { "var": "event.reason" } },
+      "dependencies": []
+    }
+  ]
+}

--- a/e2e-test/examples/versionable-lifecycle/order-v1.definition.json
+++ b/e2e-test/examples/versionable-lifecycle/order-v1.definition.json
@@ -1,8 +1,8 @@
 {
   "states": {
-    "pending": { "id": "pending" },
-    "confirmed": { "id": "confirmed" },
-    "shipped": { "id": "shipped" },
+    "pending": { "id": "pending", "isFinal": false },
+    "confirmed": { "id": "confirmed", "isFinal": false },
+    "shipped": { "id": "shipped", "isFinal": false },
     "delivered": { "id": "delivered", "isFinal": true },
     "cancelled": { "id": "cancelled", "isFinal": true }
   },

--- a/e2e-test/examples/versionable-lifecycle/order-v1.schema.json
+++ b/e2e-test/examples/versionable-lifecycle/order-v1.schema.json
@@ -2,18 +2,18 @@
   "stateMessage": {
     "typeName": "Order",
     "fields": [
-      { "name": "orderId", "number": 1, "typeName": "string" },
-      { "name": "customer", "number": 2, "typeName": "string" },
-      { "name": "total", "number": 3, "typeName": "int64" },
-      { "name": "trackingNumber", "number": 4, "typeName": "string", "optional": true },
-      { "name": "deliveredAt", "number": 5, "typeName": "string", "optional": true },
-      { "name": "cancelReason", "number": 6, "typeName": "string", "optional": true }
+      { "name": "orderId", "number": 1, "typeName": "string", "repeated": false, "optional": false },
+      { "name": "customer", "number": 2, "typeName": "string", "repeated": false, "optional": false },
+      { "name": "total", "number": 3, "typeName": "int64", "repeated": false, "optional": false },
+      { "name": "trackingNumber", "number": 4, "typeName": "string", "repeated": false, "optional": true },
+      { "name": "deliveredAt", "number": 5, "typeName": "string", "repeated": false, "optional": true },
+      { "name": "cancelReason", "number": 6, "typeName": "string", "repeated": false, "optional": true }
     ]
   },
   "commands": {
     "confirm": { "typeName": "Confirm", "fields": [] },
-    "ship": { "typeName": "Ship", "fields": [{ "name": "trackingNumber", "number": 1, "typeName": "string" }] },
-    "deliver": { "typeName": "Deliver", "fields": [{ "name": "timestamp", "number": 1, "typeName": "string" }] },
-    "cancel": { "typeName": "Cancel", "fields": [{ "name": "reason", "number": 1, "typeName": "string" }] }
+    "ship": { "typeName": "Ship", "fields": [{ "name": "trackingNumber", "number": 1, "typeName": "string", "repeated": false, "optional": false }] },
+    "deliver": { "typeName": "Deliver", "fields": [{ "name": "timestamp", "number": 1, "typeName": "string", "repeated": false, "optional": false }] },
+    "cancel": { "typeName": "Cancel", "fields": [{ "name": "reason", "number": 1, "typeName": "string", "repeated": false, "optional": false }] }
   }
 }

--- a/e2e-test/examples/versionable-lifecycle/order-v1.schema.json
+++ b/e2e-test/examples/versionable-lifecycle/order-v1.schema.json
@@ -1,0 +1,19 @@
+{
+  "stateMessage": {
+    "typeName": "Order",
+    "fields": [
+      { "name": "orderId", "number": 1, "typeName": "string" },
+      { "name": "customer", "number": 2, "typeName": "string" },
+      { "name": "total", "number": 3, "typeName": "int64" },
+      { "name": "trackingNumber", "number": 4, "typeName": "string", "optional": true },
+      { "name": "deliveredAt", "number": 5, "typeName": "string", "optional": true },
+      { "name": "cancelReason", "number": 6, "typeName": "string", "optional": true }
+    ]
+  },
+  "commands": {
+    "confirm": { "typeName": "Confirm", "fields": [] },
+    "ship": { "typeName": "Ship", "fields": [{ "name": "trackingNumber", "number": 1, "typeName": "string" }] },
+    "deliver": { "typeName": "Deliver", "fields": [{ "name": "timestamp", "number": 1, "typeName": "string" }] },
+    "cancel": { "typeName": "Cancel", "fields": [{ "name": "reason", "number": 1, "typeName": "string" }] }
+  }
+}

--- a/e2e-test/examples/versionable-lifecycle/order-v2.definition.json
+++ b/e2e-test/examples/versionable-lifecycle/order-v2.definition.json
@@ -1,8 +1,8 @@
 {
   "states": {
-    "pending": { "id": "pending" },
-    "confirmed": { "id": "confirmed" },
-    "shipped": { "id": "shipped" },
+    "pending": { "id": "pending", "isFinal": false },
+    "confirmed": { "id": "confirmed", "isFinal": false },
+    "shipped": { "id": "shipped", "isFinal": false },
     "delivered": { "id": "delivered", "isFinal": true },
     "cancelled": { "id": "cancelled", "isFinal": true }
   },

--- a/e2e-test/examples/versionable-lifecycle/order-v2.definition.json
+++ b/e2e-test/examples/versionable-lifecycle/order-v2.definition.json
@@ -1,0 +1,52 @@
+{
+  "states": {
+    "pending": { "id": "pending" },
+    "confirmed": { "id": "confirmed" },
+    "shipped": { "id": "shipped" },
+    "delivered": { "id": "delivered", "isFinal": true },
+    "cancelled": { "id": "cancelled", "isFinal": true }
+  },
+  "initialState": "pending",
+  "transitions": [
+    {
+      "from": "pending",
+      "to": "confirmed",
+      "eventName": "confirm",
+      "guard": { "==": [1, 1] },
+      "effect": {},
+      "dependencies": []
+    },
+    {
+      "from": "confirmed",
+      "to": "confirmed",
+      "eventName": "expedite",
+      "guard": { "==": [1, 1] },
+      "effect": { "priority": "express" },
+      "dependencies": []
+    },
+    {
+      "from": "confirmed",
+      "to": "shipped",
+      "eventName": "ship",
+      "guard": { "==": [1, 1] },
+      "effect": { "trackingNumber": { "var": "event.trackingNumber" } },
+      "dependencies": []
+    },
+    {
+      "from": "shipped",
+      "to": "delivered",
+      "eventName": "deliver",
+      "guard": { "==": [1, 1] },
+      "effect": { "deliveredAt": { "var": "event.timestamp" } },
+      "dependencies": []
+    },
+    {
+      "from": "pending",
+      "to": "cancelled",
+      "eventName": "cancel",
+      "guard": { "==": [1, 1] },
+      "effect": { "cancelReason": { "var": "event.reason" } },
+      "dependencies": []
+    }
+  ]
+}

--- a/e2e-test/examples/versionable-lifecycle/order-v2.schema.json
+++ b/e2e-test/examples/versionable-lifecycle/order-v2.schema.json
@@ -1,0 +1,21 @@
+{
+  "stateMessage": {
+    "typeName": "Order",
+    "fields": [
+      { "name": "orderId", "number": 1, "typeName": "string" },
+      { "name": "customer", "number": 2, "typeName": "string" },
+      { "name": "total", "number": 3, "typeName": "int64" },
+      { "name": "trackingNumber", "number": 4, "typeName": "string", "optional": true },
+      { "name": "deliveredAt", "number": 5, "typeName": "string", "optional": true },
+      { "name": "cancelReason", "number": 6, "typeName": "string", "optional": true },
+      { "name": "priority", "number": 7, "typeName": "string" }
+    ]
+  },
+  "commands": {
+    "confirm": { "typeName": "Confirm", "fields": [] },
+    "expedite": { "typeName": "Expedite", "fields": [] },
+    "ship": { "typeName": "Ship", "fields": [{ "name": "trackingNumber", "number": 1, "typeName": "string" }] },
+    "deliver": { "typeName": "Deliver", "fields": [{ "name": "timestamp", "number": 1, "typeName": "string" }] },
+    "cancel": { "typeName": "Cancel", "fields": [{ "name": "reason", "number": 1, "typeName": "string" }] }
+  }
+}

--- a/e2e-test/examples/versionable-lifecycle/order-v2.schema.json
+++ b/e2e-test/examples/versionable-lifecycle/order-v2.schema.json
@@ -2,20 +2,20 @@
   "stateMessage": {
     "typeName": "Order",
     "fields": [
-      { "name": "orderId", "number": 1, "typeName": "string" },
-      { "name": "customer", "number": 2, "typeName": "string" },
-      { "name": "total", "number": 3, "typeName": "int64" },
-      { "name": "trackingNumber", "number": 4, "typeName": "string", "optional": true },
-      { "name": "deliveredAt", "number": 5, "typeName": "string", "optional": true },
-      { "name": "cancelReason", "number": 6, "typeName": "string", "optional": true },
-      { "name": "priority", "number": 7, "typeName": "string" }
+      { "name": "orderId", "number": 1, "typeName": "string", "repeated": false, "optional": false },
+      { "name": "customer", "number": 2, "typeName": "string", "repeated": false, "optional": false },
+      { "name": "total", "number": 3, "typeName": "int64", "repeated": false, "optional": false },
+      { "name": "trackingNumber", "number": 4, "typeName": "string", "repeated": false, "optional": true },
+      { "name": "deliveredAt", "number": 5, "typeName": "string", "repeated": false, "optional": true },
+      { "name": "cancelReason", "number": 6, "typeName": "string", "repeated": false, "optional": true },
+      { "name": "priority", "number": 7, "typeName": "string", "repeated": false, "optional": false }
     ]
   },
   "commands": {
     "confirm": { "typeName": "Confirm", "fields": [] },
     "expedite": { "typeName": "Expedite", "fields": [] },
-    "ship": { "typeName": "Ship", "fields": [{ "name": "trackingNumber", "number": 1, "typeName": "string" }] },
-    "deliver": { "typeName": "Deliver", "fields": [{ "name": "timestamp", "number": 1, "typeName": "string" }] },
-    "cancel": { "typeName": "Cancel", "fields": [{ "name": "reason", "number": 1, "typeName": "string" }] }
+    "ship": { "typeName": "Ship", "fields": [{ "name": "trackingNumber", "number": 1, "typeName": "string", "repeated": false, "optional": false }] },
+    "deliver": { "typeName": "Deliver", "fields": [{ "name": "timestamp", "number": 1, "typeName": "string", "repeated": false, "optional": false }] },
+    "cancel": { "typeName": "Cancel", "fields": [{ "name": "reason", "number": 1, "typeName": "string", "repeated": false, "optional": false }] }
   }
 }

--- a/e2e-test/lib/registry/publishVersion.ts
+++ b/e2e-test/lib/registry/publishVersion.ts
@@ -1,0 +1,75 @@
+import fs from 'fs';
+import path from 'path';
+import type {
+  OttochainMessage,
+  PublishVersion,
+  SchemaShape,
+  StateMachineDefinition,
+  CalculatedState,
+} from '@ottochain/sdk/core';
+import type { StatesMap } from '../types.ts';
+
+/**
+ * Publish (create-or-append) a registry schema-package version (#23/#26).
+ *
+ * - `name`        full "labels.tld" (e.g. "order.package"); the chain derives the routing id (not on wire).
+ * - `version`     SemVer string "MAJOR.MINOR.PATCH".
+ * - `schemaB64`   base64 of the proto FileDescriptorSet. The chain only base64-validates + hashes it, then
+ *                 DROPS the bytes — a deterministic placeholder is fine for the e2e.
+ * - `schemaShape` the typed proto projection (advisory).
+ * - `definition`  the StateMachineDefinition — hashed into `logicHash`; a fiber verified-binds to this.
+ */
+export interface PublishVersionOptions {
+  name: string;
+  version: string;
+  definition: string | StateMachineDefinition;
+  schemaShape: string | SchemaShape;
+  schemaB64?: string;
+  strict?: boolean;
+  metadata?: Record<string, string>;
+}
+
+function loadMaybe<T>(v: string | T): T {
+  if (typeof v === 'string') {
+    const p = path.resolve(v);
+    if (!fs.existsSync(p)) throw new Error(`File not found: ${p}`);
+    const parsed: T = JSON.parse(fs.readFileSync(p, 'utf8'));
+    return parsed;
+  }
+  return v;
+}
+
+export const generator = ({ options }: { cid?: string; wallets?: unknown; options: PublishVersionOptions }): OttochainMessage => {
+  const msg: PublishVersion = {
+    name: options.name,
+    version: options.version,
+    schemaB64: options.schemaB64 ?? Buffer.from(`descriptor:${options.name}:${options.version}`).toString('base64'),
+    schemaShape: loadMaybe<SchemaShape>(options.schemaShape),
+    definition: loadMaybe<StateMachineDefinition>(options.definition),
+    ...(options.strict !== undefined ? { strict: options.strict } : {}),
+    ...(options.metadata ? { metadata: options.metadata } : {}),
+  };
+  return { PublishVersion: msg };
+};
+
+export const validator = ({ statesMap, options }: { cid?: string; statesMap: StatesMap; options: PublishVersionOptions; wallets?: unknown }) => {
+  for (const [url, { final }] of Object.entries(statesMap)) {
+    const state = (final as { state?: CalculatedState } | null)?.state;
+    const entry = state?.registry?.[options.name];
+    if (!entry) {
+      throw new Error(`\x1b[33m[publishVersion.validator]\x1b[0m no registry entry for "${options.name}" at ${url}`);
+    }
+    // RegistryTarget double-nesting: target.SchemaPackage.versions (VersionLineage) .versions (the SemVer map)
+    const target = entry.target as { SchemaPackage?: { versions?: { versions?: Record<string, unknown> } } };
+    const versions = target?.SchemaPackage?.versions?.versions;
+    if (!versions || !(options.version in versions)) {
+      throw new Error(
+        `\x1b[33m[publishVersion.validator]\x1b[0m version ${options.version} not in lineage for "${options.name}" at ${url} (have: ${versions ? Object.keys(versions).join(',') : 'none'})`
+      );
+    }
+    if (!Array.isArray(entry.owner) || entry.owner.length === 0) {
+      throw new Error(`\x1b[33m[publishVersion.validator]\x1b[0m entry "${options.name}" has no owner at ${url}`);
+    }
+    console.log(`\x1b[33m[publishVersion.validator]\x1b[32m ${options.name}@${options.version} registered (owner set) at ${url}\x1b[0m`);
+  }
+};

--- a/e2e-test/lib/registry/publishVersion.ts
+++ b/e2e-test/lib/registry/publishVersion.ts
@@ -46,7 +46,9 @@ export const generator = ({ options }: { cid?: string; wallets?: unknown; option
     schemaB64: options.schemaB64 ?? Buffer.from(`descriptor:${options.name}:${options.version}`).toString('base64'),
     schemaShape: loadMaybe<SchemaShape>(options.schemaShape),
     definition: loadMaybe<StateMachineDefinition>(options.definition),
-    ...(options.strict !== undefined ? { strict: options.strict } : {}),
+    // `strict` is required on the chain (no default) — always send it so the signed canonical matches
+    // what the chain re-derives. `metadata` is Option (omit-safe), so it stays conditional.
+    strict: options.strict ?? false,
     ...(options.metadata ? { metadata: options.metadata } : {}),
   };
   return { PublishVersion: msg };

--- a/e2e-test/lib/registry/registerAlias.ts
+++ b/e2e-test/lib/registry/registerAlias.ts
@@ -1,0 +1,40 @@
+import type { OttochainMessage, RegisterAlias, CalculatedState } from '@ottochain/sdk/core';
+import type { StatesMap } from '../types.ts';
+
+/**
+ * Register a human-readable nickname for an existing fiber (#29). The name's TLD must match the target
+ * fiber's kind (.machine -> state machine, .script -> script); the signer must own the target fiber. Sets
+ * the forward alias (name -> fiber) and the fiber's canonical reverse record (fiber -> name).
+ */
+export interface RegisterAliasOptions {
+  name: string;
+  targetFiberId: string;
+  metadata?: Record<string, string>;
+}
+
+export const generator = ({ options }: { cid?: string; wallets?: unknown; options: RegisterAliasOptions }): OttochainMessage => {
+  const msg: RegisterAlias = {
+    name: options.name,
+    targetFiberId: options.targetFiberId,
+    ...(options.metadata ? { metadata: options.metadata } : {}),
+  };
+  return { RegisterAlias: msg };
+};
+
+export const validator = ({ statesMap, options }: { cid?: string; statesMap: StatesMap; options: RegisterAliasOptions; wallets?: unknown }) => {
+  for (const [url, { final }] of Object.entries(statesMap)) {
+    const state = (final as { state?: CalculatedState } | null)?.state;
+    // Forward: the alias name now resolves to an entry.
+    if (!state?.registry?.[options.name]) {
+      throw new Error(`\x1b[33m[registerAlias.validator]\x1b[0m forward alias "${options.name}" missing at ${url}`);
+    }
+    // Reverse: the fiber's canonical name (#29) points back at this alias.
+    const reverse = state?.reverseNames?.[options.targetFiberId];
+    if (reverse !== options.name) {
+      throw new Error(
+        `\x1b[33m[registerAlias.validator]\x1b[0m reverse record for ${options.targetFiberId} = "${reverse}" (expected "${options.name}") at ${url}`
+      );
+    }
+    console.log(`\x1b[33m[registerAlias.validator]\x1b[32m alias "${options.name}" <-> ${options.targetFiberId} (forward + reverse) at ${url}\x1b[0m`);
+  }
+};

--- a/e2e-test/lib/registry/setVersionStatus.ts
+++ b/e2e-test/lib/registry/setVersionStatus.ts
@@ -1,0 +1,36 @@
+import type { OttochainMessage, SetVersionStatus, RegistryStatus, CalculatedState } from '@ottochain/sdk/core';
+import type { StatesMap } from '../types.ts';
+
+/**
+ * Change a registered version's lifecycle status (Active <-> Deprecated -> Yanked). Owner-gated (#26).
+ * `status` is the uppercase RegistryStatus enum: "ACTIVE" | "DEPRECATED" | "YANKED".
+ */
+export interface SetVersionStatusOptions {
+  name: string;
+  version: string;
+  status: RegistryStatus;
+}
+
+export const generator = ({ options }: { cid?: string; wallets?: unknown; options: SetVersionStatusOptions }): OttochainMessage => {
+  const msg: SetVersionStatus = { name: options.name, version: options.version, status: options.status };
+  return { SetVersionStatus: msg };
+};
+
+export const validator = ({ statesMap, options }: { cid?: string; statesMap: StatesMap; options: SetVersionStatusOptions; wallets?: unknown }) => {
+  for (const [url, { final }] of Object.entries(statesMap)) {
+    const state = (final as { state?: CalculatedState } | null)?.state;
+    const target = state?.registry?.[options.name]?.target as
+      | { SchemaPackage?: { versions?: { versions?: Record<string, { status?: string }> } } }
+      | undefined;
+    const rv = target?.SchemaPackage?.versions?.versions?.[options.version];
+    if (!rv) {
+      throw new Error(`\x1b[33m[setVersionStatus.validator]\x1b[0m ${options.name}@${options.version} not found at ${url}`);
+    }
+    if (rv.status !== options.status) {
+      throw new Error(
+        `\x1b[33m[setVersionStatus.validator]\x1b[0m expected status ${options.status} but found ${rv.status} for ${options.name}@${options.version} at ${url}`
+      );
+    }
+    console.log(`\x1b[33m[setVersionStatus.validator]\x1b[32m ${options.name}@${options.version} -> ${options.status} at ${url}\x1b[0m`);
+  }
+};

--- a/e2e-test/lib/script/createScript.ts
+++ b/e2e-test/lib/script/createScript.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import type { OttochainMessage } from '@ottochain/sdk';
+import type { OttochainMessage } from '@ottochain/sdk/core';
 import type { StatesMap } from '../types.ts';
 
 export interface CreateOracleOptions {
@@ -30,10 +30,11 @@ export const generator = ({ cid, options }: { cid: string; wallets?: unknown; op
   }
 
   // Build the CreateScript message.
-  // Note: since metakit 1.8.0 the server DROPS null object fields before
-  // canonicalizing (JsonBinaryCodec.dropNulls), and sendDataTransaction
-  // applies the SDK's dropNulls before signing to match. An explicit
-  // "initialState": null here is therefore equivalent to omitting the field.
+  // metakit drops null object fields before canonicalizing (JsonBinaryCodec.dropNulls), and
+  // sendDataTransaction applies the same dropNulls before signing — so an explicit
+  // "initialState": null is equivalent to omitting it (the field is dropped before the signature
+  // is computed either way). The `?? null` below is just an explicit default, not a signing
+  // requirement.
   const createMsg: Record<string, unknown> = {
     fiberId: cid,
     scriptProgram: oracleDefinition.scriptProgram,

--- a/e2e-test/lib/script/invokeScript.ts
+++ b/e2e-test/lib/script/invokeScript.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import type { OttochainMessage } from '@ottochain/sdk';
+import type { OttochainMessage } from '@ottochain/sdk/core';
 import type { StatesMap } from '../types.ts';
 import { validateOracleLogs } from '../validateLogs.ts';
 

--- a/e2e-test/lib/sendDataTransaction.ts
+++ b/e2e-test/lib/sendDataTransaction.ts
@@ -8,14 +8,6 @@ import type { KeyPair } from '@ottochain/sdk';
  * Uses the SDK's batchSign (RFC 8785 canonicalize → DataUpdate sign)
  * to produce a Signed<T> with one proof per wallet, then submits to all
  * DL1 nodes.
- *
- * IMPORTANT: null object fields are dropped from the message BEFORE signing
- * (and the null-free value is what gets submitted). Since metakit 1.8.0 the
- * node's `serializeUpdate` drops null object fields before canonicalizing
- * (JsonBinaryCodec.dropNulls), so signatures must be computed over the same
- * null-free canonical form or the DL1 rejects every update with HTTP 400
- * (InvalidSignature). Pinned by the Scala-side
- * E2eSignedPayloadCompatSuite (modules/shared-data).
  */
 export default async function sendSignedUpdate(
   message: unknown,
@@ -24,11 +16,12 @@ export default async function sendSignedUpdate(
 ): Promise<{ hash: string }[]> {
   const privateKeys = Object.values(wallets).map((w) => w.privateKey);
 
-  // Match the node's canonical form: metakit drops null object fields
-  // before hashing/verifying, so we must sign (and send) the null-free value.
-  const cleaned = dropNulls(message);
-
-  const signed = await batchSign(cleaned, privateKeys, { isDataUpdate: true });
+  // Drop null fields before signing. metakit (rc.9) drops nulls when building the canonical
+  // bytes the chain signs/verifies, so the client must sign the same null-free form. Otherwise a
+  // message carrying a null (e.g. a state's `metadata: null` in a state-machine definition) is
+  // signed over a different canonical than the chain re-derives, and verification fails (HTTP 400) —
+  // which is why state-machine creates failed while null-free scripts passed.
+  const signed = await batchSign(dropNulls(message), privateKeys, { isDataUpdate: true });
 
   console.log(
     `\x1b[33m[sendDataTransaction]\x1b[36m Sending to DL1:\x1b[0m ${JSON.stringify(signed).substring(0, 200)}...`
@@ -57,17 +50,29 @@ export default async function sendSignedUpdate(
     return fulfilled.map((r) => r.value);
   }
 
+  // Surface the dl1's actual rejection: HttpClient throws a NetworkError carrying `statusCode` and
+  // `response` (the raw response body). Log status + body per node (even when empty) and fold them into
+  // the thrown error so the runner's "Failed flows" output shows WHY, not just "HTTP 400: Bad Request".
   const errorMessages = responses
-    .map((r) => {
+    .map((r, i) => {
       if (r.status === 'rejected') {
-        const err = r.reason as Error & { response?: string };
-        if (err.response) {
-          console.log(`\x1b[33m[sendDataTransaction]\x1b[31m Error response body:\x1b[0m ${err.response}`);
-        }
-        return err.message;
+        const err = (r.reason ?? {}) as { message?: string; statusCode?: number; response?: unknown };
+        const url = dl1Urls[i];
+        const status = err.statusCode ?? '?';
+        const body =
+          err.response === undefined || err.response === null || err.response === ''
+            ? '(empty body)'
+            : typeof err.response === 'string'
+              ? err.response
+              : JSON.stringify(err.response);
+        console.log(
+          `\x1b[33m[sendDataTransaction]\x1b[31m ${url} -> HTTP ${status}:\x1b[0m ${body} ${err.message ? `(${err.message})` : ''}`
+        );
+        return `${url} HTTP ${status}: ${body}`;
       }
       return '';
     })
-    .join('; ');
-  throw new Error(`All requests failed. Errors: ${errorMessages}`);
+    .filter(Boolean)
+    .join(' | ');
+  throw new Error(`All requests failed: ${errorMessages}`);
 }

--- a/e2e-test/lib/state-machine/archiveFiber.ts
+++ b/e2e-test/lib/state-machine/archiveFiber.ts
@@ -1,10 +1,16 @@
-import type { OttochainMessage } from '@ottochain/sdk';
+import type { OttochainMessage } from '@ottochain/sdk/core';
 import type { StatesMap } from '../types.ts';
 
-export const generator = ({ cid }: { cid: string }): OttochainMessage => {
+export interface ArchiveFiberOptions {
+  targetSequenceNumber?: number;
+}
+
+export const generator = ({ cid, options }: { cid: string; wallets?: unknown; options?: ArchiveFiberOptions }): OttochainMessage => {
   return {
     ArchiveStateMachine: {
       fiberId: cid,
+      // ArchiveStateMachine is Sequenced — the chain requires the fiber's current sequence number.
+      targetSequenceNumber: options?.targetSequenceNumber ?? 0,
     },
   };
 };

--- a/e2e-test/lib/state-machine/createFiber.ts
+++ b/e2e-test/lib/state-machine/createFiber.ts
@@ -1,12 +1,14 @@
 import fs from 'fs';
 import path from 'path';
-import type { CreateStateMachine, OttochainMessage } from '@ottochain/sdk';
+import type { CreateStateMachine, OttochainMessage } from '@ottochain/sdk/core';
 import type { StatesMap } from '../types.ts';
 
 export interface CreateFiberOptions {
   definition: string | object;
   initialData: string | object;
   parentFiberId?: string;
+  /** Verified-binding reference: bind the new fiber to a registered package version (#37). */
+  schemaRef?: { name: string; version: string };
 }
 
 export const generator = ({ cid, options }: { cid: string; wallets?: unknown; options: CreateFiberOptions }): OttochainMessage => {
@@ -38,6 +40,11 @@ export const generator = ({ cid, options }: { cid: string; wallets?: unknown; op
     definition: definition as CreateStateMachine['definition'],
     initialData,
     parentFiberId: options.parentFiberId ?? null,
+    // Bind to a registered version (verified binding): definition.computeDigest must equal the
+    // registered logicHash, else the chain rejects at ML0 combine. version uses VersionReq.Exact.
+    ...(options.schemaRef
+      ? { schemaRef: { name: options.schemaRef.name, version: { Exact: { version: options.schemaRef.version } } } }
+      : {}),
   };
 
   return { CreateStateMachine: msg };

--- a/e2e-test/lib/state-machine/processEvent.ts
+++ b/e2e-test/lib/state-machine/processEvent.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import type { TransitionStateMachine, OttochainMessage } from '@ottochain/sdk';
+import type { TransitionStateMachine, OttochainMessage } from '@ottochain/sdk/core';
 import type { StatesMap } from '../types.ts';
 import { validateEventLogs } from '../validateLogs.ts';
 

--- a/e2e-test/lib/state-machine/upgradeFiber.ts
+++ b/e2e-test/lib/state-machine/upgradeFiber.ts
@@ -1,0 +1,69 @@
+import fs from 'fs';
+import path from 'path';
+import type {
+  OttochainMessage,
+  UpgradeFiber,
+  SchemaRef,
+  StateMachineDefinition,
+  JsonLogicExpression,
+  CalculatedState,
+} from '@ottochain/sdk/core';
+import type { StatesMap } from '../types.ts';
+
+/**
+ * Upgrade an existing fiber to a different registered version of the SAME package (#27).
+ *
+ * The chain verifies `newDefinition.computeDigest == targetVersion.logicHash` (verified re-bind),
+ * applies the optional `migration` (a JSON-Logic transform of the prior stateData; the output BECOMES
+ * the new state — see FiberEngine.migrate), preserves the current state id (must exist in the new
+ * definition), and re-pins the binding. `migration` omitted = identity (state unchanged).
+ */
+export interface UpgradeFiberOptions {
+  targetRef: { name: string; version: string };
+  newDefinition: string | StateMachineDefinition;
+  migration?: string | JsonLogicExpression;
+  targetSequenceNumber?: number;
+}
+
+function loadMaybe<T>(v: string | T): T {
+  if (typeof v === 'string') {
+    const p = path.resolve(v);
+    if (!fs.existsSync(p)) throw new Error(`File not found: ${p}`);
+    const parsed: T = JSON.parse(fs.readFileSync(p, 'utf8'));
+    return parsed;
+  }
+  return v;
+}
+
+export const generator = ({ cid, options }: { cid: string; wallets?: unknown; options: UpgradeFiberOptions }): OttochainMessage => {
+  const targetRef: SchemaRef = {
+    name: options.targetRef.name,
+    version: { Exact: { version: options.targetRef.version } },
+  };
+  const msg: UpgradeFiber = {
+    fiberId: cid,
+    targetRef,
+    newDefinition: loadMaybe<StateMachineDefinition>(options.newDefinition),
+    targetSequenceNumber: options.targetSequenceNumber ?? 0,
+    ...(options.migration !== undefined ? { migration: loadMaybe<JsonLogicExpression>(options.migration) } : {}),
+  };
+  return { UpgradeFiber: msg };
+};
+
+export const validator = ({ cid, statesMap, options }: { cid: string; statesMap: StatesMap; options: UpgradeFiberOptions; wallets?: unknown }) => {
+  for (const [url, { final }] of Object.entries(statesMap)) {
+    const fiber = (final as { state?: CalculatedState } | null)?.state?.stateMachines?.[cid];
+    if (!fiber) {
+      throw new Error(`\x1b[33m[upgradeFiber.validator]\x1b[0m no fiber ${cid} at ${url}`);
+    }
+    const binding = fiber.schemaBinding;
+    if (binding?.name !== options.targetRef.name || binding?.version !== options.targetRef.version) {
+      throw new Error(
+        `\x1b[33m[upgradeFiber.validator]\x1b[0m fiber ${cid} not re-bound to ${options.targetRef.name}@${options.targetRef.version} (binding=${JSON.stringify(binding)}) at ${url}`
+      );
+    }
+    console.log(
+      `\x1b[33m[upgradeFiber.validator]\x1b[32m fiber ${cid} re-bound to ${options.targetRef.name}@${options.targetRef.version} at ${url}\x1b[0m`
+    );
+  }
+};

--- a/e2e-test/runner.ts
+++ b/e2e-test/runner.ts
@@ -407,6 +407,71 @@ async function runFlow(
       let message: unknown;
       let stepOptions: Record<string, unknown>;
 
+      // ---- Registry ops (publishVersion / setVersionStatus / registerAlias) ----
+      // Non-sequenced: confirm via /registry/{name}; no seq number or DL1-fiberCommit sync.
+      const REGISTRY_LIBS: Record<string, string> = {
+        publishVersion: './lib/registry/publishVersion.ts',
+        setVersionStatus: './lib/registry/setVersionStatus.ts',
+        registerAlias: './lib/registry/registerAlias.ts',
+      };
+      if (REGISTRY_LIBS[step.action]) {
+        const regLib = await import(REGISTRY_LIBS[step.action]);
+        const regName = step.name as string;
+        const regOptions: Record<string, unknown> = {
+          ...step,
+          targetFiberId: (step.targetFiberId as string) ?? session.cid,
+          ...(step.definition ? { definition: path.join(examplesDir, example.dir, step.definition) } : {}),
+          ...(step.schemaShape ? { schemaShape: path.join(examplesDir, example.dir, step.schemaShape as string) } : {}),
+        };
+        const regMessage = regLib.generator({ cid: session.cid, wallets, options: regOptions });
+        const regPath = `registry/${encodeURIComponent(regName)}`;
+        // Did the op land in the registry? (per-action predicate on the /registry/{name} response)
+        const landed = (d: unknown): boolean => {
+          const e = d as { target?: { SchemaPackage?: { versions?: { versions?: Record<string, { status?: string }> } } } } | null;
+          const vs = e?.target?.SchemaPackage?.versions?.versions;
+          if (step.action === 'publishVersion') return !!vs && (step.version as string) in vs;
+          if (step.action === 'setVersionStatus') return vs?.[step.version as string]?.status === step.status;
+          return e != null; // registerAlias
+        };
+
+        if (step.expectRejected === 'dl1') {
+          // Structural reject (e.g. reserved name) -> the /data POST should fail with HTTP 400.
+          let rejected = false;
+          try {
+            await sendSignedUpdate(regMessage, wallets, dl1Urls);
+          } catch (err) {
+            rejected = (err as Error).message.includes('400');
+          }
+          if (!rejected) throw new Error(`expected DL1 to reject ${step.action} ${regName} (HTTP 400), but it was accepted`);
+          l(' \x1b[32mOK (DL1 rejected)\x1b[0m');
+          continue;
+        }
+        if (step.expectRejected === 'ml0') {
+          // Admitted by DL1 (structurally valid) but rejected at ML0 combine -> never lands.
+          await sendSignedUpdate(regMessage, wallets, dl1Urls).catch(() => undefined);
+          const client = new HttpClient(`${ml0Urls[0]}/data-application/v1/${regPath}`);
+          for (let attempt = 0; attempt < 8; attempt++) {
+            await new Promise((r) => setTimeout(r, retryDelayMs));
+            let data: unknown = null;
+            try {
+              data = await client.get<unknown>('');
+            } catch {
+              /* entry may not exist — fine */
+            }
+            if (landed(data)) throw new Error(`expected ML0 to reject ${step.action} ${regName}, but it landed`);
+          }
+          l(' \x1b[32mOK (ML0 rejected, state unchanged)\x1b[0m');
+          continue;
+        }
+
+        const regInitial = await getInitialStates(ml0Env);
+        await sendSignedUpdate(regMessage, wallets, dl1Urls);
+        await waitForMl0Confirmation(ml0Urls[0], regPath, landed, maxRetries, retryDelayMs, `${step.action} ${regName}`, log);
+        await validateWithRetries(regLib.validator, session.cid, regInitial, regOptions, wallets, maxRetries, retryDelayMs, ml0Urls);
+        l(' \x1b[32mOK\x1b[0m');
+        continue;
+      }
+
       const loadContext = {
         wallets,
         session,
@@ -458,7 +523,8 @@ async function runFlow(
             loadContext
           );
 
-          stepOptions = { definition, initialData };
+          // schemaRef (optional) binds the new fiber to a registered package version (verified binding).
+          stepOptions = { definition, initialData, schemaRef: step.schemaRef };
 
           const libModule = await import('./lib/state-machine/createFiber.ts');
           generator = libModule.generator;
@@ -551,6 +617,33 @@ async function runFlow(
           break;
         }
 
+        case 'upgradeFiber': {
+          // Upgrade the session fiber to another registered version of the same package (#27),
+          // optionally migrating prior state. Sequenced: bumps the fiber's sequence number.
+          stepOptions = {
+            targetRef: step.targetRef,
+            newDefinition: path.join(examplesDir, example.dir, step.newDefinition as string),
+            ...(step.migration ? { migration: path.join(examplesDir, example.dir, step.migration as string) } : {}),
+            targetSequenceNumber: preSendSeqNum >= 0 ? preSendSeqNum : 0,
+          };
+          const libModule = await import('./lib/state-machine/upgradeFiber.ts');
+          generator = libModule.generator;
+          validator = libModule.validator;
+          message = generator({ cid: session.cid, wallets, options: stepOptions });
+          break;
+        }
+
+        case 'archiveStateMachine': {
+          // Sequenced, but archive flips status to ARCHIVED without bumping the sequence number
+          // (see the confirmation predicate below, which special-cases this).
+          stepOptions = { targetSequenceNumber: preSendSeqNum >= 0 ? preSendSeqNum : 0 };
+          const libModule = await import('./lib/state-machine/archiveFiber.ts');
+          generator = libModule.generator;
+          validator = libModule.validator;
+          message = generator({ cid: session.cid, wallets, options: stepOptions });
+          break;
+        }
+
         default:
           throw new Error(`Unknown action: ${step.action}`);
       }
@@ -632,7 +725,11 @@ async function runFlow(
           if (isCreateStep) {
             return record.status === 'ACTIVE';
           }
-          // For transitions/invocations: sequenceNumber must have increased
+          // Archive flips status to ARCHIVED without bumping the sequence number.
+          if (step.action === 'archiveStateMachine') {
+            return record.status === 'ARCHIVED';
+          }
+          // For transitions/invocations/upgrades: sequenceNumber must have increased
           return (record.sequenceNumber ?? -1) > preSendSeqNum;
         },
         resubmit: async () => {

--- a/modules/data_l1/src/main/resources/dag-l1.conf
+++ b/modules/data_l1/src/main/resources/dag-l1.conf
@@ -9,7 +9,11 @@ consensus {
 }
 
 data-consensus {
+  # peers-count is facilitators-besides-self per data round. With N DL1 nodes set this to N-1 so EVERY round
+  # includes ALL nodes — otherwise a node left out of a round keeps its copy of an applied update, which goes
+  # stale and poisons later blocks (a single Invalid tx fails the whole block; see Validator.scala notes).
   peers-count = 1
+  peers-count = ${?DATA_PEERS_COUNT}
   timeout = 10 seconds
   max-data-updates-to-dequeue = 50
 }

--- a/modules/l0/src/main/scala/xyz/kd5ujc/metagraph_l0/ML0CustomRoutes.scala
+++ b/modules/l0/src/main/scala/xyz/kd5ujc/metagraph_l0/ML0CustomRoutes.scala
@@ -17,6 +17,7 @@ import xyz.kd5ujc.metagraph_l0.webhooks.{SubscribeRequest, SubscribeResponse, Su
 import xyz.kd5ujc.schema.Updates.OttochainMessage
 import xyz.kd5ujc.schema.fiber.FiberLogEntry.{EventReceipt, OracleInvocation}
 import xyz.kd5ujc.schema.fiber.{AuditRenderer, FiberStatus}
+import xyz.kd5ujc.schema.registry.RegistryName
 import xyz.kd5ujc.schema.{CalculatedState, OnChain}
 
 import io.circe.Json
@@ -130,6 +131,33 @@ class ML0CustomRoutes[F[_]: Async](
             .collect { case i: OracleInvocation => i }
         })
         .toResponse
+
+    // =========================================================================
+    // Registry Endpoints — schema-package + alias lifecycle (discovery / e2e assertions)
+    // =========================================================================
+
+    // All registry entries: name -> RegistryEntry (target = schema-package version lineage, or alias).
+    case GET -> Root / "registry" =>
+      checkpointService.get.map { case Checkpoint(_, state) =>
+        state.registry.asRight[DataApplicationValidationError]
+      }.toResponse
+
+    // Reverse record (#29): fiber UUID -> its canonical registered name. Declared before the
+    // by-name route; arity differs so there is no ambiguity, but keep the specific path first.
+    case GET -> Root / "registry" / "reverse" / UUIDVar(fiberId) =>
+      checkpointService.get.map { case Checkpoint(_, state) =>
+        state.reverseNames.get(fiberId).asRight[DataApplicationValidationError]
+      }.toResponse
+
+    // A single entry by full `labels.tld` name (e.g. `counter.package`, `my-counter.machine`).
+    case GET -> Root / "registry" / nameStr =>
+      checkpointService.get.map { case Checkpoint(_, state) =>
+        RegistryName
+          .from(nameStr)
+          .toOption
+          .flatMap(state.registry.get)
+          .asRight[DataApplicationValidationError]
+      }.toResponse
 
     // =========================================================================
     // Webhook Management Endpoints

--- a/modules/models/src/main/scala/xyz/kd5ujc/schema/Updates.scala
+++ b/modules/models/src/main/scala/xyz/kd5ujc/schema/Updates.scala
@@ -148,9 +148,9 @@ object Updates {
     schemaB64:   String,
     schemaShape: SchemaShape,
     definition:  StateMachineDefinition,
-    strict:      Boolean = false,
-    // Optional off-chain links grab-bag, set on the entry at first publish (e.g. "repo"/"homepage" -> URL).
-    metadata: SortedMap[String, String] = SortedMap.empty
+    strict:      Boolean,
+    // Optional off-chain links grab-bag (None == omitted), set on the entry at first publish.
+    metadata: Option[SortedMap[String, String]] = None
   ) extends RegistryOp
       with OttochainMessage {
     val fiberId: UUID = RegistryOp.routingId(name)
@@ -176,7 +176,7 @@ object Updates {
   final case class RegisterAlias(
     name:          RegistryName,
     targetFiberId: UUID,
-    metadata:      SortedMap[String, String] = SortedMap.empty
+    metadata:      Option[SortedMap[String, String]] = None
   ) extends RegistryOp
       with OttochainMessage {
     val fiberId: UUID = RegistryOp.routingId(name)

--- a/modules/models/src/main/scala/xyz/kd5ujc/schema/registry/SchemaShape.scala
+++ b/modules/models/src/main/scala/xyz/kd5ujc/schema/registry/SchemaShape.scala
@@ -24,8 +24,8 @@ final case class FieldShape(
   name:     String,
   number:   Int,
   typeName: String,
-  repeated: Boolean = false,
-  optional: Boolean = false
+  repeated: Boolean,
+  optional: Boolean
 )
 
 @derive(customizableEncoder, customizableDecoder)

--- a/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/Combiner.scala
+++ b/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/Combiner.scala
@@ -15,6 +15,8 @@ import xyz.kd5ujc.shared_data.lifecycle.combine.{CombineRejected, FiberCombiner,
 import xyz.kd5ujc.shared_data.lifecycle.validate.Limits
 import xyz.kd5ujc.shared_data.syntax.all._
 
+import org.typelevel.log4cats.slf4j.Slf4jLogger
+
 /**
  * Entry point for creating a CombinerService.
  *
@@ -72,6 +74,11 @@ object Combiner {
         // `previous` state. Any other failure (non-deterministic / infrastructure) propagates and aborts — by
         // design, so a transient local error never becomes divergent committed state across nodes.
         dispatched.recoverWith { case CombineRejected(reason) =>
+          Slf4jLogger
+            .getLogger[F]
+            .warn(
+              s"[combine-reject] ${update.value.getClass.getSimpleName} fiberId=${update.value.fiberId} reason=$reason"
+            ) >>
           ctx.getCurrentOrdinal.map { ordinal =>
             previous.appendLogs(
               List(

--- a/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/Validator.scala
+++ b/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/Validator.scala
@@ -124,7 +124,18 @@ object Validator {
         )(implicit context: L0NodeContext[F]): F[DataApplicationValidationErrorOr[Unit]] = {
           val fiberCombined = new FiberValidator.CombinedValidator[F](current, signedUpdate.proofs)
           val oracleCombined = new ScriptValidator.CombinedValidator[F](current, signedUpdate.proofs)
-          val registryCombined = new RegistryValidator.CombinedValidator[F](current, signedUpdate.proofs)
+
+          // Registry ops use L1 (structural) validation ONLY here, NOT the L0 contextual preview.
+          // The L0 checks (ownership, monotonic version) need the CalculatedState version lineage, which the
+          // DL1 cannot see (OnChain.registryCommits is name->hash, no lineage) — so a stale/non-monotonic
+          // publish that is still in flight CANNOT be rejected at L1. If we ran the L0 preview here, a
+          // now-stale registry update (valid when its DL1 block formed, stale by the time ML0 re-validates)
+          // would return Invalid and the framework rejects the ENTIRE block (all-or-nothing), dropping valid
+          // updates batched with it. The RegistryCombiner is the AUTHORITATIVE stateful gate and already
+          // rejects gracefully (CombineRejected -> RejectionReceipt, #154), so deferring stateful rejection
+          // to combine keeps consensus state correct while not poisoning blocks. (TOCTOU-safe; the framework
+          // partial-block-accept fix is the real solution, deferred.)
+          val registryL1 = new RegistryValidator.L1Validator[F]
 
           signedUpdate.value match {
             case u: CreateStateMachine     => fiberCombined.createFiber(u)
@@ -133,9 +144,9 @@ object Validator {
             case u: UpgradeFiber           => fiberCombined.upgrade(u)
             case u: CreateScript           => oracleCombined.createOracle(u)
             case u: InvokeScript           => oracleCombined.invokeOracle(u)
-            case u: PublishVersion         => registryCombined.publish(u)
-            case u: SetVersionStatus       => registryCombined.setStatus(u)
-            case u: RegisterAlias          => registryCombined.registerAlias(u)
+            case u: PublishVersion         => registryL1.publish(u)
+            case u: SetVersionStatus       => registryL1.setStatus(u)
+            case u: RegisterAlias          => registryL1.registerAlias(u)
           }
         }
 

--- a/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/combine/RegistryCombiner.scala
+++ b/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/combine/RegistryCombiner.scala
@@ -17,6 +17,8 @@ import xyz.kd5ujc.schema.registry._
 import xyz.kd5ujc.schema.{CalculatedState, OnChain, Updates}
 import xyz.kd5ujc.shared_data.syntax.all._
 
+import org.typelevel.log4cats.slf4j.Slf4jLogger
+
 /**
  * Combiner for the registry. The chain enforces structural invariants — append-only / immutable /
  * strictly-monotonic via [[VersionLineage]], ownership, and a descriptor size bound — and never PARSES the
@@ -98,6 +100,7 @@ class RegistryCombiner[F[_]: Async: SecurityProvider](
             }
       }
       result <- current.withRegistryEntry[F](pv.name, updatedEntry)
+      _      <- Slf4jLogger.getLogger[F].info(s"[registry-publish] applied ${pv.name.render}@${pv.version.render}")
     } yield result
   }
 

--- a/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/combine/RegistryCombiner.scala
+++ b/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/combine/RegistryCombiner.scala
@@ -5,6 +5,8 @@ import java.util.UUID
 import cats.effect.Async
 import cats.syntax.all._
 
+import scala.collection.immutable.SortedMap
+
 import io.constellationnetwork.currency.dataApplication.{DataState, L0NodeContext}
 import io.constellationnetwork.metagraph_sdk.std.JsonBinaryHasher.HasherOps
 import io.constellationnetwork.schema.address.Address
@@ -48,7 +50,7 @@ class RegistryCombiner[F[_]: Async: SecurityProvider](
         )
         .whenA(pv.schemaB64.length.toLong > maxBundleBytes)
       _ <- RegistryMetadata
-        .validate(pv.metadata)
+        .validate(pv.metadata.getOrElse(SortedMap.empty[String, String]))
         .fold(
           e => Async[F].raiseError[Unit](CombineRejected(s"invalid metadata for ${pv.name.render}: $e")),
           _ => Async[F].unit
@@ -73,7 +75,7 @@ class RegistryCombiner[F[_]: Async: SecurityProvider](
             pv.name,
             signers,
             RegistryTarget.SchemaPackage(VersionLineage.of(rv)),
-            pv.metadata
+            pv.metadata.getOrElse(SortedMap.empty[String, String])
           ): RegistryEntry).pure[F]
         case Some(entry) =>
           if (!signers.exists(entry.owner.contains))
@@ -143,7 +145,7 @@ class RegistryCombiner[F[_]: Async: SecurityProvider](
         .raiseError[Unit](CombineRejected(s"alias name ${ra.name.render} uses a reserved label"))
         .whenA(RegistryName.isReserved(ra.name))
       _ <- RegistryMetadata
-        .validate(ra.metadata)
+        .validate(ra.metadata.getOrElse(SortedMap.empty[String, String]))
         .fold(
           e => Async[F].raiseError[Unit](CombineRejected(s"invalid metadata for ${ra.name.render}: $e")),
           _ => Async[F].unit

--- a/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/validate/RegistryValidator.scala
+++ b/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/validate/RegistryValidator.scala
@@ -30,7 +30,7 @@ object RegistryValidator {
         shapeOk      <- RegistryRules.L1.schemaShapeWellFormed(update.schemaShape)
         bundleOk     <- RegistryRules.L1.bundleWithinLimit(update)
         reservedOk   <- RegistryRules.L1.notReserved(update.name)
-        metaOk       <- RegistryRules.L1.metadataConforms(update.metadata)
+        metaOk       <- RegistryRules.L1.metadataConforms(update.metadata.getOrElse(Map.empty[String, String]))
         definitionOk <- FiberRules.L1.validStateMachineDefinition(update.definition)
         limitsOk     <- FiberRules.L1.definitionWithinLimits(update.definition)
       } yield List(schemaOk, shapeOk, bundleOk, reservedOk, metaOk, definitionOk, limitsOk).combineAll
@@ -44,7 +44,7 @@ object RegistryValidator {
       for {
         tldOk      <- RegistryRules.L1.aliasTldIsFiber(update.name)
         reservedOk <- RegistryRules.L1.notReserved(update.name)
-        metaOk     <- RegistryRules.L1.metadataConforms(update.metadata)
+        metaOk     <- RegistryRules.L1.metadataConforms(update.metadata.getOrElse(Map.empty[String, String]))
       } yield List(tldOk, reservedOk, metaOk).combineAll
   }
 

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/ConformanceCheckerSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/ConformanceCheckerSuite.scala
@@ -17,12 +17,18 @@ object ConformanceCheckerSuite extends SimpleIOSuite {
   private val msg = MessageShape(
     "App.State",
     List(
-      FieldShape("balance", 1, "int64"),
-      FieldShape("name", 2, "string"),
-      FieldShape("active", 3, "bool"),
-      FieldShape("ratio", 4, "double"),
-      FieldShape("tags", 5, "string", repeated = true),
-      FieldShape("meta", 6, "App.Meta") // message type -> shallow, accepts any non-null value
+      FieldShape("balance", 1, "int64", repeated = false, optional = false),
+      FieldShape("name", 2, "string", repeated = false, optional = false),
+      FieldShape("active", 3, "bool", repeated = false, optional = false),
+      FieldShape("ratio", 4, "double", repeated = false, optional = false),
+      FieldShape("tags", 5, "string", repeated = true, optional = false),
+      FieldShape(
+        "meta",
+        6,
+        "App.Meta",
+        repeated = false,
+        optional = false
+      ) // message type -> shallow, accepts any non-null value
     )
   )
 

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/GenesisBuilderSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/GenesisBuilderSuite.scala
@@ -25,7 +25,8 @@ object GenesisBuilderSuite extends SimpleIOSuite {
 
   private val shape: SchemaShape =
     SchemaShape(
-      stateMessage = MessageShape("App.State", List(FieldShape("balance", 1, "int64"))),
+      stateMessage =
+        MessageShape("App.State", List(FieldShape("balance", 1, "int64", repeated = false, optional = false))),
       commands = SortedMap.empty
     )
 

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/GenesisDataSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/GenesisDataSuite.scala
@@ -19,8 +19,11 @@ object GenesisDataSuite extends SimpleIOSuite {
 
   private val shape: SchemaShape =
     SchemaShape(
-      stateMessage = MessageShape("App.State", List(FieldShape("balance", 1, "int64"))),
-      commands = SortedMap("start" -> MessageShape("App.Start", List(FieldShape("amount", 1, "int64"))))
+      stateMessage =
+        MessageShape("App.State", List(FieldShape("balance", 1, "int64", repeated = false, optional = false))),
+      commands = SortedMap(
+        "start" -> MessageShape("App.Start", List(FieldShape("amount", 1, "int64", repeated = false, optional = false)))
+      )
     )
 
   private val entry: RegistryEntry =

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/GenesisLoaderSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/GenesisLoaderSuite.scala
@@ -22,7 +22,8 @@ object GenesisLoaderSuite extends SimpleIOSuite {
 
   private val shape: SchemaShape =
     SchemaShape(
-      stateMessage = MessageShape("App.State", List(FieldShape("balance", 1, "int64"))),
+      stateMessage =
+        MessageShape("App.State", List(FieldShape("balance", 1, "int64", repeated = false, optional = false))),
       commands = SortedMap.empty
     )
 

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/PublishVersionSigningCanonicalSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/PublishVersionSigningCanonicalSuite.scala
@@ -1,0 +1,104 @@
+package xyz.kd5ujc.shared_data
+
+import cats.data.Validated.{Invalid, Valid}
+import cats.effect.IO
+
+import xyz.kd5ujc.schema.Updates
+import xyz.kd5ujc.schema.Updates.OttochainMessage
+import xyz.kd5ujc.shared_data.lifecycle.validate.RegistryValidator
+
+import io.circe.parser.{decode, parse}
+import io.circe.syntax.EncoderOps
+import io.circe.{Json, JsonObject}
+import weaver.SimpleIOSuite
+
+/**
+ * Regression for the PublishVersion signing canonical (the DL1-400 behind PR #155's e2e):
+ * a client signs `JCS(dropNulls(payload))`; the chain verifies over `JCS(dropNulls(encode(decode(payload))))`.
+ * If decode->encode injects a field the client omitted, `dropNulls` cannot reconcile it, the canonicals
+ * diverge, and every PublishVersion is rejected `InvalidSignature`.
+ *
+ * The invariant this guards: a signed-message field is either `Option[T]` (None -> null -> dropped, omit-safe)
+ * or REQUIRED (no default, the client must send it). A non-`Option` field with a default (e.g. the old
+ * `repeated/optional/strict: Boolean = false`, or `metadata: SortedMap = empty`) re-encodes to a concrete
+ * value the client omitted and breaks the signature. `harnessJson` is exactly what
+ * e2e-test/lib/registry/publishVersion.ts now sends for order-v1.
+ */
+object PublishVersionSigningCanonicalSuite extends SimpleIOSuite {
+
+  private val harnessJson: String =
+    """{"PublishVersion":{
+      |  "name":"order.package",
+      |  "version":"1.0.0",
+      |  "schemaB64":"ZGVzY3JpcHRvcjpvcmRlci5wYWNrYWdlOjEuMC4w",
+      |  "schemaShape":{
+      |    "stateMessage":{"typeName":"Order","fields":[
+      |      {"name":"orderId","number":1,"typeName":"string","repeated":false,"optional":false},
+      |      {"name":"customer","number":2,"typeName":"string","repeated":false,"optional":false},
+      |      {"name":"total","number":3,"typeName":"int64","repeated":false,"optional":false},
+      |      {"name":"trackingNumber","number":4,"typeName":"string","repeated":false,"optional":true},
+      |      {"name":"deliveredAt","number":5,"typeName":"string","repeated":false,"optional":true},
+      |      {"name":"cancelReason","number":6,"typeName":"string","repeated":false,"optional":true}
+      |    ]},
+      |    "commands":{
+      |      "confirm":{"typeName":"Confirm","fields":[]},
+      |      "ship":{"typeName":"Ship","fields":[{"name":"trackingNumber","number":1,"typeName":"string","repeated":false,"optional":false}]},
+      |      "deliver":{"typeName":"Deliver","fields":[{"name":"timestamp","number":1,"typeName":"string","repeated":false,"optional":false}]},
+      |      "cancel":{"typeName":"Cancel","fields":[{"name":"reason","number":1,"typeName":"string","repeated":false,"optional":false}]}
+      |    }
+      |  },
+      |  "definition":{
+      |    "states":{
+      |      "pending":{"id":"pending","isFinal":false},
+      |      "confirmed":{"id":"confirmed","isFinal":false},
+      |      "shipped":{"id":"shipped","isFinal":false},
+      |      "delivered":{"id":"delivered","isFinal":true},
+      |      "cancelled":{"id":"cancelled","isFinal":true}
+      |    },
+      |    "initialState":"pending",
+      |    "transitions":[
+      |      {"from":"pending","to":"confirmed","eventName":"confirm","guard":{"==":[1,1]},"effect":{},"dependencies":[]},
+      |      {"from":"confirmed","to":"shipped","eventName":"ship","guard":{"==":[1,1]},"effect":{"trackingNumber":{"var":"event.trackingNumber"}},"dependencies":[]},
+      |      {"from":"shipped","to":"delivered","eventName":"deliver","guard":{"==":[1,1]},"effect":{"deliveredAt":{"var":"event.timestamp"}},"dependencies":[]},
+      |      {"from":"pending","to":"cancelled","eventName":"cancel","guard":{"==":[1,1]},"effect":{"cancelReason":{"var":"event.reason"}},"dependencies":[]}
+      |    ]
+      |  },
+      |  "strict":false
+      |}}""".stripMargin
+
+  /** Mirrors metakit JsonBinaryCodec.dropNulls: drop null object fields (array entries preserved). */
+  private def dropNulls(j: Json): Json =
+    j.arrayOrObject(
+      j,
+      arr => Json.fromValues(arr.map(dropNulls)),
+      obj =>
+        Json.fromJsonObject(
+          JsonObject.fromIterable(obj.toIterable.collect { case (k, v) if !v.isNull => k -> dropNulls(v) })
+        )
+    )
+
+  test("harness PublishVersion decodes against the chain OttochainMessage decoder") {
+    IO.pure(decode[OttochainMessage](harnessJson) match {
+      case Right(_)  => success
+      case Left(err) => failure(s"DECODE FAILED: $err")
+    })
+  }
+
+  test("chain verify-canonical == harness signed-canonical (no injected defaults)") {
+    val parsed = parse(harnessJson).toOption.get
+    val reencoded = decode[OttochainMessage](harnessJson).toOption.get.asJson
+    IO.pure(expect.same(dropNulls(reencoded), dropNulls(parsed)))
+  }
+
+  test("harness PublishVersion passes DL1 (L1) stateless validation") {
+    decode[OttochainMessage](harnessJson) match {
+      case Right(pv: Updates.PublishVersion) =>
+        new RegistryValidator.L1Validator[IO].publish(pv).map {
+          case Valid(_)      => success
+          case Invalid(errs) => failure(s"L1 REJECTED: ${errs.toNonEmptyList.toList.map(_.toString).mkString(" | ")}")
+        }
+      case Right(other) => IO.pure(failure(s"decoded to unexpected type: ${other.getClass.getSimpleName}"))
+      case Left(err)    => IO.pure(failure(s"DECODE FAILED: $err"))
+    }
+  }
+}

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/RegistryCodecSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/RegistryCodecSuite.scala
@@ -19,8 +19,11 @@ object RegistryCodecSuite extends SimpleIOSuite {
 
   private val shape: SchemaShape =
     SchemaShape(
-      stateMessage = MessageShape("App.State", List(FieldShape("balance", 1, "int64"))),
-      commands = SortedMap("start" -> MessageShape("App.Start", List(FieldShape("amount", 1, "int64"))))
+      stateMessage =
+        MessageShape("App.State", List(FieldShape("balance", 1, "int64", repeated = false, optional = false))),
+      commands = SortedMap(
+        "start" -> MessageShape("App.Start", List(FieldShape("amount", 1, "int64", repeated = false, optional = false)))
+      )
     )
 
   private val entry: RegistryEntry =

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/RegistryCombinerSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/RegistryCombinerSuite.scala
@@ -125,7 +125,11 @@ object RegistryCombinerSuite extends SimpleIOSuite {
     }
   }
 
-  test("publish by a non-owner to an existing entry is rejected (validator invalid + combiner aborts)") {
+  // Registry stateful rejection is deferred to the combiner (the authoritative gate): validateSignedUpdate
+  // runs L1-structural only, so a non-owner / non-monotonic publish PASSES validation (L1 can't see the
+  // CalculatedState lineage) and is rejected at combine (RejectionReceipt). This avoids poisoning the whole
+  // DL1 block when a now-stale registry update is re-validated at ML0 (see Validator.scala).
+  test("publish by a non-owner to an existing entry is rejected at combine (L1 passes; combiner is the gate)") {
     TestFixture.resource(Set(Alice, Bob)).use { fixture =>
       implicit val sp: SecurityProvider[IO] = fixture.securityProvider
       implicit val l0: L0NodeContext[IO] = fixture.l0Context
@@ -139,11 +143,11 @@ object RegistryCombinerSuite extends SimpleIOSuite {
         pr2           <- fixture.registry.generateProofs(p2, Set(Bob))
         valid         <- validator.validateSignedUpdate(s1, Signed(p2, pr2))
         combineFailed <- combiner.insert(s1, Signed(p2, pr2)).map(wasRejected)
-      } yield expect(valid.isInvalid) and expect(combineFailed)
+      } yield expect(valid.isValid) and expect(combineFailed)
     }
   }
 
-  test("non-monotonic publish is rejected (validator invalid + combiner aborts)") {
+  test("non-monotonic publish is rejected at combine (L1 passes; combiner is the gate)") {
     TestFixture.resource(Set(Alice)).use { fixture =>
       implicit val sp: SecurityProvider[IO] = fixture.securityProvider
       implicit val l0: L0NodeContext[IO] = fixture.l0Context
@@ -157,7 +161,7 @@ object RegistryCombinerSuite extends SimpleIOSuite {
         prLow         <- fixture.registry.generateProofs(pLow, Set(Alice))
         valid         <- validator.validateSignedUpdate(s1, Signed(pLow, prLow))
         combineFailed <- combiner.insert(s1, Signed(pLow, prLow)).map(wasRejected)
-      } yield expect(valid.isInvalid) and expect(combineFailed)
+      } yield expect(valid.isValid) and expect(combineFailed)
     }
   }
 
@@ -551,7 +555,8 @@ object RegistryCombinerSuite extends SimpleIOSuite {
         prA           <- fixture.registry.generateProofs(alias, Set(Alice))
         valid         <- validator.validateSignedUpdate(s1, Signed(alias, prA))
         combineFailed <- combiner.insert(s1, Signed(alias, prA)).map(wasRejected)
-      } yield expect(valid.isInvalid) and expect(combineFailed)
+        // kind-mismatch is an L0 (CalculatedState) check, deferred to combine — L1 passes structurally
+      } yield expect(valid.isValid) and expect(combineFailed)
     }
   }
 
@@ -569,7 +574,8 @@ object RegistryCombinerSuite extends SimpleIOSuite {
         prB           <- fixture.registry.generateProofs(alias, Set(Bob)) // Bob, not an owner, signs
         valid         <- validator.validateSignedUpdate(s1, Signed(alias, prB))
         combineFailed <- combiner.insert(s1, Signed(alias, prB)).map(wasRejected)
-      } yield expect(valid.isInvalid) and expect(combineFailed)
+        // ownership is an L0 (CalculatedState) check, deferred to combine — L1 passes structurally
+      } yield expect(valid.isValid) and expect(combineFailed)
     }
   }
 

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/RegistryCombinerSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/RegistryCombinerSuite.scala
@@ -45,8 +45,11 @@ object RegistryCombinerSuite extends SimpleIOSuite {
 
   private val shape: SchemaShape =
     SchemaShape(
-      stateMessage = MessageShape("App.State", List(FieldShape("balance", 1, "int64"))),
-      commands = SortedMap("start" -> MessageShape("App.Start", List(FieldShape("amount", 1, "int64"))))
+      stateMessage =
+        MessageShape("App.State", List(FieldShape("balance", 1, "int64", repeated = false, optional = false))),
+      commands = SortedMap(
+        "start" -> MessageShape("App.Start", List(FieldShape("amount", 1, "int64", repeated = false, optional = false)))
+      )
     )
 
   // The registered logic. Verified binding admits a fiber only if its definition hashes to the registered
@@ -71,7 +74,8 @@ object RegistryCombinerSuite extends SimpleIOSuite {
       version = v,
       schemaB64 = b64(s"schema-$name-${v.render}"),
       schemaShape = shape,
-      definition = minimalDef
+      definition = minimalDef,
+      strict = false
     )
 
   // A v2 definition that RETAINS the "initial" state (so an upgrade preserving currentState is valid) but
@@ -87,7 +91,7 @@ object RegistryCombinerSuite extends SimpleIOSuite {
   }
 
   private def publishWith(name: String, v: SemVer, definition: StateMachineDefinition): PublishVersion =
-    PublishVersion(pkg(name), v, b64(s"schema-$name-${v.render}"), shape, definition)
+    PublishVersion(pkg(name), v, b64(s"schema-$name-${v.render}"), shape, definition, strict = false)
 
   private val genesis = DataState(OnChain.genesis, CalculatedState.genesis)
 
@@ -612,7 +616,7 @@ object RegistryCombinerSuite extends SimpleIOSuite {
           shape,
           minimalDef,
           strict = false,
-          metadata = meta
+          metadata = Some(meta)
         )
       val bad = PublishVersion(
         pkg("widget"),
@@ -621,7 +625,7 @@ object RegistryCombinerSuite extends SimpleIOSuite {
         shape,
         minimalDef,
         strict = false,
-        metadata = SortedMap("note" -> ("x" * 200)) // value exceeds 128 chars
+        metadata = Some(SortedMap("note" -> ("x" * 200))) // value exceeds 128 chars
       )
       for {
         validator     <- Validator.make[IO]

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/RegistryLineageSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/RegistryLineageSuite.scala
@@ -18,8 +18,11 @@ object RegistryLineageSuite extends SimpleIOSuite {
 
   private val shape: SchemaShape =
     SchemaShape(
-      stateMessage = MessageShape("App.State", List(FieldShape("balance", 1, "int64"))),
-      commands = SortedMap("start" -> MessageShape("App.Start", List(FieldShape("amount", 1, "int64"))))
+      stateMessage =
+        MessageShape("App.State", List(FieldShape("balance", 1, "int64", repeated = false, optional = false))),
+      commands = SortedMap(
+        "start" -> MessageShape("App.Start", List(FieldShape("amount", 1, "int64", repeated = false, optional = false)))
+      )
     )
 
   private def rv(
@@ -132,14 +135,30 @@ object RegistryLineageSuite extends SimpleIOSuite {
   // ── schemaShapeWellFormed: structural proto validation of the typed domain projection ─────────
 
   test("schemaShapeWellFormed accepts a valid shape and rejects each malformed kind") {
-    val outOfRange = shape.copy(stateMessage = MessageShape("App.State", List(FieldShape("x", 0, "int64"))))
-    val tooBig = shape.copy(stateMessage = MessageShape("App.State", List(FieldShape("x", 536870912, "int64"))))
-    val reserved = shape.copy(stateMessage = MessageShape("App.State", List(FieldShape("x", 19500, "int64"))))
-    val dup = shape.copy(stateMessage =
-      MessageShape("App.State", List(FieldShape("a", 1, "int64"), FieldShape("b", 1, "int64")))
+    val outOfRange = shape.copy(stateMessage =
+      MessageShape("App.State", List(FieldShape("x", 0, "int64", repeated = false, optional = false)))
     )
-    val emptyFieldName = shape.copy(stateMessage = MessageShape("App.State", List(FieldShape("", 1, "int64"))))
-    val emptyTypeName = shape.copy(stateMessage = MessageShape("  ", List(FieldShape("a", 1, "int64"))))
+    val tooBig = shape.copy(stateMessage =
+      MessageShape("App.State", List(FieldShape("x", 536870912, "int64", repeated = false, optional = false)))
+    )
+    val reserved = shape.copy(stateMessage =
+      MessageShape("App.State", List(FieldShape("x", 19500, "int64", repeated = false, optional = false)))
+    )
+    val dup = shape.copy(stateMessage =
+      MessageShape(
+        "App.State",
+        List(
+          FieldShape("a", 1, "int64", repeated = false, optional = false),
+          FieldShape("b", 1, "int64", repeated = false, optional = false)
+        )
+      )
+    )
+    val emptyFieldName = shape.copy(stateMessage =
+      MessageShape("App.State", List(FieldShape("", 1, "int64", repeated = false, optional = false)))
+    )
+    val emptyTypeName = shape.copy(stateMessage =
+      MessageShape("  ", List(FieldShape("a", 1, "int64", repeated = false, optional = false)))
+    )
     val emptyCmdName = shape.copy(commands = SortedMap(" " -> MessageShape("App.Start", Nil)))
     for {
       ok  <- RegistryRules.L1.schemaShapeWellFormed[IO](shape)

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/StandardAppsConformanceSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/StandardAppsConformanceSuite.scala
@@ -32,19 +32,19 @@ object StandardAppsConformanceSuite extends SimpleIOSuite {
   val identity: MessageShape = MessageShape(
     "ottochain.apps.identity.v1.Identity",
     List(
-      FieldShape("id", 1, "string"),
-      FieldShape("address", 2, "string"),
-      FieldShape("public_key", 3, "string"),
-      FieldShape("display_name", 4, "string"),
-      FieldShape("identity_type", 5, "ottochain.apps.identity.v1.IdentityType"),
-      FieldShape("state", 6, "ottochain.apps.identity.v1.IdentityState"),
-      FieldShape("reputation", 7, "ottochain.apps.identity.v1.Reputation"),
-      FieldShape("stake", 8, "int64"),
-      FieldShape("domains", 9, "string", repeated = true),
-      FieldShape("platform_links", 10, "ottochain.apps.identity.v1.PlatformLink", repeated = true),
-      FieldShape("penalty_history", 11, "ottochain.apps.identity.v1.PenaltyEvent", repeated = true),
-      FieldShape("created_at", 12, "google.protobuf.Timestamp"),
-      FieldShape("updated_at", 13, "google.protobuf.Timestamp")
+      FieldShape("id", 1, "string", repeated = false, optional = false),
+      FieldShape("address", 2, "string", repeated = false, optional = false),
+      FieldShape("public_key", 3, "string", repeated = false, optional = false),
+      FieldShape("display_name", 4, "string", repeated = false, optional = false),
+      FieldShape("identity_type", 5, "ottochain.apps.identity.v1.IdentityType", repeated = false, optional = false),
+      FieldShape("state", 6, "ottochain.apps.identity.v1.IdentityState", repeated = false, optional = false),
+      FieldShape("reputation", 7, "ottochain.apps.identity.v1.Reputation", repeated = false, optional = false),
+      FieldShape("stake", 8, "int64", repeated = false, optional = false),
+      FieldShape("domains", 9, "string", repeated = true, optional = false),
+      FieldShape("platform_links", 10, "ottochain.apps.identity.v1.PlatformLink", repeated = true, optional = false),
+      FieldShape("penalty_history", 11, "ottochain.apps.identity.v1.PenaltyEvent", repeated = true, optional = false),
+      FieldShape("created_at", 12, "google.protobuf.Timestamp", repeated = false, optional = false),
+      FieldShape("updated_at", 13, "google.protobuf.Timestamp", repeated = false, optional = false)
     )
   )
 
@@ -52,16 +52,16 @@ object StandardAppsConformanceSuite extends SimpleIOSuite {
   val proposal: MessageShape = MessageShape(
     "ottochain.apps.governance.v1.Proposal",
     List(
-      FieldShape("id", 1, "string"),
-      FieldShape("title", 2, "string"),
-      FieldShape("description", 3, "string"),
-      FieldShape("action_type", 4, "string"),
-      FieldShape("payload", 5, "google.protobuf.Struct"),
-      FieldShape("proposer", 6, "string"),
-      FieldShape("proposed_at", 7, "google.protobuf.Timestamp"),
-      FieldShape("deadline", 8, "google.protobuf.Timestamp"),
-      FieldShape("queued_at", 9, "google.protobuf.Timestamp"),
-      FieldShape("executable_at", 10, "google.protobuf.Timestamp")
+      FieldShape("id", 1, "string", repeated = false, optional = false),
+      FieldShape("title", 2, "string", repeated = false, optional = false),
+      FieldShape("description", 3, "string", repeated = false, optional = false),
+      FieldShape("action_type", 4, "string", repeated = false, optional = false),
+      FieldShape("payload", 5, "google.protobuf.Struct", repeated = false, optional = false),
+      FieldShape("proposer", 6, "string", repeated = false, optional = false),
+      FieldShape("proposed_at", 7, "google.protobuf.Timestamp", repeated = false, optional = false),
+      FieldShape("deadline", 8, "google.protobuf.Timestamp", repeated = false, optional = false),
+      FieldShape("queued_at", 9, "google.protobuf.Timestamp", repeated = false, optional = false),
+      FieldShape("executable_at", 10, "google.protobuf.Timestamp", repeated = false, optional = false)
     )
   )
 
@@ -69,20 +69,20 @@ object StandardAppsConformanceSuite extends SimpleIOSuite {
   val market: MessageShape = MessageShape(
     "ottochain.apps.markets.v1.Market",
     List(
-      FieldShape("id", 1, "string"),
-      FieldShape("market_type", 2, "ottochain.apps.markets.v1.MarketType"),
-      FieldShape("creator", 3, "string"),
-      FieldShape("title", 4, "string"),
-      FieldShape("terms", 5, "google.protobuf.Struct"),
-      FieldShape("deadline", 6, "google.protobuf.Timestamp"),
-      FieldShape("threshold", 7, "int64"),
-      FieldShape("commitments", 8, "ottochain.apps.markets.v1.Commitment", repeated = true),
-      FieldShape("oracles", 9, "string", repeated = true),
-      FieldShape("quorum", 10, "int32"),
-      FieldShape("resolutions", 11, "ottochain.apps.markets.v1.Resolution", repeated = true),
-      FieldShape("status", 12, "ottochain.apps.markets.v1.MarketState"),
-      FieldShape("created_at", 13, "google.protobuf.Timestamp"),
-      FieldShape("updated_at", 14, "google.protobuf.Timestamp")
+      FieldShape("id", 1, "string", repeated = false, optional = false),
+      FieldShape("market_type", 2, "ottochain.apps.markets.v1.MarketType", repeated = false, optional = false),
+      FieldShape("creator", 3, "string", repeated = false, optional = false),
+      FieldShape("title", 4, "string", repeated = false, optional = false),
+      FieldShape("terms", 5, "google.protobuf.Struct", repeated = false, optional = false),
+      FieldShape("deadline", 6, "google.protobuf.Timestamp", repeated = false, optional = false),
+      FieldShape("threshold", 7, "int64", repeated = false, optional = false),
+      FieldShape("commitments", 8, "ottochain.apps.markets.v1.Commitment", repeated = true, optional = false),
+      FieldShape("oracles", 9, "string", repeated = true, optional = false),
+      FieldShape("quorum", 10, "int32", repeated = false, optional = false),
+      FieldShape("resolutions", 11, "ottochain.apps.markets.v1.Resolution", repeated = true, optional = false),
+      FieldShape("status", 12, "ottochain.apps.markets.v1.MarketState", repeated = false, optional = false),
+      FieldShape("created_at", 13, "google.protobuf.Timestamp", repeated = false, optional = false),
+      FieldShape("updated_at", 14, "google.protobuf.Timestamp", repeated = false, optional = false)
     )
   )
 


### PR DESCRIPTION
WIP — registry/schema/fiber lifecycle e2e (publish, verified-bind, upgrade across schema versions, status, alias, archive).

Stacked on #154 (feat/versionable-contracts) — until #154 merges, GitHub shows its commits here; the substantive change is the final commit (test(e2e): versionable lifecycle harness). The diff cleans up automatically once #154 lands on main.

Done: /v1/registry route; generators (publishVersion/setVersionStatus/registerAlias, createFiber +schemaRef, archiveFiber +targetSequenceNumber, upgradeFiber); order v1->v2 + migration fixtures + example.ts flow (happy-path + DL1/ML0 negative flows).

Pending: runner verbs + registry-aware confirmation, genesis seed, the run.
Depends on ottochain-sdk #181 (wire types) on main for CI.