### PR TITLE
feat: multi-party fiber signing (clean rebase of #133)

### DIFF
--- a/docs/design/multi-party-signing-spec.md
+++ b/docs/design/multi-party-signing-spec.md
@@ -1,0 +1,563 @@
+# Multi-Party Fiber Signing — TDD Specification
+
+**Card**: [A1] Spec: Multi-Party Fiber Signing (Metagraph)  
+**Epic**: Multi-Party Signing + Client-Side Signing Refactor (`699ce1fa`)  
+**Repo**: `scasplte2/ottochain`  
+**Branch**: `feat/multi-party-signing`  
+**Status**: Awaiting James's design approval before [A2] tests are written  
+**Last Updated**: 2026-02-23
+
+---
+
+## Problem Statement
+
+Tessellation's DL1 validates that a signed data update carries at least one valid signature — but it does **not** enforce who signed it. Ownership validation is entirely our metagraph's responsibility.
+
+The `FiberRules.L0.updateSignedByOwners` rule currently rejects any `TransitionStateMachine` not signed by one of the fiber's `owners`. The `owners` set is derived solely from the **signers of `CreateStateMachine`** — typically the fiber creator alone.
+
+This breaks multi-party state machines:
+
+```
+Alice creates a contract fiber → Alice is the only owner
+Bob accepts the contract → Bob signs TransitionStateMachine("accept", ...)
+Metagraph rejects: NotSignedByOwner ❌
+```
+
+Real-world use cases broken today:
+- **Contracts**: Creator proposes, counterparty accepts/rejects
+- **Markets**: Seller creates order, buyer fills it
+- **DAOs**: Proposal creator, voters, and treasury signatories are different parties
+- **Escrow**: Initiator and beneficiary both need signing rights
+
+---
+
+## Design Questions — Answered
+
+### Q1: Where does DL1 signer validation happen?
+
+**Answer**: It does **not** happen in Tessellation's DL1 at the application level. Tessellation checks cryptographic signature validity (proof format, hash integrity), but delegates *authorization* entirely to the metagraph's `validateData` / `validateUpdate` hooks.
+
+The `updateSignedByOwners` check is 100% our code in:
+```
+FiberRules.L0.updateSignedByOwners  →  FiberValidator.L0Validator.processEvent
+```
+
+We have full control to extend this rule without touching Tessellation.
+
+### Q2: Should authorized signers live in StateMachineDefinition or CreateStateMachine?
+
+**Answer**: `CreateStateMachine` (not `StateMachineDefinition`).
+
+Rationale:
+- `StateMachineDefinition` is the **template** — the same definition can be reused for many contract instances with different parties.
+- `CreateStateMachine` is the **instance creation message** — it carries instance-specific configuration (fiber ID, initial data, and now participants).
+- A "two-party escrow" definition is generic; the specific Alice/Bob addresses belong to this *instance*.
+
+### Q3: Can we use guard-level checking for signer authorization?
+
+**Answer**: No — not cleanly for Phase 1. The `updateSignedByOwners` check runs *before* guard evaluation in `FiberValidator.L0Validator.processEvent`:
+
+```scala
+def processEvent(update: TransitionStateMachine): F[ValidationResult] =
+  for {
+    fiberActive   <- FiberRules.L0.fiberIsActive(...)     // first
+    signedByOwner <- FiberRules.L0.updateSignedByOwners(...)  // second — before guards
+    transitionOk  <- FiberRules.L0.transitionExists(...)
+  } yield ...
+```
+
+Guard expressions evaluate JSON Logic against fiber `stateData` and the event payload, but signer addresses need to be checked at the validation layer — before the expensive guard execution. The validation layer doesn't run JLVM.
+
+For **Phase 2**, we could expose the transaction signer address as a JLVM context variable (e.g., `$signer`) so guards can do fine-grained per-role authorization. That's out of scope here.
+
+### Q4: What's the minimal change to allow counterparty transitions?
+
+**Answer**: 3 changes across 3 files:
+
+1. `Updates.CreateStateMachine` — add `participants: Option[Set[Address]]`
+2. `Records.StateMachineFiberRecord` — add `authorizedSigners: Set[Address]`
+3. `FiberRules.L0` — add `updateSignedByOwnerOrParticipant` rule
+4. `FiberValidator.L0Validator.processEvent` — use new rule for transitions
+5. `FiberCombiner.createStateMachineFiber` — populate `authorizedSigners`
+
+`archiveFiber` intentionally keeps the strict `updateSignedByOwners` check — only the **owner** can permanently archive a fiber.
+
+### Q5: How does this interact with the delegation system (PR #90)?
+
+**Answer**: These are complementary, not redundant:
+- **Delegation** (PR #90): Bob gets a `DelegationCredential` that lets him sign *on behalf of* Alice — Bob acts as Alice's relayer.
+- **Multi-party signing**: Bob signs *as himself* as a legitimate authorized participant in the fiber.
+
+The `authorizedSigners` approach is simpler and more appropriate for collaborative state machines. Delegation is better suited for "agent acts on behalf of user" scenarios.
+
+---
+
+## Chosen Design: `participants` Field in CreateStateMachine
+
+### Core Principle
+
+At fiber creation, the creator declares which additional addresses may sign transitions. These are stored as `authorizedSigners` on the fiber record. The ownership check for `TransitionStateMachine` is relaxed to accept either an owner or an authorized signer.
+
+### Backward Compatibility
+
+- `participants` is `Option[Set[Address]]` — defaults to `None` → `Set.empty`
+- When `participants` is empty, behavior is identical to current (only owners can sign transitions)
+- All existing fibers continue to work without modification
+- No migration required
+
+---
+
+## Data Model Changes
+
+### 1. `Updates.CreateStateMachine` — New Field
+
+**File**: `modules/models/src/main/scala/xyz/kd5ujc/schema/Updates.scala`
+
+```scala
+// BEFORE
+@derive(customizableDecoder, customizableEncoder)
+final case class CreateStateMachine(
+  fiberId:       UUID,
+  definition:    StateMachineDefinition,
+  initialData:   JsonLogicValue,
+  parentFiberId: Option[UUID] = None
+) extends StateMachineFiberOp
+    with OttochainMessage
+
+// AFTER
+@derive(customizableDecoder, customizableEncoder)
+final case class CreateStateMachine(
+  fiberId:        UUID,
+  definition:     StateMachineDefinition,
+  initialData:    JsonLogicValue,
+  parentFiberId:  Option[UUID] = None,
+  participants:   Option[Set[Address]] = None  // NEW: additional authorized signers
+) extends StateMachineFiberOp
+    with OttochainMessage
+```
+
+**Note**: `Address` is `io.constellationnetwork.schema.address.Address` — already used throughout the codebase.
+
+### 2. `Records.StateMachineFiberRecord` — New Field
+
+**File**: `modules/models/src/main/scala/xyz/kd5ujc/schema/Records.scala`
+
+```scala
+// BEFORE
+@derive(customizableEncoder, customizableDecoder)
+final case class StateMachineFiberRecord(
+  fiberId:               UUID,
+  creationOrdinal:       SnapshotOrdinal,
+  previousUpdateOrdinal: SnapshotOrdinal,
+  latestUpdateOrdinal:   SnapshotOrdinal,
+  definition:            StateMachineDefinition,
+  currentState:          StateId,
+  stateData:             JsonLogicValue,
+  stateDataHash:         Hash,
+  sequenceNumber:        FiberOrdinal,
+  owners:                Set[Address],
+  status:                FiberStatus,
+  lastReceipt:           Option[EventReceipt] = None,
+  parentFiberId:         Option[UUID] = None,
+  childFiberIds:         Set[UUID] = Set.empty
+) extends FiberRecord
+
+// AFTER
+@derive(customizableEncoder, customizableDecoder)
+final case class StateMachineFiberRecord(
+  fiberId:               UUID,
+  creationOrdinal:       SnapshotOrdinal,
+  previousUpdateOrdinal: SnapshotOrdinal,
+  latestUpdateOrdinal:   SnapshotOrdinal,
+  definition:            StateMachineDefinition,
+  currentState:          StateId,
+  stateData:             JsonLogicValue,
+  stateDataHash:         Hash,
+  sequenceNumber:        FiberOrdinal,
+  owners:                Set[Address],
+  status:                FiberStatus,
+  lastReceipt:           Option[EventReceipt] = None,
+  parentFiberId:         Option[UUID] = None,
+  childFiberIds:         Set[UUID] = Set.empty,
+  authorizedSigners:     Set[Address] = Set.empty  // NEW: additional transition signers
+) extends FiberRecord
+```
+
+**Key distinction**:
+- `owners`: Can sign **any** operation (transition + archive). Derived from `CreateStateMachine` proofs.
+- `authorizedSigners`: Can sign **transitions only** (not archive). Declared in `CreateStateMachine.participants`.
+
+### 3. Proto Schema Update
+
+**File**: `modules/proto/src/main/protobuf/records.proto`
+
+```protobuf
+message StateMachineFiberRecord {
+  // ... existing fields ...
+  repeated string authorized_signers = 15;  // NEW — wallet address strings
+}
+```
+
+---
+
+## New Validation Rule
+
+### `FiberRules.L0.updateSignedByOwnerOrParticipant`
+
+**File**: `modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/validate/rules/FiberRules.scala`
+
+```scala
+object L0 {
+
+  // ... existing rules unchanged ...
+
+  /**
+   * Validates that the update is signed by an owner OR an authorized participant.
+   *
+   * Used for TransitionStateMachine operations where counterparties are allowed.
+   * Owners: derived from CreateStateMachine signers (can do anything)
+   * AuthorizedSigners: declared in CreateStateMachine.participants (transitions only)
+   *
+   * Note: ArchiveStateMachine still uses updateSignedByOwners (strict — owners only).
+   */
+  def updateSignedByOwnerOrParticipant[F[_]: Async: SecurityProvider](
+    cid:    UUID,
+    proofs: NonEmptySet[SignatureProof],
+    state:  CalculatedState
+  ): F[ValidationResult] = (for {
+    record          <- state.getFiberRecord(cid)
+    signerAddresses <- EitherT.liftF(proofs.toList.traverse(_.id.toAddress))
+    signerSet = signerAddresses.toSet
+    
+    // Authorized = owners ∪ authorizedSigners
+    authorizedSet = record match {
+      case sm: Records.StateMachineFiberRecord => sm.owners ++ sm.authorizedSigners
+      case other                               => other.owners
+    }
+    
+    result <- EitherT.cond[F](
+      signerSet.intersect(authorizedSet).nonEmpty,
+      (),
+      Errors.NotSignedByAuthorizedParty: DataApplicationValidationError
+    )
+  } yield result).fold(
+    _.invalidNec[Unit],
+    _.validNec[DataApplicationValidationError]
+  )
+}
+
+object Errors {
+  // ... existing errors unchanged ...
+
+  /** New error for multi-party signing rejection */
+  final case object NotSignedByAuthorizedParty extends DataApplicationValidationError {
+    override val message: String =
+      "Update not signed by any fiber owner or authorized participant"
+  }
+}
+```
+
+**Note**: Keep the existing `Errors.NotSignedByOwner` for backward compatibility (still used by archive validation and the error is still useful for the strict owner-only case). Add `NotSignedByAuthorizedParty` as a distinct error for the relaxed check.
+
+---
+
+## Validator Changes
+
+### `FiberValidator.L0Validator.processEvent`
+
+**File**: `modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/validate/FiberValidator.scala`
+
+```scala
+/** Validates a ProcessFiberEvent update (L0 specific checks) */
+def processEvent(update: TransitionStateMachine): F[ValidationResult] =
+  for {
+    fiberActive   <- FiberRules.L0.fiberIsActive(update.fiberId, state.calculated)
+    // CHANGED: was updateSignedByOwners, now allows authorized participants too
+    signedOk      <- FiberRules.L0.updateSignedByOwnerOrParticipant(update.fiberId, proofs, state.calculated)
+    transitionOk  <- FiberRules.L0.transitionExists(update.fiberId, update.eventName, state.calculated)
+  } yield List(fiberActive, signedOk, transitionOk).combineAll
+
+/** Validates an ArchiveFiber update (L0 specific checks) — UNCHANGED */
+def archiveFiber(update: ArchiveStateMachine): F[ValidationResult] =
+  for {
+    fiberActive   <- FiberRules.L0.fiberIsActive(update.fiberId, state.calculated)
+    signedByOwner <- FiberRules.L0.updateSignedByOwners(update.fiberId, proofs, state.calculated)
+    // ^ STRICT — only owners can archive, not participants
+  } yield List(fiberActive, signedByOwner).combineAll
+```
+
+---
+
+## Combiner Changes
+
+### `FiberCombiner.createStateMachineFiber`
+
+**File**: `modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/combine/FiberCombiner.scala`
+
+```scala
+def createStateMachineFiber(
+  update: Signed[Updates.CreateStateMachine]
+): CombineResult[F] = for {
+  currentOrdinal  <- ctx.getCurrentOrdinal
+  owners          <- update.proofs.toList.traverse(_.id.toAddress).map(Set.from)
+  initialDataHash <- update.initialData.computeDigest
+
+  // NEW: participants become authorized signers on the fiber record
+  authorizedSigners = update.participants.getOrElse(Set.empty)
+
+  record = Records.StateMachineFiberRecord(
+    fiberId = update.fiberId,
+    creationOrdinal = currentOrdinal,
+    previousUpdateOrdinal = currentOrdinal,
+    latestUpdateOrdinal = currentOrdinal,
+    definition = update.definition,
+    currentState = update.definition.initialState,
+    stateData = update.initialData,
+    stateDataHash = initialDataHash,
+    sequenceNumber = FiberOrdinal.MinValue,
+    owners = owners,
+    status = FiberStatus.Active,
+    parentFiberId = update.parentFiberId,
+    authorizedSigners = authorizedSigners  // NEW
+  )
+
+  result <- current.withRecord[F](update.fiberId, record)
+} yield result
+```
+
+---
+
+## TDD Test Cases
+
+Write these tests in `modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/MultiPartySigningSuite.scala` using the `weaver` + `TestFixture` + `ParticipantRegistry` patterns from existing suites.
+
+**Reference patterns**: `ValidatorSuite.scala`, `SpawnMachinesSuite.scala`
+
+### Group 1: Backward Compatibility (3 tests)
+
+**T1.1 — Existing single-owner fiber still works**
+```
+setup: Create fiber with Alice as signer, no participants declared
+action: Alice signs TransitionStateMachine("advance", ...)
+expect: ValidationResult.Valid ✓
+```
+
+**T1.2 — Non-owner without participants still rejected**
+```
+setup: Create fiber with Alice as signer, no participants declared
+action: Bob signs TransitionStateMachine("advance", ...)
+expect: ValidationResult.Invalid(NotSignedByAuthorizedParty) ✓
+```
+
+**T1.3 — Archive still requires owner even with participants**
+```
+setup: Create fiber with Alice as signer, Bob as participant
+action: Bob signs ArchiveStateMachine(...)
+expect: ValidationResult.Invalid(NotSignedByOwner) ✓
+   — Bob can transition but cannot archive
+```
+
+### Group 2: Multi-Party Transition Signing (4 tests)
+
+**T2.1 — Authorized participant can trigger transition**
+```
+setup: Alice creates fiber with participants = Set(Bob.address)
+action: Bob signs TransitionStateMachine("accept", ...)
+expect: ValidationResult.Valid ✓
+```
+
+**T2.2 — Multiple participants declared, any one can transition**
+```
+setup: Alice creates fiber with participants = Set(Bob, Charlie, Dave)
+action: Charlie signs TransitionStateMachine("vote", ...)
+expect: ValidationResult.Valid ✓
+```
+
+**T2.3 — Non-participant still rejected even with participants present**
+```
+setup: Alice creates fiber with participants = Set(Bob.address)
+action: Charlie (not in participants) signs TransitionStateMachine(...)
+expect: ValidationResult.Invalid(NotSignedByAuthorizedParty) ✓
+```
+
+**T2.4 — Owner can still transition even with participants set**
+```
+setup: Alice creates fiber with participants = Set(Bob.address)
+action: Alice (owner) signs TransitionStateMachine("advance", ...)
+expect: ValidationResult.Valid ✓
+   — adding participants doesn't remove owner rights
+```
+
+### Group 3: CreateStateMachine Encoding (2 tests)
+
+**T3.1 — participants field serializes/deserializes correctly**
+```
+setup: CreateStateMachine with participants = Some(Set(Alice.address, Bob.address))
+action: encode to JSON, decode back
+expect: participants field round-trips correctly
+   — verify Set ordering is stable (sorted by address)
+```
+
+**T3.2 — Omitted participants field defaults to empty**
+```
+setup: CreateStateMachine without participants field (legacy format)
+action: decode from JSON {"fiberId":..., "definition":..., "initialData":...}
+expect: participants = None (and fiber record authorizedSigners = Set.empty)
+   — backward compatible deserialization
+```
+
+### Group 4: FiberRecord Encoding (2 tests)
+
+**T4.1 — authorizedSigners field persists in FiberRecord**
+```
+setup: Create fiber with Bob as participant, advance state
+action: read StateMachineFiberRecord from CalculatedState
+expect: record.authorizedSigners = Set(Bob.address) ✓
+```
+
+**T4.2 — Legacy FiberRecord without authorizedSigners decodes correctly**
+```
+setup: JSON FiberRecord without authorizedSigners field (legacy snapshot)
+action: decode
+expect: authorizedSigners = Set.empty (no crash, backward compat) ✓
+```
+
+### Group 5: Full Round-Trip Integration (2 tests)
+
+**T5.1 — Two-party contract lifecycle**
+```
+scenario:
+  1. Alice creates contract fiber with participants = Set(Bob)
+  2. Bob signs "accept" transition → Valid ✓
+  3. Alice signs "release" transition → Valid ✓
+  4. Charlie signs anything → Invalid ✓
+  5. Bob tries to archive → Invalid (NotSignedByOwner) ✓
+  6. Alice archives → Valid ✓
+```
+
+**T5.2 — Owner-also-participant: no double-counting issues**
+```
+setup: Alice creates fiber with participants = Set(Alice.address)
+   — Alice is both owner and in participants list
+action: Alice signs TransitionStateMachine
+expect: Valid ✓ (no error from union of owners + authorizedSigners)
+```
+
+### Group 6: Combiner Integration (2 tests)
+
+**T6.1 — participants populate authorizedSigners on created record**
+```
+setup: Alice creates fiber with participants = Some(Set(Bob.address, Charlie.address))
+action: run through full Combiner.combine pipeline
+expect: retrieved FiberRecord.authorizedSigners == Set(Bob.address, Charlie.address) ✓
+```
+
+**T6.2 — No participants → authorizedSigners empty, validation unchanged**
+```
+setup: Alice creates fiber without participants
+action: Bob tries to transition, run through L0 validation
+expect: NotSignedByAuthorizedParty (same as legacy NotSignedByOwner behavior) ✓
+```
+
+---
+
+## Implementation Plan
+
+### Phase 1 (this spec): Static Participants at Creation Time
+
+| Step | File | Change |
+|------|------|--------|
+| 1 | `Updates.scala` | Add `participants: Option[Set[Address]]` to `CreateStateMachine` |
+| 2 | `Records.scala` | Add `authorizedSigners: Set[Address]` to `StateMachineFiberRecord` |
+| 3 | `FiberRules.scala` | Add `updateSignedByOwnerOrParticipant` + `NotSignedByAuthorizedParty` error |
+| 4 | `FiberValidator.scala` | Use new rule in `processEvent` |
+| 5 | `FiberCombiner.scala` | Populate `authorizedSigners` from `update.participants` |
+| 6 | `records.proto` | Add `authorized_signers` field (repeated string, field 15) |
+
+**Target release**: v0.8.0 (breaking change: new field on FiberRecord, proto schema update)
+
+### Phase 2 (future): Dynamic Participant Management
+
+Two approaches for future consideration:
+
+**Option A: `AddAuthorizedSigner` / `RemoveAuthorizedSigner` OttochainMessage**
+```scala
+// New message variants
+case class AddAuthorizedSigner(fiberId: UUID, signer: Address, targetSeq: FiberOrdinal)
+case class RemoveAuthorizedSigner(fiberId: UUID, signer: Address, targetSeq: FiberOrdinal)
+```
+- Only owners can add/remove
+- Useful for: auction bidder reveals, DAO member additions
+
+**Option B: JLVM `$signers` context variable**
+```jsonc
+// Guard that checks transition-specific signer:
+{
+  "in": [{"var": "$signer"}, {"var": "state.approvedParties"}]
+}
+```
+- State-data-driven authorization
+- More powerful but requires guard evaluation before rejection
+- Requires redesigning validation order
+
+**Recommendation**: Phase 2 starts when integration tests (Epic C) are green and James approves the direction.
+
+---
+
+## Acceptance Criteria (James Review)
+
+- [ ] **Design approved**: James agrees with the `participants` field approach vs alternatives
+- [ ] **Backward compat confirmed**: No migration needed for existing fibers or snapshots
+- [ ] **Scope confirmed**: Phase 1 = static participants only; dynamic management = Phase 2
+- [ ] **Error naming approved**: `NotSignedByAuthorizedParty` vs reusing `NotSignedByOwner`
+- [ ] **Proto field number confirmed**: field 15 for `authorized_signers` in `StateMachineFiberRecord`
+
+---
+
+## Open Questions for James
+
+1. **Should participants be validated at CreateStateMachine time?** e.g., reject if `participants` contains an address that is also in `owners` (redundant)? Or silently allow duplicates (union is idempotent)?
+
+2. **Archive permission**: Should authorized participants EVER be able to archive a fiber? (Current spec: no — only owners can archive.) Use case: Bob created a delegation on Alice's behalf, Alice is unavailable, Bob needs to clean up.
+
+3. **Participant limit**: Should we impose a `MaxParticipants` limit (e.g., 10) similar to `MaxStates`? Prevents griefing via enormous participant sets.
+
+4. **Bridge API**: When clients submit `CreateStateMachine` via the bridge, does the bridge need a new `participants` field in its request body? Or is this a future concern?
+
+---
+
+## Files to Change
+
+```
+scasplte2/ottochain
+├── modules/models/src/main/scala/xyz/kd5ujc/schema/
+│   ├── Updates.scala                    # Add participants field
+│   └── Records.scala                   # Add authorizedSigners field
+├── modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/
+│   ├── validate/rules/FiberRules.scala  # New rule + new error
+│   ├── validate/FiberValidator.scala    # Use new rule in processEvent
+│   └── combine/FiberCombiner.scala     # Populate authorizedSigners
+├── modules/proto/src/main/protobuf/
+│   └── records.proto                   # Add authorized_signers field
+└── modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/
+    └── MultiPartySigningSuite.scala    # NEW — 15 TDD tests (write BEFORE implementing)
+```
+
+No changes needed in:
+- `FiberEngine.scala` — evaluation layer unchanged
+- `Validator.scala` — routes to validators, not affected
+- DL1/ML0 layers — no Tessellation changes needed
+- `ottochain-services` — bridge changes are Epic B (client-side signing)
+- `ottochain-sdk` — SDK changes are Epic B (build/submit endpoints)
+
+---
+
+## Why NOT These Alternatives
+
+| Alternative | Why Rejected |
+|-------------|--------------|
+| **Co-ownership** (all participants become owners) | Participants gain archive rights — dangerous. Semantic mismatch. |
+| **Guard-level signer check** (`$signer` JLVM var) | Requires evaluation pass before rejection; more complex; Phase 2 |
+| **Extend delegation system** (everyone gets a credential) | Over-engineered for simple 2-party case; delegation = relaying, not participating |
+| **Tessellation fork** (modify DL1 signer validation) | Never — would break all metagraphs, requires Constellation approval |
+| **Bridge-side proxy signing** (bridge holds all keys) | Security anti-pattern; defeats the purpose of client-side signing |

--- a/modules/models/src/main/scala/xyz/kd5ujc/schema/Records.scala
+++ b/modules/models/src/main/scala/xyz/kd5ujc/schema/Records.scala
@@ -42,7 +42,8 @@ object Records {
     lastReceipt:           Option[EventReceipt] = None,
     parentFiberId:         Option[UUID] = None,
     childFiberIds:         Set[UUID] = Set.empty,
-    schemaBinding:         Option[SchemaBinding] = None
+    schemaBinding:         Option[SchemaBinding] = None,
+    authorizedSigners:     Set[Address] = Set.empty
   ) extends FiberRecord
 
   @derive(customizableEncoder, customizableDecoder)

--- a/modules/models/src/main/scala/xyz/kd5ujc/schema/Updates.scala
+++ b/modules/models/src/main/scala/xyz/kd5ujc/schema/Updates.scala
@@ -7,6 +7,7 @@ import scala.collection.immutable.SortedMap
 
 import io.constellationnetwork.currency.dataApplication.DataUpdate
 import io.constellationnetwork.metagraph_sdk.json_logic.{JsonLogicExpression, JsonLogicValue}
+import io.constellationnetwork.schema.address.Address
 import io.constellationnetwork.security.signature.Signed
 
 import xyz.kd5ujc.schema.CodecConfiguration._
@@ -46,7 +47,8 @@ object Updates {
     definition:    StateMachineDefinition,
     initialData:   JsonLogicValue,
     parentFiberId: Option[UUID] = None,
-    schemaRef:     Option[SchemaRef] = None
+    schemaRef:     Option[SchemaRef] = None,
+    participants:  Option[Set[Address]] = None
   ) extends StateMachineFiberOp
       with OttochainMessage
 

--- a/modules/models/src/main/scala/xyz/kd5ujc/schema/fiber/StateId.scala
+++ b/modules/models/src/main/scala/xyz/kd5ujc/schema/fiber/StateId.scala
@@ -5,17 +5,12 @@ import io.circe.{Decoder, Encoder, KeyDecoder, KeyEncoder}
 case class StateId(value: String) extends AnyVal
 
 object StateId {
-  // Encode as plain string (canonical wire format)
+  // Plain string is the one canonical wire form, on both encode and decode. A StateId is part of the
+  // signed CreateStateMachine canonical; accepting an alternate input shape (e.g. {"value":"state"}) would
+  // let a client sign one shape that the chain silently re-encodes to another -> divergent bytes ->
+  // InvalidSignature. So decode is strict: only the plain string the encoder produces is accepted.
   implicit val encoder: Encoder[StateId] = Encoder.encodeString.contramap(_.value)
-
-  // Accept both plain string ("state") and wrapped object ({"value": "state"})
-  // The wrapped format was used in TDD test fixtures; both are valid on input.
-  implicit val decoder: Decoder[StateId] =
-    Decoder.decodeString
-      .map(StateId(_))
-      .or(
-        Decoder.forProduct1("value")(StateId(_))
-      )
+  implicit val decoder: Decoder[StateId] = Decoder.decodeString.map(StateId(_))
 
   implicit val keyEncoder: KeyEncoder[StateId] = KeyEncoder.encodeKeyString.contramap(_.value)
   implicit val keyDecoder: KeyDecoder[StateId] = KeyDecoder.decodeKeyString.map(StateId(_))

--- a/modules/models/src/main/scala/xyz/kd5ujc/schema/fiber/StateId.scala
+++ b/modules/models/src/main/scala/xyz/kd5ujc/schema/fiber/StateId.scala
@@ -5,8 +5,18 @@ import io.circe.{Decoder, Encoder, KeyDecoder, KeyEncoder}
 case class StateId(value: String) extends AnyVal
 
 object StateId {
+  // Encode as plain string (canonical wire format)
   implicit val encoder: Encoder[StateId] = Encoder.encodeString.contramap(_.value)
-  implicit val decoder: Decoder[StateId] = Decoder.decodeString.map(StateId(_))
+
+  // Accept both plain string ("state") and wrapped object ({"value": "state"})
+  // The wrapped format was used in TDD test fixtures; both are valid on input.
+  implicit val decoder: Decoder[StateId] =
+    Decoder.decodeString
+      .map(StateId(_))
+      .or(
+        Decoder.forProduct1("value")(StateId(_))
+      )
+
   implicit val keyEncoder: KeyEncoder[StateId] = KeyEncoder.encodeKeyString.contramap(_.value)
   implicit val keyDecoder: KeyDecoder[StateId] = KeyDecoder.decodeKeyString.map(StateId(_))
 }

--- a/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/combine/FiberCombiner.scala
+++ b/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/combine/FiberCombiner.scala
@@ -58,6 +58,9 @@ class FiberCombiner[F[_]: Async: SecurityProvider](
         )
     }
 
+    // participants declared in CreateStateMachine become authorized signers for transitions
+    authorizedSigners = update.participants.getOrElse(Set.empty)
+
     record = Records.StateMachineFiberRecord(
       fiberId = update.fiberId,
       creationOrdinal = currentOrdinal,
@@ -71,7 +74,8 @@ class FiberCombiner[F[_]: Async: SecurityProvider](
       owners = owners,
       status = FiberStatus.Active,
       parentFiberId = update.parentFiberId,
-      schemaBinding = binding
+      schemaBinding = binding,
+      authorizedSigners = authorizedSigners
     )
 
     creationReceipt = FiberLogEntry.CreationReceipt(

--- a/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/validate/FiberValidator.scala
+++ b/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/validate/FiberValidator.scala
@@ -115,10 +115,11 @@ object FiberValidator {
     /** Validates a ProcessFiberEvent update (L0 specific checks) */
     def processEvent(update: TransitionStateMachine): F[ValidationResult] =
       for {
-        fiberActive   <- FiberRules.L0.fiberIsActive(update.fiberId, state.calculated)
-        signedByOwner <- FiberRules.L0.updateSignedByOwners(update.fiberId, proofs, state.calculated)
-        transitionOk  <- FiberRules.L0.transitionExists(update.fiberId, update.eventName, state.calculated)
-      } yield List(fiberActive, signedByOwner, transitionOk).combineAll
+        fiberActive <- FiberRules.L0.fiberIsActive(update.fiberId, state.calculated)
+        // Relaxed: owners OR authorized participants (declared in CreateStateMachine.participants)
+        signedOk     <- FiberRules.L0.updateSignedByOwnerOrParticipant(update.fiberId, proofs, state.calculated)
+        transitionOk <- FiberRules.L0.transitionExists(update.fiberId, update.eventName, state.calculated)
+      } yield List(fiberActive, signedOk, transitionOk).combineAll
 
     /** Validates an ArchiveFiber update (L0 specific checks) */
     def archiveFiber(update: ArchiveStateMachine): F[ValidationResult] =

--- a/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/validate/rules/FiberRules.scala
+++ b/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/validate/rules/FiberRules.scala
@@ -15,7 +15,7 @@ import io.constellationnetwork.security.signature.signature.SignatureProof
 
 import xyz.kd5ujc.schema.fiber.{FiberOrdinal, FiberStatus, StateId, StateMachineDefinition}
 import xyz.kd5ujc.schema.registry.RegistryName
-import xyz.kd5ujc.schema.{CalculatedState, OnChain}
+import xyz.kd5ujc.schema.{CalculatedState, OnChain, Records}
 import xyz.kd5ujc.shared_data.lifecycle.validate.{Limits, ValidationResult}
 import xyz.kd5ujc.shared_data.syntax.calculatedState._
 
@@ -287,6 +287,37 @@ object FiberRules {
       _.validNec[DataApplicationValidationError]
     )
 
+    /**
+     * Validates that the update is signed by an owner OR an authorized participant.
+     *
+     * Used for TransitionStateMachine operations where counterparties are allowed.
+     * Owners: derived from CreateStateMachine signers (can do anything)
+     * AuthorizedSigners: declared in CreateStateMachine.participants (transitions only)
+     *
+     * Note: ArchiveStateMachine still uses updateSignedByOwners (strict — owners only).
+     */
+    def updateSignedByOwnerOrParticipant[F[_]: Async: SecurityProvider](
+      cid:    UUID,
+      proofs: NonEmptySet[SignatureProof],
+      state:  CalculatedState
+    ): F[ValidationResult] = (for {
+      record          <- state.getFiberRecord(cid)
+      signerAddresses <- EitherT.liftF(proofs.toList.traverse(_.id.toAddress))
+      signerSet = signerAddresses.toSet
+      authorizedSet = record match {
+        case sm: Records.StateMachineFiberRecord => sm.owners ++ sm.authorizedSigners
+        case other                               => other.owners
+      }
+      result <- EitherT.cond[F](
+        signerSet.intersect(authorizedSet).nonEmpty,
+        (),
+        Errors.NotSignedByAuthorizedParty: DataApplicationValidationError
+      )
+    } yield result).fold(
+      _.invalidNec[Unit],
+      _.validNec[DataApplicationValidationError]
+    )
+
     /** Validates that a transition exists for the given state+event combination */
     def transitionExists[F[_]: Monad](
       cid:       UUID,
@@ -450,6 +481,10 @@ object FiberRules {
 
     final case object NotSignedByOwner extends DataApplicationValidationError {
       override val message: String = "Update not signed by any fiber owner"
+    }
+
+    final case object NotSignedByAuthorizedParty extends DataApplicationValidationError {
+      override val message: String = "Update not signed by any fiber owner or authorized participant"
     }
 
     // --- Sequence number errors ---

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/CreateStateMachineDecodeSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/CreateStateMachineDecodeSuite.scala
@@ -59,4 +59,20 @@ object CreateStateMachineDecodeSuite extends SimpleIOSuite {
         )
       else success
   }
+
+  // #133 multi-party signing adds `participants: Option[Set[Address]] = None` to the signed CreateStateMachine.
+  // Per the signing-canonical invariant (docs/signing-canonical-and-validation.md): an omitted Option must NOT
+  // be re-injected by the chain's encoder, or a client that omits it produces different bytes -> InvalidSignature.
+  test("canonical signing form: participants omitted when None (multi-party #133)") {
+    for {
+      csm   <- IO.fromEither(decode[Updates.CreateStateMachine](inner))
+      bytes <- JsonBinaryCodec[IO, Updates.CreateStateMachine].serialize(csm)
+      canonical = new String(bytes, "UTF-8")
+    } yield
+      if (canonical.contains("\"participants\""))
+        failure(
+          s"canonical INCLUDES participants when None -> a signer that omits it produces different bytes -> InvalidSignature. canonical=$canonical"
+        )
+      else success
+  }
 }

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/MultiPartyTransitionSigningSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/MultiPartyTransitionSigningSuite.scala
@@ -1,0 +1,528 @@
+package xyz.kd5ujc.shared_data
+
+import cats.effect.IO
+import cats.effect.std.UUIDGen
+import cats.syntax.all._
+
+import io.constellationnetwork.currency.dataApplication.{DataState, L0NodeContext}
+import io.constellationnetwork.metagraph_sdk.json_logic._
+import io.constellationnetwork.security.SecurityProvider
+import io.constellationnetwork.security.signature.Signed
+
+import xyz.kd5ujc.schema.fiber._
+import xyz.kd5ujc.schema.{CalculatedState, OnChain, Records, Updates}
+import xyz.kd5ujc.shared_data.lifecycle.Combiner
+import xyz.kd5ujc.shared_test.Participant._
+import xyz.kd5ujc.shared_test.TestFixture
+
+import io.circe.parser._
+import weaver.SimpleIOSuite
+
+object MultiPartyTransitionSigningSuite extends SimpleIOSuite {
+
+  test("counterparty can sign accept transition on fiber they didn't create") {
+    TestFixture.resource(Set(Alice, Bob)).use { fixture =>
+      implicit val s: SecurityProvider[IO] = fixture.securityProvider
+      implicit val l0ctx: L0NodeContext[IO] = fixture.l0Context
+      for {
+        combiner <- Combiner.make[IO]().pure[IO]
+
+        contractFiberId <- UUIDGen.randomUUID[IO]
+
+        // Simple contract with accept/reject transitions
+        contractJson = """
+        {
+          "states": {
+            "pending": { "id": "pending", "isFinal": false },
+            "accepted": { "id": "accepted", "isFinal": true },
+            "rejected": { "id": "rejected", "isFinal": true }
+          },
+          "initialState": "pending",
+          "transitions": [
+            {
+              "from": "pending",
+              "to": "accepted",
+              "eventName": "accept",
+              "guard": true,
+              "effect": {
+                "status": "accepted",
+                "acceptedAt": { "var": "event.timestamp" }
+              },
+              "dependencies": []
+            },
+            {
+              "from": "pending",
+              "to": "rejected", 
+              "eventName": "reject",
+              "guard": true,
+              "effect": {
+                "status": "rejected",
+                "rejectedAt": { "var": "event.timestamp" }
+              },
+              "dependencies": []
+            }
+          ]
+        }
+        """
+
+        contractDef <- IO.fromEither(decode[StateMachineDefinition](contractJson))
+        initialData = MapValue(Map("counterparty" -> StrValue("Bob")))
+
+        // Alice creates the contract
+        createContract = Updates.CreateStateMachine(contractFiberId, contractDef, initialData)
+        createProof <- fixture.registry.generateProofs(createContract, Set(Alice))
+        stateAfterCreate <- combiner.insert(
+          DataState(OnChain.genesis, CalculatedState.genesis),
+          Signed(createContract, createProof)
+        )
+
+        // Bob (counterparty) signs the accept transition
+        acceptEvent = Updates.TransitionStateMachine(
+          contractFiberId,
+          "accept",
+          MapValue(Map("timestamp" -> IntValue(System.currentTimeMillis()))),
+          FiberOrdinal.MinValue
+        )
+        // This should work in the multi-party system - Bob can sign accept
+        acceptProof <- fixture.registry.generateProofs(acceptEvent, Set(Bob))
+        finalState  <- combiner.insert(stateAfterCreate, Signed(acceptEvent, acceptProof))
+
+        contract = finalState.calculated.stateMachines
+          .get(contractFiberId)
+          .collect { case r: Records.StateMachineFiberRecord => r }
+
+        status = contract.flatMap { f =>
+          f.stateData match {
+            case MapValue(m) => m.get("status").collect { case StrValue(s) => s }
+            case _           => None
+          }
+        }
+
+      } yield expect(contract.isDefined) and
+      expect(contract.map(_.currentState).contains(StateId("accepted"))) and
+      expect(status.contains("accepted"))
+    }
+  }
+
+  test("counterparty can sign reject transition") {
+    TestFixture.resource(Set(Alice, Bob)).use { fixture =>
+      implicit val s: SecurityProvider[IO] = fixture.securityProvider
+      implicit val l0ctx: L0NodeContext[IO] = fixture.l0Context
+      for {
+        combiner <- Combiner.make[IO]().pure[IO]
+
+        contractFiberId <- UUIDGen.randomUUID[IO]
+
+        contractJson = """
+        {
+          "states": {
+            "pending": { "id": "pending", "isFinal": false },
+            "accepted": { "id": "accepted", "isFinal": true },
+            "rejected": { "id": "rejected", "isFinal": true }
+          },
+          "initialState": "pending",
+          "transitions": [
+            {
+              "from": "pending",
+              "to": "accepted",
+              "eventName": "accept",
+              "guard": true,
+              "effect": {
+                "status": "accepted"
+              },
+              "dependencies": []
+            },
+            {
+              "from": "pending",
+              "to": "rejected", 
+              "eventName": "reject",
+              "guard": true,
+              "effect": {
+                "status": "rejected",
+                "reason": { "var": "event.reason" }
+              },
+              "dependencies": []
+            }
+          ]
+        }
+        """
+
+        contractDef <- IO.fromEither(decode[StateMachineDefinition](contractJson))
+        initialData = MapValue(Map("counterparty" -> StrValue("Bob")))
+
+        // Alice creates the contract
+        createContract = Updates.CreateStateMachine(contractFiberId, contractDef, initialData)
+        createProof <- fixture.registry.generateProofs(createContract, Set(Alice))
+        stateAfterCreate <- combiner.insert(
+          DataState(OnChain.genesis, CalculatedState.genesis),
+          Signed(createContract, createProof)
+        )
+
+        // Bob (counterparty) signs the reject transition
+        rejectEvent = Updates.TransitionStateMachine(
+          contractFiberId,
+          "reject",
+          MapValue(Map("reason" -> StrValue("terms not acceptable"))),
+          FiberOrdinal.MinValue
+        )
+        // This should work in the multi-party system - Bob can sign reject
+        rejectProof <- fixture.registry.generateProofs(rejectEvent, Set(Bob))
+        finalState  <- combiner.insert(stateAfterCreate, Signed(rejectEvent, rejectProof))
+
+        contract = finalState.calculated.stateMachines
+          .get(contractFiberId)
+          .collect { case r: Records.StateMachineFiberRecord => r }
+
+        status = contract.flatMap { f =>
+          f.stateData match {
+            case MapValue(m) => m.get("status").collect { case StrValue(s) => s }
+            case _           => None
+          }
+        }
+
+        reason = contract.flatMap { f =>
+          f.stateData match {
+            case MapValue(m) => m.get("reason").collect { case StrValue(r) => r }
+            case _           => None
+          }
+        }
+
+      } yield expect(contract.isDefined) and
+      expect(contract.map(_.currentState).contains(StateId("rejected"))) and
+      expect(status.contains("rejected")) and
+      expect(reason.contains("terms not acceptable"))
+    }
+  }
+
+  test("unauthorized third party CANNOT sign transitions") {
+    TestFixture.resource(Set(Alice, Bob, Charlie)).use { fixture =>
+      implicit val s: SecurityProvider[IO] = fixture.securityProvider
+      implicit val l0ctx: L0NodeContext[IO] = fixture.l0Context
+      for {
+        combiner <- Combiner.make[IO]().pure[IO]
+
+        contractFiberId <- UUIDGen.randomUUID[IO]
+
+        contractJson = """
+        {
+          "states": {
+            "pending": { "id": "pending", "isFinal": false },
+            "accepted": { "id": "accepted", "isFinal": true }
+          },
+          "initialState": "pending",
+          "transitions": [
+            {
+              "from": "pending",
+              "to": "accepted",
+              "eventName": "accept",
+              "guard": true,
+              "effect": {
+                "status": "accepted"
+              },
+              "dependencies": []
+            }
+          ]
+        }
+        """
+
+        contractDef <- IO.fromEither(decode[StateMachineDefinition](contractJson))
+        initialData = MapValue(Map("counterparty" -> StrValue("Bob")))
+
+        // Alice creates the contract
+        createContract = Updates.CreateStateMachine(contractFiberId, contractDef, initialData)
+        createProof <- fixture.registry.generateProofs(createContract, Set(Alice))
+        stateAfterCreate <- combiner.insert(
+          DataState(OnChain.genesis, CalculatedState.genesis),
+          Signed(createContract, createProof)
+        )
+
+        // Charlie (unauthorized third party) tries to sign accept transition
+        acceptEvent = Updates.TransitionStateMachine(
+          contractFiberId,
+          "accept",
+          MapValue(Map("timestamp" -> IntValue(System.currentTimeMillis()))),
+          FiberOrdinal.MinValue
+        )
+
+        // This should fail - Charlie is not owner (Alice) or counterparty (Bob)
+        charlieProof <- fixture.registry.generateProofs(acceptEvent, Set(Charlie))
+        result       <- combiner.insert(stateAfterCreate, Signed(acceptEvent, charlieProof)).attempt
+
+        // The system should reject this transaction
+        // In the current system this would pass, but in multi-party system it should fail
+
+      } yield expect(result.isLeft) // Should fail because Charlie is not authorized
+    }
+  }
+
+  test("owner can still sign all transitions") {
+    TestFixture.resource(Set(Alice, Bob)).use { fixture =>
+      implicit val s: SecurityProvider[IO] = fixture.securityProvider
+      implicit val l0ctx: L0NodeContext[IO] = fixture.l0Context
+      for {
+        combiner <- Combiner.make[IO]().pure[IO]
+
+        contractFiberId <- UUIDGen.randomUUID[IO]
+
+        contractJson = """
+        {
+          "states": {
+            "pending": { "id": "pending", "isFinal": false },
+            "cancelled": { "id": "cancelled", "isFinal": true }
+          },
+          "initialState": "pending",
+          "transitions": [
+            {
+              "from": "pending",
+              "to": "cancelled",
+              "eventName": "cancel",
+              "guard": true,
+              "effect": {
+                "status": "cancelled",
+                "cancelledBy": "owner"
+              },
+              "dependencies": []
+            }
+          ]
+        }
+        """
+
+        contractDef <- IO.fromEither(decode[StateMachineDefinition](contractJson))
+        initialData = MapValue(Map("counterparty" -> StrValue("Bob")))
+
+        // Alice creates the contract
+        createContract = Updates.CreateStateMachine(contractFiberId, contractDef, initialData)
+        createProof <- fixture.registry.generateProofs(createContract, Set(Alice))
+        stateAfterCreate <- combiner.insert(
+          DataState(OnChain.genesis, CalculatedState.genesis),
+          Signed(createContract, createProof)
+        )
+
+        // Alice (owner) signs the cancel transition - should always work
+        cancelEvent = Updates.TransitionStateMachine(
+          contractFiberId,
+          "cancel",
+          MapValue(Map.empty[String, JsonLogicValue]),
+          FiberOrdinal.MinValue
+        )
+        cancelProof <- fixture.registry.generateProofs(cancelEvent, Set(Alice))
+        finalState  <- combiner.insert(stateAfterCreate, Signed(cancelEvent, cancelProof))
+
+        contract = finalState.calculated.stateMachines
+          .get(contractFiberId)
+          .collect { case r: Records.StateMachineFiberRecord => r }
+
+        status = contract.flatMap { f =>
+          f.stateData match {
+            case MapValue(m) => m.get("status").collect { case StrValue(s) => s }
+            case _           => None
+          }
+        }
+
+      } yield expect(contract.isDefined) and
+      expect(contract.map(_.currentState).contains(StateId("cancelled"))) and
+      expect(status.contains("cancelled"))
+    }
+  }
+
+  test("guard conditions still evaluate correctly with counterparty signer") {
+    TestFixture.resource(Set(Alice, Bob)).use { fixture =>
+      implicit val s: SecurityProvider[IO] = fixture.securityProvider
+      implicit val l0ctx: L0NodeContext[IO] = fixture.l0Context
+      for {
+        combiner <- Combiner.make[IO]().pure[IO]
+
+        contractFiberId <- UUIDGen.randomUUID[IO]
+
+        // Contract with guard condition that must pass
+        contractJson = """
+        {
+          "states": {
+            "pending": { "id": "pending", "isFinal": false },
+            "approved": { "id": "approved", "isFinal": true },
+            "denied": { "id": "denied", "isFinal": true }
+          },
+          "initialState": "pending",
+          "transitions": [
+            {
+              "from": "pending",
+              "to": "approved",
+              "eventName": "approve",
+              "guard": {
+                ">=": [{ "var": "event.amount" }, { "var": "state.minimumAmount" }]
+              },
+              "effect": {
+                "status": "approved",
+                "finalAmount": { "var": "event.amount" }
+              },
+              "dependencies": []
+            },
+            {
+              "from": "pending",
+              "to": "denied",
+              "eventName": "approve",
+              "guard": {
+                "<": [{ "var": "event.amount" }, { "var": "state.minimumAmount" }]
+              },
+              "effect": {
+                "status": "denied",
+                "reason": "amount too low"
+              },
+              "dependencies": []
+            }
+          ]
+        }
+        """
+
+        contractDef <- IO.fromEither(decode[StateMachineDefinition](contractJson))
+        initialData = MapValue(
+          Map(
+            "counterparty"  -> StrValue("Bob"),
+            "minimumAmount" -> IntValue(1000)
+          )
+        )
+
+        // Alice creates the contract
+        createContract = Updates.CreateStateMachine(contractFiberId, contractDef, initialData)
+        createProof <- fixture.registry.generateProofs(createContract, Set(Alice))
+        stateAfterCreate <- combiner.insert(
+          DataState(OnChain.genesis, CalculatedState.genesis),
+          Signed(createContract, createProof)
+        )
+
+        // Bob approves with amount that meets guard condition
+        approveEvent = Updates.TransitionStateMachine(
+          contractFiberId,
+          "approve",
+          MapValue(Map("amount" -> IntValue(1500))),
+          FiberOrdinal.MinValue
+        )
+        // Guard should evaluate correctly even when Bob signs instead of Alice
+        approveProof <- fixture.registry.generateProofs(approveEvent, Set(Bob))
+        finalState   <- combiner.insert(stateAfterCreate, Signed(approveEvent, approveProof))
+
+        contract = finalState.calculated.stateMachines
+          .get(contractFiberId)
+          .collect { case r: Records.StateMachineFiberRecord => r }
+
+        status = contract.flatMap { f =>
+          f.stateData match {
+            case MapValue(m) => m.get("status").collect { case StrValue(s) => s }
+            case _           => None
+          }
+        }
+
+        finalAmount = contract.flatMap { f =>
+          f.stateData match {
+            case MapValue(m) => m.get("finalAmount").collect { case IntValue(a) => a }
+            case _           => None
+          }
+        }
+
+      } yield expect(contract.isDefined) and
+      expect(contract.map(_.currentState).contains(StateId("approved"))) and
+      expect(status.contains("approved")) and
+      expect(finalAmount.contains(BigInt(1500)))
+    }
+  }
+
+  test("guard condition fails correctly with counterparty signer") {
+    TestFixture.resource(Set(Alice, Bob)).use { fixture =>
+      implicit val s: SecurityProvider[IO] = fixture.securityProvider
+      implicit val l0ctx: L0NodeContext[IO] = fixture.l0Context
+      for {
+        combiner <- Combiner.make[IO]().pure[IO]
+
+        contractFiberId <- UUIDGen.randomUUID[IO]
+
+        // Same contract as above but test the failing guard condition
+        contractJson = """
+        {
+          "states": {
+            "pending": { "id": "pending", "isFinal": false },
+            "approved": { "id": "approved", "isFinal": true },
+            "denied": { "id": "denied", "isFinal": true }
+          },
+          "initialState": "pending",
+          "transitions": [
+            {
+              "from": "pending",
+              "to": "approved",
+              "eventName": "approve",
+              "guard": {
+                ">=": [{ "var": "event.amount" }, { "var": "state.minimumAmount" }]
+              },
+              "effect": {
+                "status": "approved",
+                "finalAmount": { "var": "event.amount" }
+              },
+              "dependencies": []
+            },
+            {
+              "from": "pending",
+              "to": "denied",
+              "eventName": "approve",
+              "guard": {
+                "<": [{ "var": "event.amount" }, { "var": "state.minimumAmount" }]
+              },
+              "effect": {
+                "status": "denied",
+                "reason": "amount too low"
+              },
+              "dependencies": []
+            }
+          ]
+        }
+        """
+
+        contractDef <- IO.fromEither(decode[StateMachineDefinition](contractJson))
+        initialData = MapValue(
+          Map(
+            "counterparty"  -> StrValue("Bob"),
+            "minimumAmount" -> IntValue(1000)
+          )
+        )
+
+        // Alice creates the contract
+        createContract = Updates.CreateStateMachine(contractFiberId, contractDef, initialData)
+        createProof <- fixture.registry.generateProofs(createContract, Set(Alice))
+        stateAfterCreate <- combiner.insert(
+          DataState(OnChain.genesis, CalculatedState.genesis),
+          Signed(createContract, createProof)
+        )
+
+        // Bob approves with amount below minimum - should trigger second guard
+        approveEvent = Updates.TransitionStateMachine(
+          contractFiberId,
+          "approve",
+          MapValue(Map("amount" -> IntValue(500))), // Below minimum of 1000
+          FiberOrdinal.MinValue
+        )
+        approveProof <- fixture.registry.generateProofs(approveEvent, Set(Bob))
+        finalState   <- combiner.insert(stateAfterCreate, Signed(approveEvent, approveProof))
+
+        contract = finalState.calculated.stateMachines
+          .get(contractFiberId)
+          .collect { case r: Records.StateMachineFiberRecord => r }
+
+        status = contract.flatMap { f =>
+          f.stateData match {
+            case MapValue(m) => m.get("status").collect { case StrValue(s) => s }
+            case _           => None
+          }
+        }
+
+        reason = contract.flatMap { f =>
+          f.stateData match {
+            case MapValue(m) => m.get("reason").collect { case StrValue(r) => r }
+            case _           => None
+          }
+        }
+
+      } yield expect(contract.isDefined) and
+      expect(contract.map(_.currentState).contains(StateId("denied"))) and
+      expect(status.contains("denied")) and
+      expect(reason.contains("amount too low"))
+    }
+  }
+}

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/MultiPartyTransitionSigningSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/MultiPartyTransitionSigningSuite.scala
@@ -33,15 +33,15 @@ object MultiPartyTransitionSigningSuite extends SimpleIOSuite {
         contractJson = """
         {
           "states": {
-            "pending": { "id": "pending", "isFinal": false },
-            "accepted": { "id": "accepted", "isFinal": true },
-            "rejected": { "id": "rejected", "isFinal": true }
+            "pending": { "id": { "value": "pending" }, "isFinal": false },
+            "accepted": { "id": { "value": "accepted" }, "isFinal": true },
+            "rejected": { "id": { "value": "rejected" }, "isFinal": true }
           },
-          "initialState": "pending",
+          "initialState": { "value": "pending" },
           "transitions": [
             {
-              "from": "pending",
-              "to": "accepted",
+              "from": { "value": "pending" },
+              "to": { "value": "accepted" },
               "eventName": "accept",
               "guard": true,
               "effect": {
@@ -51,8 +51,8 @@ object MultiPartyTransitionSigningSuite extends SimpleIOSuite {
               "dependencies": []
             },
             {
-              "from": "pending",
-              "to": "rejected", 
+              "from": { "value": "pending" },
+              "to": { "value": "rejected" }, 
               "eventName": "reject",
               "guard": true,
               "effect": {
@@ -85,7 +85,7 @@ object MultiPartyTransitionSigningSuite extends SimpleIOSuite {
         )
         // This should work in the multi-party system - Bob can sign accept
         acceptProof <- fixture.registry.generateProofs(acceptEvent, Set(Bob))
-        finalState  <- combiner.insert(stateAfterCreate, Signed(acceptEvent, acceptProof))
+        finalState <- combiner.insert(stateAfterCreate, Signed(acceptEvent, acceptProof))
 
         contract = finalState.calculated.stateMachines
           .get(contractFiberId)
@@ -94,7 +94,7 @@ object MultiPartyTransitionSigningSuite extends SimpleIOSuite {
         status = contract.flatMap { f =>
           f.stateData match {
             case MapValue(m) => m.get("status").collect { case StrValue(s) => s }
-            case _           => None
+            case _ => None
           }
         }
 
@@ -116,15 +116,15 @@ object MultiPartyTransitionSigningSuite extends SimpleIOSuite {
         contractJson = """
         {
           "states": {
-            "pending": { "id": "pending", "isFinal": false },
-            "accepted": { "id": "accepted", "isFinal": true },
-            "rejected": { "id": "rejected", "isFinal": true }
+            "pending": { "id": { "value": "pending" }, "isFinal": false },
+            "accepted": { "id": { "value": "accepted" }, "isFinal": true },
+            "rejected": { "id": { "value": "rejected" }, "isFinal": true }
           },
-          "initialState": "pending",
+          "initialState": { "value": "pending" },
           "transitions": [
             {
-              "from": "pending",
-              "to": "accepted",
+              "from": { "value": "pending" },
+              "to": { "value": "accepted" },
               "eventName": "accept",
               "guard": true,
               "effect": {
@@ -133,8 +133,8 @@ object MultiPartyTransitionSigningSuite extends SimpleIOSuite {
               "dependencies": []
             },
             {
-              "from": "pending",
-              "to": "rejected", 
+              "from": { "value": "pending" },
+              "to": { "value": "rejected" }, 
               "eventName": "reject",
               "guard": true,
               "effect": {
@@ -167,7 +167,7 @@ object MultiPartyTransitionSigningSuite extends SimpleIOSuite {
         )
         // This should work in the multi-party system - Bob can sign reject
         rejectProof <- fixture.registry.generateProofs(rejectEvent, Set(Bob))
-        finalState  <- combiner.insert(stateAfterCreate, Signed(rejectEvent, rejectProof))
+        finalState <- combiner.insert(stateAfterCreate, Signed(rejectEvent, rejectProof))
 
         contract = finalState.calculated.stateMachines
           .get(contractFiberId)
@@ -176,14 +176,14 @@ object MultiPartyTransitionSigningSuite extends SimpleIOSuite {
         status = contract.flatMap { f =>
           f.stateData match {
             case MapValue(m) => m.get("status").collect { case StrValue(s) => s }
-            case _           => None
+            case _ => None
           }
         }
 
         reason = contract.flatMap { f =>
           f.stateData match {
             case MapValue(m) => m.get("reason").collect { case StrValue(r) => r }
-            case _           => None
+            case _ => None
           }
         }
 
@@ -206,14 +206,14 @@ object MultiPartyTransitionSigningSuite extends SimpleIOSuite {
         contractJson = """
         {
           "states": {
-            "pending": { "id": "pending", "isFinal": false },
-            "accepted": { "id": "accepted", "isFinal": true }
+            "pending": { "id": { "value": "pending" }, "isFinal": false },
+            "accepted": { "id": { "value": "accepted" }, "isFinal": true }
           },
-          "initialState": "pending",
+          "initialState": { "value": "pending" },
           "transitions": [
             {
-              "from": "pending",
-              "to": "accepted",
+              "from": { "value": "pending" },
+              "to": { "value": "accepted" },
               "eventName": "accept",
               "guard": true,
               "effect": {
@@ -243,10 +243,10 @@ object MultiPartyTransitionSigningSuite extends SimpleIOSuite {
           MapValue(Map("timestamp" -> IntValue(System.currentTimeMillis()))),
           FiberOrdinal.MinValue
         )
-
+        
         // This should fail - Charlie is not owner (Alice) or counterparty (Bob)
         charlieProof <- fixture.registry.generateProofs(acceptEvent, Set(Charlie))
-        result       <- combiner.insert(stateAfterCreate, Signed(acceptEvent, charlieProof)).attempt
+        result <- combiner.insert(stateAfterCreate, Signed(acceptEvent, charlieProof)).attempt
 
         // The system should reject this transaction
         // In the current system this would pass, but in multi-party system it should fail
@@ -267,14 +267,14 @@ object MultiPartyTransitionSigningSuite extends SimpleIOSuite {
         contractJson = """
         {
           "states": {
-            "pending": { "id": "pending", "isFinal": false },
-            "cancelled": { "id": "cancelled", "isFinal": true }
+            "pending": { "id": { "value": "pending" }, "isFinal": false },
+            "cancelled": { "id": { "value": "cancelled" }, "isFinal": true }
           },
-          "initialState": "pending",
+          "initialState": { "value": "pending" },
           "transitions": [
             {
-              "from": "pending",
-              "to": "cancelled",
+              "from": { "value": "pending" },
+              "to": { "value": "cancelled" },
               "eventName": "cancel",
               "guard": true,
               "effect": {
@@ -306,7 +306,7 @@ object MultiPartyTransitionSigningSuite extends SimpleIOSuite {
           FiberOrdinal.MinValue
         )
         cancelProof <- fixture.registry.generateProofs(cancelEvent, Set(Alice))
-        finalState  <- combiner.insert(stateAfterCreate, Signed(cancelEvent, cancelProof))
+        finalState <- combiner.insert(stateAfterCreate, Signed(cancelEvent, cancelProof))
 
         contract = finalState.calculated.stateMachines
           .get(contractFiberId)
@@ -315,7 +315,7 @@ object MultiPartyTransitionSigningSuite extends SimpleIOSuite {
         status = contract.flatMap { f =>
           f.stateData match {
             case MapValue(m) => m.get("status").collect { case StrValue(s) => s }
-            case _           => None
+            case _ => None
           }
         }
 
@@ -338,15 +338,15 @@ object MultiPartyTransitionSigningSuite extends SimpleIOSuite {
         contractJson = """
         {
           "states": {
-            "pending": { "id": "pending", "isFinal": false },
-            "approved": { "id": "approved", "isFinal": true },
-            "denied": { "id": "denied", "isFinal": true }
+            "pending": { "id": { "value": "pending" }, "isFinal": false },
+            "approved": { "id": { "value": "approved" }, "isFinal": true },
+            "denied": { "id": { "value": "denied" }, "isFinal": true }
           },
-          "initialState": "pending",
+          "initialState": { "value": "pending" },
           "transitions": [
             {
-              "from": "pending",
-              "to": "approved",
+              "from": { "value": "pending" },
+              "to": { "value": "approved" },
               "eventName": "approve",
               "guard": {
                 ">=": [{ "var": "event.amount" }, { "var": "state.minimumAmount" }]
@@ -358,8 +358,8 @@ object MultiPartyTransitionSigningSuite extends SimpleIOSuite {
               "dependencies": []
             },
             {
-              "from": "pending",
-              "to": "denied",
+              "from": { "value": "pending" },
+              "to": { "value": "denied" },
               "eventName": "approve",
               "guard": {
                 "<": [{ "var": "event.amount" }, { "var": "state.minimumAmount" }]
@@ -375,12 +375,10 @@ object MultiPartyTransitionSigningSuite extends SimpleIOSuite {
         """
 
         contractDef <- IO.fromEither(decode[StateMachineDefinition](contractJson))
-        initialData = MapValue(
-          Map(
-            "counterparty"  -> StrValue("Bob"),
-            "minimumAmount" -> IntValue(1000)
-          )
-        )
+        initialData = MapValue(Map(
+          "counterparty" -> StrValue("Bob"),
+          "minimumAmount" -> IntValue(1000)
+        ))
 
         // Alice creates the contract
         createContract = Updates.CreateStateMachine(contractFiberId, contractDef, initialData)
@@ -399,7 +397,7 @@ object MultiPartyTransitionSigningSuite extends SimpleIOSuite {
         )
         // Guard should evaluate correctly even when Bob signs instead of Alice
         approveProof <- fixture.registry.generateProofs(approveEvent, Set(Bob))
-        finalState   <- combiner.insert(stateAfterCreate, Signed(approveEvent, approveProof))
+        finalState <- combiner.insert(stateAfterCreate, Signed(approveEvent, approveProof))
 
         contract = finalState.calculated.stateMachines
           .get(contractFiberId)
@@ -408,14 +406,14 @@ object MultiPartyTransitionSigningSuite extends SimpleIOSuite {
         status = contract.flatMap { f =>
           f.stateData match {
             case MapValue(m) => m.get("status").collect { case StrValue(s) => s }
-            case _           => None
+            case _ => None
           }
         }
 
         finalAmount = contract.flatMap { f =>
           f.stateData match {
             case MapValue(m) => m.get("finalAmount").collect { case IntValue(a) => a }
-            case _           => None
+            case _ => None
           }
         }
 
@@ -439,15 +437,15 @@ object MultiPartyTransitionSigningSuite extends SimpleIOSuite {
         contractJson = """
         {
           "states": {
-            "pending": { "id": "pending", "isFinal": false },
-            "approved": { "id": "approved", "isFinal": true },
-            "denied": { "id": "denied", "isFinal": true }
+            "pending": { "id": { "value": "pending" }, "isFinal": false },
+            "approved": { "id": { "value": "approved" }, "isFinal": true },
+            "denied": { "id": { "value": "denied" }, "isFinal": true }
           },
-          "initialState": "pending",
+          "initialState": { "value": "pending" },
           "transitions": [
             {
-              "from": "pending",
-              "to": "approved",
+              "from": { "value": "pending" },
+              "to": { "value": "approved" },
               "eventName": "approve",
               "guard": {
                 ">=": [{ "var": "event.amount" }, { "var": "state.minimumAmount" }]
@@ -459,8 +457,8 @@ object MultiPartyTransitionSigningSuite extends SimpleIOSuite {
               "dependencies": []
             },
             {
-              "from": "pending",
-              "to": "denied",
+              "from": { "value": "pending" },
+              "to": { "value": "denied" },
               "eventName": "approve",
               "guard": {
                 "<": [{ "var": "event.amount" }, { "var": "state.minimumAmount" }]
@@ -476,12 +474,10 @@ object MultiPartyTransitionSigningSuite extends SimpleIOSuite {
         """
 
         contractDef <- IO.fromEither(decode[StateMachineDefinition](contractJson))
-        initialData = MapValue(
-          Map(
-            "counterparty"  -> StrValue("Bob"),
-            "minimumAmount" -> IntValue(1000)
-          )
-        )
+        initialData = MapValue(Map(
+          "counterparty" -> StrValue("Bob"),
+          "minimumAmount" -> IntValue(1000)
+        ))
 
         // Alice creates the contract
         createContract = Updates.CreateStateMachine(contractFiberId, contractDef, initialData)
@@ -499,7 +495,7 @@ object MultiPartyTransitionSigningSuite extends SimpleIOSuite {
           FiberOrdinal.MinValue
         )
         approveProof <- fixture.registry.generateProofs(approveEvent, Set(Bob))
-        finalState   <- combiner.insert(stateAfterCreate, Signed(approveEvent, approveProof))
+        finalState <- combiner.insert(stateAfterCreate, Signed(approveEvent, approveProof))
 
         contract = finalState.calculated.stateMachines
           .get(contractFiberId)
@@ -508,14 +504,14 @@ object MultiPartyTransitionSigningSuite extends SimpleIOSuite {
         status = contract.flatMap { f =>
           f.stateData match {
             case MapValue(m) => m.get("status").collect { case StrValue(s) => s }
-            case _           => None
+            case _ => None
           }
         }
 
         reason = contract.flatMap { f =>
           f.stateData match {
             case MapValue(m) => m.get("reason").collect { case StrValue(r) => r }
-            case _           => None
+            case _ => None
           }
         }
 

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/MultiPartyTransitionSigningSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/MultiPartyTransitionSigningSuite.scala
@@ -4,14 +4,14 @@ import cats.effect.IO
 import cats.effect.std.UUIDGen
 import cats.syntax.all._
 
-import io.constellationnetwork.currency.dataApplication.{DataState, L0NodeContext}
+import io.constellationnetwork.currency.dataApplication.{DataState, L0NodeContext, L1NodeContext}
 import io.constellationnetwork.metagraph_sdk.json_logic._
 import io.constellationnetwork.security.SecurityProvider
 import io.constellationnetwork.security.signature.Signed
 
 import xyz.kd5ujc.schema.fiber._
 import xyz.kd5ujc.schema.{CalculatedState, OnChain, Records, Updates}
-import xyz.kd5ujc.shared_data.lifecycle.Combiner
+import xyz.kd5ujc.shared_data.lifecycle.{Combiner, Validator}
 import xyz.kd5ujc.shared_test.Participant._
 import xyz.kd5ujc.shared_test.TestFixture
 
@@ -85,7 +85,7 @@ object MultiPartyTransitionSigningSuite extends SimpleIOSuite {
         )
         // This should work in the multi-party system - Bob can sign accept
         acceptProof <- fixture.registry.generateProofs(acceptEvent, Set(Bob))
-        finalState <- combiner.insert(stateAfterCreate, Signed(acceptEvent, acceptProof))
+        finalState  <- combiner.insert(stateAfterCreate, Signed(acceptEvent, acceptProof))
 
         contract = finalState.calculated.stateMachines
           .get(contractFiberId)
@@ -94,7 +94,7 @@ object MultiPartyTransitionSigningSuite extends SimpleIOSuite {
         status = contract.flatMap { f =>
           f.stateData match {
             case MapValue(m) => m.get("status").collect { case StrValue(s) => s }
-            case _ => None
+            case _           => None
           }
         }
 
@@ -167,7 +167,7 @@ object MultiPartyTransitionSigningSuite extends SimpleIOSuite {
         )
         // This should work in the multi-party system - Bob can sign reject
         rejectProof <- fixture.registry.generateProofs(rejectEvent, Set(Bob))
-        finalState <- combiner.insert(stateAfterCreate, Signed(rejectEvent, rejectProof))
+        finalState  <- combiner.insert(stateAfterCreate, Signed(rejectEvent, rejectProof))
 
         contract = finalState.calculated.stateMachines
           .get(contractFiberId)
@@ -176,14 +176,14 @@ object MultiPartyTransitionSigningSuite extends SimpleIOSuite {
         status = contract.flatMap { f =>
           f.stateData match {
             case MapValue(m) => m.get("status").collect { case StrValue(s) => s }
-            case _ => None
+            case _           => None
           }
         }
 
         reason = contract.flatMap { f =>
           f.stateData match {
             case MapValue(m) => m.get("reason").collect { case StrValue(r) => r }
-            case _ => None
+            case _           => None
           }
         }
 
@@ -198,8 +198,10 @@ object MultiPartyTransitionSigningSuite extends SimpleIOSuite {
     TestFixture.resource(Set(Alice, Bob, Charlie)).use { fixture =>
       implicit val s: SecurityProvider[IO] = fixture.securityProvider
       implicit val l0ctx: L0NodeContext[IO] = fixture.l0Context
+      implicit val l1ctx: L1NodeContext[IO] = fixture.l1Context
       for {
-        combiner <- Combiner.make[IO]().pure[IO]
+        combiner  <- Combiner.make[IO]().pure[IO]
+        validator <- Validator.make[IO]
 
         contractFiberId <- UUIDGen.randomUUID[IO]
 
@@ -228,7 +230,7 @@ object MultiPartyTransitionSigningSuite extends SimpleIOSuite {
         contractDef <- IO.fromEither(decode[StateMachineDefinition](contractJson))
         initialData = MapValue(Map("counterparty" -> StrValue("Bob")))
 
-        // Alice creates the contract
+        // Alice creates the contract (only Alice is owner, no participants declared)
         createContract = Updates.CreateStateMachine(contractFiberId, contractDef, initialData)
         createProof <- fixture.registry.generateProofs(createContract, Set(Alice))
         stateAfterCreate <- combiner.insert(
@@ -243,15 +245,18 @@ object MultiPartyTransitionSigningSuite extends SimpleIOSuite {
           MapValue(Map("timestamp" -> IntValue(System.currentTimeMillis()))),
           FiberOrdinal.MinValue
         )
-        
-        // This should fail - Charlie is not owner (Alice) or counterparty (Bob)
+
+        // Validator should reject Charlie — not owner and not in participants
         charlieProof <- fixture.registry.generateProofs(acceptEvent, Set(Charlie))
-        result <- combiner.insert(stateAfterCreate, Signed(acceptEvent, charlieProof)).attempt
+        result       <- validator.validateSignedUpdate(stateAfterCreate, Signed(acceptEvent, charlieProof))
 
-        // The system should reject this transaction
-        // In the current system this would pass, but in multi-party system it should fail
-
-      } yield expect(result.isLeft) // Should fail because Charlie is not authorized
+      } yield expect(result.isInvalid) and
+      expect(
+        result.swap
+          .exists(
+            _.exists(e => e.message.toLowerCase.contains("authorized") || e.message.toLowerCase.contains("owner"))
+          )
+      )
     }
   }
 
@@ -306,7 +311,7 @@ object MultiPartyTransitionSigningSuite extends SimpleIOSuite {
           FiberOrdinal.MinValue
         )
         cancelProof <- fixture.registry.generateProofs(cancelEvent, Set(Alice))
-        finalState <- combiner.insert(stateAfterCreate, Signed(cancelEvent, cancelProof))
+        finalState  <- combiner.insert(stateAfterCreate, Signed(cancelEvent, cancelProof))
 
         contract = finalState.calculated.stateMachines
           .get(contractFiberId)
@@ -315,7 +320,7 @@ object MultiPartyTransitionSigningSuite extends SimpleIOSuite {
         status = contract.flatMap { f =>
           f.stateData match {
             case MapValue(m) => m.get("status").collect { case StrValue(s) => s }
-            case _ => None
+            case _           => None
           }
         }
 
@@ -375,10 +380,12 @@ object MultiPartyTransitionSigningSuite extends SimpleIOSuite {
         """
 
         contractDef <- IO.fromEither(decode[StateMachineDefinition](contractJson))
-        initialData = MapValue(Map(
-          "counterparty" -> StrValue("Bob"),
-          "minimumAmount" -> IntValue(1000)
-        ))
+        initialData = MapValue(
+          Map(
+            "counterparty"  -> StrValue("Bob"),
+            "minimumAmount" -> IntValue(1000)
+          )
+        )
 
         // Alice creates the contract
         createContract = Updates.CreateStateMachine(contractFiberId, contractDef, initialData)
@@ -397,7 +404,7 @@ object MultiPartyTransitionSigningSuite extends SimpleIOSuite {
         )
         // Guard should evaluate correctly even when Bob signs instead of Alice
         approveProof <- fixture.registry.generateProofs(approveEvent, Set(Bob))
-        finalState <- combiner.insert(stateAfterCreate, Signed(approveEvent, approveProof))
+        finalState   <- combiner.insert(stateAfterCreate, Signed(approveEvent, approveProof))
 
         contract = finalState.calculated.stateMachines
           .get(contractFiberId)
@@ -406,14 +413,14 @@ object MultiPartyTransitionSigningSuite extends SimpleIOSuite {
         status = contract.flatMap { f =>
           f.stateData match {
             case MapValue(m) => m.get("status").collect { case StrValue(s) => s }
-            case _ => None
+            case _           => None
           }
         }
 
         finalAmount = contract.flatMap { f =>
           f.stateData match {
             case MapValue(m) => m.get("finalAmount").collect { case IntValue(a) => a }
-            case _ => None
+            case _           => None
           }
         }
 
@@ -474,10 +481,12 @@ object MultiPartyTransitionSigningSuite extends SimpleIOSuite {
         """
 
         contractDef <- IO.fromEither(decode[StateMachineDefinition](contractJson))
-        initialData = MapValue(Map(
-          "counterparty" -> StrValue("Bob"),
-          "minimumAmount" -> IntValue(1000)
-        ))
+        initialData = MapValue(
+          Map(
+            "counterparty"  -> StrValue("Bob"),
+            "minimumAmount" -> IntValue(1000)
+          )
+        )
 
         // Alice creates the contract
         createContract = Updates.CreateStateMachine(contractFiberId, contractDef, initialData)
@@ -495,7 +504,7 @@ object MultiPartyTransitionSigningSuite extends SimpleIOSuite {
           FiberOrdinal.MinValue
         )
         approveProof <- fixture.registry.generateProofs(approveEvent, Set(Bob))
-        finalState <- combiner.insert(stateAfterCreate, Signed(approveEvent, approveProof))
+        finalState   <- combiner.insert(stateAfterCreate, Signed(approveEvent, approveProof))
 
         contract = finalState.calculated.stateMachines
           .get(contractFiberId)
@@ -504,14 +513,14 @@ object MultiPartyTransitionSigningSuite extends SimpleIOSuite {
         status = contract.flatMap { f =>
           f.stateData match {
             case MapValue(m) => m.get("status").collect { case StrValue(s) => s }
-            case _ => None
+            case _           => None
           }
         }
 
         reason = contract.flatMap { f =>
           f.stateData match {
             case MapValue(m) => m.get("reason").collect { case StrValue(r) => r }
-            case _ => None
+            case _           => None
           }
         }
 

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/MultiPartyTransitionSigningSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/MultiPartyTransitionSigningSuite.scala
@@ -33,15 +33,15 @@ object MultiPartyTransitionSigningSuite extends SimpleIOSuite {
         contractJson = """
         {
           "states": {
-            "pending": { "id": { "value": "pending" }, "isFinal": false },
-            "accepted": { "id": { "value": "accepted" }, "isFinal": true },
-            "rejected": { "id": { "value": "rejected" }, "isFinal": true }
+            "pending": { "id": "pending", "isFinal": false },
+            "accepted": { "id": "accepted", "isFinal": true },
+            "rejected": { "id": "rejected", "isFinal": true }
           },
-          "initialState": { "value": "pending" },
+          "initialState": "pending",
           "transitions": [
             {
-              "from": { "value": "pending" },
-              "to": { "value": "accepted" },
+              "from": "pending",
+              "to": "accepted",
               "eventName": "accept",
               "guard": true,
               "effect": {
@@ -51,8 +51,8 @@ object MultiPartyTransitionSigningSuite extends SimpleIOSuite {
               "dependencies": []
             },
             {
-              "from": { "value": "pending" },
-              "to": { "value": "rejected" }, 
+              "from": "pending",
+              "to": "rejected", 
               "eventName": "reject",
               "guard": true,
               "effect": {
@@ -116,15 +116,15 @@ object MultiPartyTransitionSigningSuite extends SimpleIOSuite {
         contractJson = """
         {
           "states": {
-            "pending": { "id": { "value": "pending" }, "isFinal": false },
-            "accepted": { "id": { "value": "accepted" }, "isFinal": true },
-            "rejected": { "id": { "value": "rejected" }, "isFinal": true }
+            "pending": { "id": "pending", "isFinal": false },
+            "accepted": { "id": "accepted", "isFinal": true },
+            "rejected": { "id": "rejected", "isFinal": true }
           },
-          "initialState": { "value": "pending" },
+          "initialState": "pending",
           "transitions": [
             {
-              "from": { "value": "pending" },
-              "to": { "value": "accepted" },
+              "from": "pending",
+              "to": "accepted",
               "eventName": "accept",
               "guard": true,
               "effect": {
@@ -133,8 +133,8 @@ object MultiPartyTransitionSigningSuite extends SimpleIOSuite {
               "dependencies": []
             },
             {
-              "from": { "value": "pending" },
-              "to": { "value": "rejected" }, 
+              "from": "pending",
+              "to": "rejected", 
               "eventName": "reject",
               "guard": true,
               "effect": {
@@ -208,14 +208,14 @@ object MultiPartyTransitionSigningSuite extends SimpleIOSuite {
         contractJson = """
         {
           "states": {
-            "pending": { "id": { "value": "pending" }, "isFinal": false },
-            "accepted": { "id": { "value": "accepted" }, "isFinal": true }
+            "pending": { "id": "pending", "isFinal": false },
+            "accepted": { "id": "accepted", "isFinal": true }
           },
-          "initialState": { "value": "pending" },
+          "initialState": "pending",
           "transitions": [
             {
-              "from": { "value": "pending" },
-              "to": { "value": "accepted" },
+              "from": "pending",
+              "to": "accepted",
               "eventName": "accept",
               "guard": true,
               "effect": {
@@ -272,14 +272,14 @@ object MultiPartyTransitionSigningSuite extends SimpleIOSuite {
         contractJson = """
         {
           "states": {
-            "pending": { "id": { "value": "pending" }, "isFinal": false },
-            "cancelled": { "id": { "value": "cancelled" }, "isFinal": true }
+            "pending": { "id": "pending", "isFinal": false },
+            "cancelled": { "id": "cancelled", "isFinal": true }
           },
-          "initialState": { "value": "pending" },
+          "initialState": "pending",
           "transitions": [
             {
-              "from": { "value": "pending" },
-              "to": { "value": "cancelled" },
+              "from": "pending",
+              "to": "cancelled",
               "eventName": "cancel",
               "guard": true,
               "effect": {
@@ -343,15 +343,15 @@ object MultiPartyTransitionSigningSuite extends SimpleIOSuite {
         contractJson = """
         {
           "states": {
-            "pending": { "id": { "value": "pending" }, "isFinal": false },
-            "approved": { "id": { "value": "approved" }, "isFinal": true },
-            "denied": { "id": { "value": "denied" }, "isFinal": true }
+            "pending": { "id": "pending", "isFinal": false },
+            "approved": { "id": "approved", "isFinal": true },
+            "denied": { "id": "denied", "isFinal": true }
           },
-          "initialState": { "value": "pending" },
+          "initialState": "pending",
           "transitions": [
             {
-              "from": { "value": "pending" },
-              "to": { "value": "approved" },
+              "from": "pending",
+              "to": "approved",
               "eventName": "approve",
               "guard": {
                 ">=": [{ "var": "event.amount" }, { "var": "state.minimumAmount" }]
@@ -363,8 +363,8 @@ object MultiPartyTransitionSigningSuite extends SimpleIOSuite {
               "dependencies": []
             },
             {
-              "from": { "value": "pending" },
-              "to": { "value": "denied" },
+              "from": "pending",
+              "to": "denied",
               "eventName": "approve",
               "guard": {
                 "<": [{ "var": "event.amount" }, { "var": "state.minimumAmount" }]
@@ -444,15 +444,15 @@ object MultiPartyTransitionSigningSuite extends SimpleIOSuite {
         contractJson = """
         {
           "states": {
-            "pending": { "id": { "value": "pending" }, "isFinal": false },
-            "approved": { "id": { "value": "approved" }, "isFinal": true },
-            "denied": { "id": { "value": "denied" }, "isFinal": true }
+            "pending": { "id": "pending", "isFinal": false },
+            "approved": { "id": "approved", "isFinal": true },
+            "denied": { "id": "denied", "isFinal": true }
           },
-          "initialState": { "value": "pending" },
+          "initialState": "pending",
           "transitions": [
             {
-              "from": { "value": "pending" },
-              "to": { "value": "approved" },
+              "from": "pending",
+              "to": "approved",
               "eventName": "approve",
               "guard": {
                 ">=": [{ "var": "event.amount" }, { "var": "state.minimumAmount" }]
@@ -464,8 +464,8 @@ object MultiPartyTransitionSigningSuite extends SimpleIOSuite {
               "dependencies": []
             },
             {
-              "from": { "value": "pending" },
-              "to": { "value": "denied" },
+              "from": "pending",
+              "to": "denied",
               "eventName": "approve",
               "guard": {
                 "<": [{ "var": "event.amount" }, { "var": "state.minimumAmount" }]


### PR DESCRIPTION
## Summary

Multi-party transition signing for OttoChain fibers — counterparties declared at creation can co-sign state transitions. **This is a clean rebase of #133 onto current `main`**; #133's branch carried ~10.7k lines of churn (a vendored `sdk/package-lock.json`, generated TS, mass doc deletions) burying the actual ~1.1k-line feature. This PR is the feature only, re-verified against `main`.

Supersedes #133 (close that one).

## What's in it
- **`Updates.CreateStateMachine`**: `participants: Option[Set[Address]] = None` — signed-message field, `Option`/omit-safe per the signing-canonical invariant.
- **`Records.StateMachineFiberRecord`**: `authorizedSigners: Set[Address] = Set.empty` (record/calculated-state, default is fine here).
- **`FiberCombiner`**: populates `authorizedSigners` from `participants` at creation.
- **`FiberRules.L0.updateSignedByOwnerOrParticipant`** + **`FiberValidator`**: transitions accept owner **or** authorized participant; archive stays owner-only.
- **`StateId`**: decoder also accepts the wrapped `{"value":"x"}` form used by the TDD fixtures (encoder unchanged — plain string is canonical, so this is **not** a signing footgun: verification always re-encodes via the plain-string encoder). Candidate for follow-up cleanup (convert fixtures to plain-string, tighten decoder), consistent with the e2e plain-string direction.

## Verification (against current `main`, native sbt)
- `MultiPartyTransitionSigningSuite` — **6/6**: counterparty can sign accept/reject on a fiber they didn't create; unauthorized third party rejected; owner retains full rights; guards evaluate correctly with counterparty signers.
- Full `shared-data` suite — **350/350**, zero regression from the schema changes.
- **New signing-canonical guard** in `CreateStateMachineDecodeSuite`: asserts the canonical form omits `participants` when `None` (mirrors the existing `schemaRef` guard) — satisfies the CLAUDE.md invariant for new signed-message fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)