### PR TITLE
feat(registry): versionable scripts + machine/script symmetry + signing invariant fixes

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -155,8 +155,17 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # DL1 data-consensus peers-count = N-1 so EVERY round includes all 3 DL1
+          # nodes. Default is 1 (dag-l1.conf), which leaves one node out of each
+          # round; its mempool copy lingers and goes stale, producing out-of-order
+          # SequenceNumberMismatch updates that sink the all-or-nothing data block
+          # for every fiber bundled in it — surfaces as flaky DL1-sync timeouts under
+          # parallel load. Inject via the compose-runner's --env passthrough; the
+          # dag-l1.conf ${?DATA_PEERS_COUNT} HOCON override reads it.
+          printf 'DATA_PEERS_COUNT=2\n' > "${RUNNER_TEMP}/dl1-extra.env"
           just up --hypergraph-release="v${{ steps.versions.outputs.tessellation }}" \
-            --skip-assembly --metagraph="${GITHUB_WORKSPACE}" --dl1 --data
+            --skip-assembly --metagraph="${GITHUB_WORKSPACE}" --dl1 --data \
+            --env="${RUNNER_TEMP}/dl1-extra.env"
 
       - name: Wait for cluster health
         run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,27 @@
 - keep the work log up to date in .workspace/ when we have reached a stopping point or completed a task
+
+## Data-application invariants (read before touching signed messages or validators)
+
+See `docs/signing-canonical-and-validation.md` for the full rationale. The two rules:
+
+1. **Signed-message fields are `Option[T]` (omit-safe) or REQUIRED (no default) — never a
+   non-`Option` field with a default.** A `Boolean = false` / `SortedMap = empty` on a signed
+   message is a latent `InvalidSignature`: the client omits it, the chain's decoder re-fills it,
+   and the signed vs verified canonicals diverge (dropNulls strips `null`, not `false`/`{}`).
+   Guarded by `PublishVersionSigningCanonicalSuite` — add a case for any new signed message.
+
+2. **The block-validity gate (`validateUpdate`/`validateSignedUpdate`) does STRUCTURAL checks
+   only; stateful rejection that needs `CalculatedState` goes in the combiner** (graceful
+   `CombineRejected` → `RejectionReceipt`, the authoritative deterministic gate). tessellation
+   block acceptance is all-or-nothing, so a stateful Invalid on one tx drops the whole block.
+   Registry stateful checks are combine-only (L1 can't see the version lineage); fiber stateful
+   checks stay at L1 (`OnChain.fiberCommits` has the seqNum).
+
+3. **`validateSignedUpdate` (block acceptance) must NEVER read `CalculatedState.registry` lineage.**
+   Any validator that calls `lineageOf` / `refResolvesAndMatches` / `versionAppendable` inside
+   `validateSignedUpdate` is a block-poisoning hazard: a TOCTOU race (concurrent publish, yank)
+   returns `Invalid` → the entire block is dropped for ALL transactions in the snapshot.
+   Rule: registry lineage checks belong ONLY in the combiner as graceful `CombineRejected`.
+   `validateSignedUpdate` for fiber upgrade/create ops: structural checks only (field presence,
+   expression depth, sequence number against `OnChain`). Guarded by this comment — review every
+   new L0Validator method that takes a `SchemaRef` or `SchemaBinding` parameter.

--- a/e2e-test/lib/registry/publishVersion.ts
+++ b/e2e-test/lib/registry/publishVersion.ts
@@ -2,7 +2,6 @@ import fs from 'fs';
 import path from 'path';
 import type {
   OttochainMessage,
-  PublishVersion,
   SchemaShape,
   StateMachineDefinition,
   CalculatedState,
@@ -40,18 +39,21 @@ function loadMaybe<T>(v: string | T): T {
 }
 
 export const generator = ({ options }: { cid?: string; wallets?: unknown; options: PublishVersionOptions }): OttochainMessage => {
-  const msg: PublishVersion = {
+  // NOTE: chain renamed PublishVersion -> PublishMachineVersion and `schemaShape` -> `machineShape`
+  // (machine/script registry symmetry). The @ottochain/sdk types are not regenerated yet, so this is
+  // typed loosely and runs under tsx (no compile-time check) — "force past" until the SDK is updated.
+  const msg = {
     name: options.name,
     version: options.version,
     schemaB64: options.schemaB64 ?? Buffer.from(`descriptor:${options.name}:${options.version}`).toString('base64'),
-    schemaShape: loadMaybe<SchemaShape>(options.schemaShape),
+    machineShape: loadMaybe<SchemaShape>(options.schemaShape),
     definition: loadMaybe<StateMachineDefinition>(options.definition),
     // `strict` is required on the chain (no default) — always send it so the signed canonical matches
     // what the chain re-derives. `metadata` is Option (omit-safe), so it stays conditional.
     strict: options.strict ?? false,
     ...(options.metadata ? { metadata: options.metadata } : {}),
   };
-  return { PublishVersion: msg };
+  return { PublishMachineVersion: msg } as unknown as OttochainMessage;
 };
 
 export const validator = ({ statesMap, options }: { cid?: string; statesMap: StatesMap; options: PublishVersionOptions; wallets?: unknown }) => {

--- a/modules/models/src/main/scala/xyz/kd5ujc/schema/GenesisManifest.scala
+++ b/modules/models/src/main/scala/xyz/kd5ujc/schema/GenesisManifest.scala
@@ -11,7 +11,7 @@ import derevo.derive
 
 /**
  * The off-chain "genesis manifest" produced by ottochain-sdk (#46): the CONTENT needed to pre-register the
- * std package set at genesis. It deliberately ships content (schemaShape + the JSON-Logic definition), NOT
+ * std package set at genesis. It deliberately ships content (machineShape + the JSON-Logic definition), NOT
  * consensus hashes — the chain computes schemaHash/logicHash from this via its own `computeDigest` (see
  * [[xyz.kd5ujc.shared_data.genesis.GenesisManifestLoader]]). A package's registered `logicHash` is therefore
  * identical-by-construction to a fiber's bind-time `definition.computeDigest`: no cross-language hash
@@ -25,10 +25,10 @@ final case class GenesisManifest(
 
 @derive(customizableEncoder, customizableDecoder)
 final case class ManifestPackage(
-  name:        RegistryName,
-  semver:      SemVer,
-  schemaShape: SchemaShape,
-  definition:  StateMachineDefinition,
-  strict:      Boolean = false,
-  metadata:    SortedMap[String, String] = SortedMap.empty
+  name:         RegistryName,
+  semver:       SemVer,
+  machineShape: SchemaShape,
+  definition:   StateMachineDefinition,
+  strict:       Boolean = false,
+  metadata:     SortedMap[String, String] = SortedMap.empty
 )

--- a/modules/models/src/main/scala/xyz/kd5ujc/schema/GenesisManifest.scala
+++ b/modules/models/src/main/scala/xyz/kd5ujc/schema/GenesisManifest.scala
@@ -4,7 +4,7 @@ import scala.collection.immutable.SortedMap
 
 import xyz.kd5ujc.schema.CodecConfiguration._
 import xyz.kd5ujc.schema.fiber.StateMachineDefinition
-import xyz.kd5ujc.schema.registry.{RegistryName, SchemaShape, SemVer}
+import xyz.kd5ujc.schema.registry.{MachineShape, RegistryName, SemVer}
 
 import derevo.circe.magnolia.{customizableDecoder, customizableEncoder}
 import derevo.derive
@@ -27,7 +27,7 @@ final case class GenesisManifest(
 final case class ManifestPackage(
   name:         RegistryName,
   semver:       SemVer,
-  machineShape: SchemaShape,
+  machineShape: MachineShape,
   definition:   StateMachineDefinition,
   strict:       Boolean = false,
   metadata:     SortedMap[String, String] = SortedMap.empty

--- a/modules/models/src/main/scala/xyz/kd5ujc/schema/Records.scala
+++ b/modules/models/src/main/scala/xyz/kd5ujc/schema/Records.scala
@@ -58,6 +58,7 @@ object Records {
     sequenceNumber:      FiberOrdinal,
     owners:              Set[Address],
     status:              FiberStatus,
-    lastInvocation:      Option[OracleInvocation] = None
+    lastInvocation:      Option[OracleInvocation] = None,
+    schemaBinding:       Option[SchemaBinding] = None
   ) extends FiberRecord
 }

--- a/modules/models/src/main/scala/xyz/kd5ujc/schema/Updates.scala
+++ b/modules/models/src/main/scala/xyz/kd5ujc/schema/Updates.scala
@@ -12,7 +12,7 @@ import io.constellationnetwork.security.signature.Signed
 
 import xyz.kd5ujc.schema.CodecConfiguration._
 import xyz.kd5ujc.schema.fiber.{AccessControlPolicy, FiberOrdinal, StateMachineDefinition}
-import xyz.kd5ujc.schema.registry.{RegistryName, RegistryStatus, SchemaRef, SchemaShape, SemVer}
+import xyz.kd5ujc.schema.registry.{RegistryName, RegistryStatus, SchemaRef, SchemaShape, ScriptShape, SemVer}
 
 import derevo.circe.magnolia.{customizableDecoder, customizableEncoder}
 import derevo.derive
@@ -102,9 +102,27 @@ object Updates {
     fiberId:       UUID,
     scriptProgram: JsonLogicExpression,
     initialState:  Option[JsonLogicValue],
-    accessControl: AccessControlPolicy
+    accessControl: AccessControlPolicy,
+    schemaRef:     Option[SchemaRef] = None
   ) extends ScriptFiberOp
       with OttochainMessage
+
+  /**
+   * Upgrade an existing script fiber to a different registered version of the SAME package. The chain
+   * verifies `newProgram.computeDigest == targetVersion.logicHash` (verified re-bind), applies the optional
+   * `migration` (a JSON-Logic transform of the prior stateData) through the engine's metered evaluator, and
+   * re-pins the binding. The commute-law is NOT verified on-chain.
+   */
+  @derive(customizableDecoder, customizableEncoder)
+  final case class UpgradeScript(
+    fiberId:              UUID,
+    targetRef:            SchemaRef,
+    newProgram:           JsonLogicExpression,
+    migration:            Option[JsonLogicExpression] = None,
+    targetSequenceNumber: FiberOrdinal
+  ) extends ScriptFiberOp
+      with OttochainMessage
+      with Sequenced
 
   @derive(customizableDecoder, customizableEncoder)
   final case class InvokeScript(
@@ -128,13 +146,13 @@ object Updates {
   }
 
   /**
-   * Create-or-append a registry version (npm-publish semantics): the first publish for a name claims it and
-   * makes the signer the owner; later publishes require an existing owner.
+   * Create-or-append a registry version for a STATE-MACHINE package (npm-publish semantics): the first
+   * publish for a name claims it and makes the signer the owner; later publishes require an existing owner.
    *
    *  - `schemaB64`: the full protobuf FileDescriptorSet (≈ deployed bytecode). The chain validates it is
    *    base64, hashes it into `schemaHash`, and drops the bytes — they live in the registration update's
    *    history + the Bridge store (Etherscan-style claim; schema-architecture.md §4a).
-   *  - `schemaShape`: the typed, proto-friendly projection the chain stores for discovery (advisory).
+   *  - `machineShape`: the typed, proto-friendly projection the chain stores for discovery (advisory).
    *  - `definition`: the typed JSON-Logic state machine. The chain hashes it into `logicHash` via
    *    `computeDigest` — the same canonical digest a fiber computes — enabling VERIFIED binding (#37): a
    *    fiber referencing this version is admitted only if its definition hashes to `logicHash`. The guards
@@ -144,15 +162,39 @@ object Updates {
    * The owner is derived from the signing proofs at combine time.
    */
   @derive(customizableDecoder, customizableEncoder)
-  final case class PublishVersion(
-    name:        RegistryName,
-    version:     SemVer,
-    schemaB64:   String,
-    schemaShape: SchemaShape,
-    definition:  StateMachineDefinition,
-    strict:      Boolean,
+  final case class PublishMachineVersion(
+    name:         RegistryName,
+    version:      SemVer,
+    schemaB64:    String,
+    machineShape: SchemaShape,
+    definition:   StateMachineDefinition,
+    strict:       Boolean,
     // Optional off-chain links grab-bag (None == omitted), set on the entry at first publish.
     metadata: Option[SortedMap[String, String]] = None
+  ) extends RegistryOp
+      with OttochainMessage {
+    val fiberId: UUID = RegistryOp.routingId(name)
+  }
+
+  /**
+   * Create-or-append a registry version for a SCRIPT package. Parallel to [[PublishMachineVersion]] for state
+   * machines, but carries a `scriptProgram` (JsonLogicExpression) instead of a `StateMachineDefinition`.
+   *
+   *  - `schemaB64`: the full protobuf FileDescriptorSet (advisory, same semantics as PublishMachineVersion).
+   *  - `scriptShape`: the typed method-surface projection the chain stores for discovery.
+   *  - `scriptProgram`: the typed JSON-Logic script. The chain hashes it into `logicHash` via `computeDigest`
+   *    — enabling VERIFIED binding (#37): a script fiber referencing this version is admitted only if its
+   *    program hashes to `logicHash`.
+   */
+  @derive(customizableDecoder, customizableEncoder)
+  final case class PublishScriptVersion(
+    name:          RegistryName,
+    version:       SemVer,
+    schemaB64:     String,
+    scriptShape:   ScriptShape,
+    scriptProgram: JsonLogicExpression,
+    strict:        Boolean,
+    metadata:      Option[SortedMap[String, String]] = None
   ) extends RegistryOp
       with OttochainMessage {
     val fiberId: UUID = RegistryOp.routingId(name)
@@ -216,7 +258,9 @@ object Updates {
       case u: Updates.UpgradeFiber           => Json.obj(u.messageName -> u.asJson)
       case u: Updates.CreateScript           => Json.obj(u.messageName -> u.asJson)
       case u: Updates.InvokeScript           => Json.obj(u.messageName -> u.asJson)
-      case u: Updates.PublishVersion         => Json.obj(u.messageName -> u.asJson)
+      case u: Updates.UpgradeScript          => Json.obj(u.messageName -> u.asJson)
+      case u: Updates.PublishMachineVersion  => Json.obj(u.messageName -> u.asJson)
+      case u: Updates.PublishScriptVersion   => Json.obj(u.messageName -> u.asJson)
       case u: Updates.SetVersionStatus       => Json.obj(u.messageName -> u.asJson)
       case u: Updates.RegisterAlias          => Json.obj(u.messageName -> u.asJson)
     }
@@ -230,7 +274,9 @@ object Updates {
           Decoder[Updates.UpgradeFiber],
           Decoder[Updates.CreateScript],
           Decoder[Updates.InvokeScript],
-          Decoder[Updates.PublishVersion],
+          Decoder[Updates.UpgradeScript],
+          Decoder[Updates.PublishMachineVersion],
+          Decoder[Updates.PublishScriptVersion],
           Decoder[Updates.SetVersionStatus],
           Decoder[Updates.RegisterAlias]
         )

--- a/modules/models/src/main/scala/xyz/kd5ujc/schema/Updates.scala
+++ b/modules/models/src/main/scala/xyz/kd5ujc/schema/Updates.scala
@@ -12,7 +12,7 @@ import io.constellationnetwork.security.signature.Signed
 
 import xyz.kd5ujc.schema.CodecConfiguration._
 import xyz.kd5ujc.schema.fiber.{AccessControlPolicy, FiberOrdinal, StateMachineDefinition}
-import xyz.kd5ujc.schema.registry.{RegistryName, RegistryStatus, SchemaRef, SchemaShape, ScriptShape, SemVer}
+import xyz.kd5ujc.schema.registry.{MachineShape, RegistryName, RegistryStatus, SchemaRef, ScriptShape, SemVer}
 
 import derevo.circe.magnolia.{customizableDecoder, customizableEncoder}
 import derevo.derive
@@ -166,7 +166,7 @@ object Updates {
     name:         RegistryName,
     version:      SemVer,
     schemaB64:    String,
-    machineShape: SchemaShape,
+    machineShape: MachineShape,
     definition:   StateMachineDefinition,
     strict:       Boolean,
     // Optional off-chain links grab-bag (None == omitted), set on the entry at first publish.

--- a/modules/models/src/main/scala/xyz/kd5ujc/schema/fiber/State.scala
+++ b/modules/models/src/main/scala/xyz/kd5ujc/schema/fiber/State.scala
@@ -10,6 +10,6 @@ import derevo.derive
 @derive(customizableEncoder, customizableDecoder)
 case class State(
   id:       StateId,
-  isFinal:  Boolean = false,
+  isFinal:  Boolean,
   metadata: Option[JsonLogicValue] = None
 )

--- a/modules/models/src/main/scala/xyz/kd5ujc/schema/fiber/Transition.scala
+++ b/modules/models/src/main/scala/xyz/kd5ujc/schema/fiber/Transition.scala
@@ -16,5 +16,5 @@ case class Transition(
   eventName:    String,
   guard:        JsonLogicExpression, // Guard condition
   effect:       JsonLogicExpression, // State transformation
-  dependencies: Set[UUID] = Set.empty // Other machines this transition reads from
+  dependencies: Set[UUID] // Other machines this transition reads from
 )

--- a/modules/models/src/main/scala/xyz/kd5ujc/schema/registry/RegisteredVersion.scala
+++ b/modules/models/src/main/scala/xyz/kd5ujc/schema/registry/RegisteredVersion.scala
@@ -9,29 +9,30 @@ import derevo.circe.magnolia.{customizableDecoder, customizableEncoder}
 import derevo.derive
 
 /**
- * One immutable version of a registry entry. The chain commits only the hashes + the typed [[SchemaShape]]
- * projection (never the full descriptor or definition bytes — those live in the Bridge + the registration
- * update's history; see schema-architecture.md §4a).
+ * One immutable version of a registry entry. The chain commits only the hashes + the typed shape projection
+ * (never the full descriptor or definition bytes — those live in the Bridge + the registration update's
+ * history; see schema-architecture.md §4a).
  *
- * @param schemaHash   commitment to the protobuf FileDescriptorSet (descriptor bytes; off-chain)
- * @param logicHash    the VERIFIED-binding anchor: `StateMachineDefinition.computeDigest` of the registered
- *                     logic, computed exactly as a fiber computes its own definition's digest. A fiber that
- *                     references this version is admitted only if its definition hashes to this value (see
- *                     [[SchemaBinding]]). Two versions MAY share a logicHash (e.g. a schema-only bump).
- * @param schemaShape  the typed, proto-friendly domain projection (publisher-claimed, advisory — the
- *                     "describe" dial; never constrains the logic)
- * @param strict       opt-in runtime conformance gate (#33): when true, a fiber bound to this version has
- *                     every PRODUCED state (create/transition/migration) checked against `schemaShape` and
- *                     the transaction aborts on a non-conforming state. Default false = the loose,
- *                     experimentation path (the schema stays advisory). Publisher-decided, per version.
+ * `shape` is [[RegistryShape.Machine]] for state-machine packages or [[RegistryShape.Script]] for script
+ * packages — an ADT that carries the correct advisory projection for the kind.
+ *
+ * @param schemaHash  commitment to the protobuf FileDescriptorSet (descriptor bytes; off-chain)
+ * @param logicHash   the VERIFIED-binding anchor: `computeDigest` of the registered logic, computed exactly
+ *                    as a fiber computes its own definition/program digest. A fiber that references this
+ *                    version is admitted only if its definition/program hashes to this value (see
+ *                    [[SchemaBinding]]). Two versions MAY share a logicHash (e.g. a schema-only bump).
+ * @param shape       the kind-correct advisory projection (publisher-claimed; the "describe" dial)
+ * @param strict      opt-in runtime conformance gate (#33): for [[RegistryShape.Machine]] versions, every
+ *                    PRODUCED state is checked against the SchemaShape and the transaction aborts on
+ *                    non-conformance. Ignored for [[RegistryShape.Script]] versions.
  */
 @derive(customizableEncoder, customizableDecoder)
 final case class RegisteredVersion(
   version:      SemVer,
   schemaHash:   Hash,
   logicHash:    Hash,
-  schemaShape:  SchemaShape,
+  shape:        RegistryShape,
   status:       RegistryStatus,
   registeredAt: SnapshotOrdinal,
-  strict:       Boolean = false
+  strict:       Boolean
 )

--- a/modules/models/src/main/scala/xyz/kd5ujc/schema/registry/RegisteredVersion.scala
+++ b/modules/models/src/main/scala/xyz/kd5ujc/schema/registry/RegisteredVersion.scala
@@ -23,7 +23,7 @@ import derevo.derive
  *                    [[SchemaBinding]]). Two versions MAY share a logicHash (e.g. a schema-only bump).
  * @param shape       the kind-correct advisory projection (publisher-claimed; the "describe" dial)
  * @param strict      opt-in runtime conformance gate (#33): for [[RegistryShape.Machine]] versions, every
- *                    PRODUCED state is checked against the SchemaShape and the transaction aborts on
+ *                    PRODUCED state is checked against the MachineShape and the transaction aborts on
  *                    non-conformance. Ignored for [[RegistryShape.Script]] versions.
  */
 @derive(customizableEncoder, customizableDecoder)

--- a/modules/models/src/main/scala/xyz/kd5ujc/schema/registry/SchemaShape.scala
+++ b/modules/models/src/main/scala/xyz/kd5ujc/schema/registry/SchemaShape.scala
@@ -40,7 +40,7 @@ final case class MessageShape(
  * SortedMap[String, String]` with the typed, field-numbered shape.
  */
 @derive(customizableEncoder, customizableDecoder)
-final case class SchemaShape(
+final case class MachineShape(
   stateMessage: MessageShape,
   commands:     SortedMap[String, MessageShape]
 ) {
@@ -93,7 +93,7 @@ sealed trait RegistryShape {
 object RegistryShape {
 
   @derive(customizableEncoder, customizableDecoder)
-  final case class Machine(machineShape: SchemaShape) extends RegistryShape {
+  final case class Machine(machineShape: MachineShape) extends RegistryShape {
     def allMessages: List[MessageShape] = machineShape.allMessages
   }
 

--- a/modules/models/src/main/scala/xyz/kd5ujc/schema/registry/SchemaShape.scala
+++ b/modules/models/src/main/scala/xyz/kd5ujc/schema/registry/SchemaShape.scala
@@ -35,9 +35,9 @@ final case class MessageShape(
 )
 
 /**
- * The on-chain projection of a version's proto schema: the State message plus one message per command/event
- * (keyed by event name). Supersedes the old loose `stateMessage: String` + `commands: SortedMap[String,
- * String]` with the typed, field-numbered shape.
+ * The on-chain projection of a state-machine version's proto schema: the State message plus one message per
+ * command/event (keyed by event name). Supersedes the old loose `stateMessage: String` + `commands:
+ * SortedMap[String, String]` with the typed, field-numbered shape.
  */
 @derive(customizableEncoder, customizableDecoder)
 final case class SchemaShape(
@@ -47,4 +47,68 @@ final case class SchemaShape(
 
   /** Every message in the shape (state + all commands), for structural validation. */
   def allMessages: List[MessageShape] = stateMessage :: commands.values.toList
+}
+
+/**
+ * The on-chain projection of a script version's surface. Sealed ADT — currently one variant:
+ * [[ScriptShape.MethodDispatch]], the canonical top-level IF-ELIF-…-ELSE dispatch on method name. Future
+ * variants (pipelines, etc.) are added here without breaking the [[RegistryShape]] wire format (the
+ * `scriptShape` field in [[RegistryShape.Script]] naturally discriminates on the inner field names).
+ */
+sealed trait ScriptShape {
+  def allMessages: List[MessageShape]
+}
+
+object ScriptShape {
+
+  /**
+   * The canonical script form: a top-level `{"if":[{"==":[{"var":"method"},"methodA"]},bodyA,...,fallback]}`
+   * dispatch. Each key in `methods` names a callable method; its [[MessageShape]] describes the argument
+   * payload the method expects.
+   */
+  @derive(customizableEncoder, customizableDecoder)
+  final case class MethodDispatch(
+    methods: SortedMap[String, MessageShape]
+  ) extends ScriptShape {
+    def allMessages: List[MessageShape] = methods.values.toList
+  }
+
+  // MethodDispatch encodes as {"methods":{...}} — the "methods" key discriminates from future variants.
+  implicit val encoder: io.circe.Encoder[ScriptShape] = io.circe.Encoder.instance { case m: MethodDispatch =>
+    io.circe.Encoder[MethodDispatch].apply(m)
+  }
+
+  implicit val decoder: io.circe.Decoder[ScriptShape] =
+    io.circe.Decoder[MethodDispatch].map[ScriptShape](identity)
+}
+
+/**
+ * ADT for the advisory schema projection stored in [[RegisteredVersion]]. Exactly one variant is present:
+ * [[RegistryShape.Machine]] for state-machine packages; [[RegistryShape.Script]] for script packages.
+ */
+sealed trait RegistryShape {
+  def allMessages: List[MessageShape]
+}
+
+object RegistryShape {
+
+  @derive(customizableEncoder, customizableDecoder)
+  final case class Machine(machineShape: SchemaShape) extends RegistryShape {
+    def allMessages: List[MessageShape] = machineShape.allMessages
+  }
+
+  @derive(customizableEncoder, customizableDecoder)
+  final case class Script(scriptShape: ScriptShape) extends RegistryShape {
+    def allMessages: List[MessageShape] = scriptShape.allMessages
+  }
+
+  // Machine encodes as {"machineShape":{...}}, Script as {"scriptShape":{...}} — distinct field names
+  // act as a natural discriminator, no explicit type tag needed.
+  implicit val encoder: io.circe.Encoder[RegistryShape] = io.circe.Encoder.instance {
+    case m: Machine => io.circe.Encoder[Machine].apply(m)
+    case s: Script  => io.circe.Encoder[Script].apply(s)
+  }
+
+  implicit val decoder: io.circe.Decoder[RegistryShape] =
+    io.circe.Decoder[Machine].map[RegistryShape](identity).or(io.circe.Decoder[Script].map[RegistryShape](identity))
 }

--- a/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/fiber/ConformanceChecker.scala
+++ b/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/fiber/ConformanceChecker.scala
@@ -8,7 +8,7 @@ import xyz.kd5ujc.schema.registry._
 /**
  * Runtime conformance gate (#33, opt-in). When a fiber is bound to a `strict` registered version, the
  * state it PRODUCES (at create, transition, or migration) must conform to that version's typed
- * [[SchemaShape]] — otherwise the transaction is aborted, so a non-conforming state is never committed.
+ * [[MachineShape]] — otherwise the transaction is aborted, so a non-conforming state is never committed.
  *
  * This is the "assume + error-out" tier: it does not prove the logic conforms for all inputs (a static
  * property the chain cannot check cheaply), only that the actual produced state does — exactly how a VM
@@ -44,7 +44,7 @@ object ConformanceChecker {
 
   /**
    * If `binding` resolves to a STRICT registered version, the produced `value` must conform to its
-   * SchemaShape's state message. Returns the violations (empty == conforms OR the gate is not applicable:
+   * MachineShape's state message. Returns the violations (empty == conforms OR the gate is not applicable:
    * unbound fiber, version not found, or non-strict version).
    */
   def violationsFor(binding: Option[SchemaBinding], state: CalculatedState, value: JsonLogicValue): List[String] =

--- a/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/fiber/ConformanceChecker.scala
+++ b/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/fiber/ConformanceChecker.scala
@@ -48,7 +48,12 @@ object ConformanceChecker {
    * unbound fiber, version not found, or non-strict version).
    */
   def violationsFor(binding: Option[SchemaBinding], state: CalculatedState, value: JsonLogicValue): List[String] =
-    strictVersion(binding, state).fold(List.empty[String])(rv => check(rv.schemaShape.stateMessage, value))
+    strictVersion(binding, state).fold(List.empty[String]) { rv =>
+      rv.shape match {
+        case RegistryShape.Machine(machineShape) => check(machineShape.stateMessage, value)
+        case _: RegistryShape.Script             => List.empty
+      }
+    }
 
   private def strictVersion(binding: Option[SchemaBinding], state: CalculatedState): Option[RegisteredVersion] =
     binding.flatMap { b =>

--- a/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/fiber/FiberEngine.scala
+++ b/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/fiber/FiberEngine.scala
@@ -64,6 +64,18 @@ trait FiberEngine[F[_]] {
     newBinding:    SchemaBinding,
     migration:     Option[JsonLogicExpression]
   ): F[TransactionResult]
+
+  /**
+   * Upgrade a script fiber to `newProgram`/`newBinding`, optionally transforming its stateData via
+   * `migration`. Metered through the same `FiberT` boundary. Scripts have no state-machine state IDs, so
+   * no current-state-in-new-program check is performed.
+   */
+  def migrateScript(
+    fiberId:    UUID,
+    newProgram: JsonLogicExpression,
+    newBinding: SchemaBinding,
+    migration:  Option[JsonLogicExpression]
+  ): F[TransactionResult]
 }
 
 object FiberEngine {
@@ -105,6 +117,16 @@ object FiberEngine {
           .run(FiberContext(ordinal, lastSnapshotHash, epochProgress, limits, gasConfig, fiberGasConfig))
           .runA(ExecutionState.initial)
 
+      def migrateScript(
+        fiberId:    UUID,
+        newProgram: JsonLogicExpression,
+        newBinding: SchemaBinding,
+        migration:  Option[JsonLogicExpression]
+      ): F[TransactionResult] =
+        migrateScriptInternal(fiberId, newProgram, newBinding, migration)
+          .run(FiberContext(ordinal, lastSnapshotHash, epochProgress, limits, gasConfig, fiberGasConfig))
+          .runA(ExecutionState.initial)
+
       private def migrateInternal(
         fiberId:       UUID,
         newDefinition: StateMachineDefinition,
@@ -124,6 +146,102 @@ object FiberEngine {
           case Some(other) =>
             abortWithReason(FailureReason.FiberInputMismatch(other.fiberId, FiberKind.Script, InputKind.Transition))
         }
+
+      private def migrateScriptInternal(
+        fiberId:    UUID,
+        newProgram: JsonLogicExpression,
+        newBinding: SchemaBinding,
+        migration:  Option[JsonLogicExpression]
+      ): FiberT[F, TransactionResult] =
+        calculatedState.getFiber(fiberId) match {
+          case None =>
+            abortWithReason(FailureReason.FiberNotFound(fiberId))
+
+          case Some(fiber) if fiber.status != FiberStatus.Active =>
+            abortWithReason(FailureReason.FiberNotActive(fiberId, fiber.status.toString))
+
+          case Some(script: Records.ScriptFiberRecord) =>
+            migrateScriptFiber(script, newProgram, newBinding, migration)
+
+          case Some(other) =>
+            abortWithReason(
+              FailureReason.FiberInputMismatch(other.fiberId, FiberKind.StateMachine, InputKind.MethodCall)
+            )
+        }
+
+      private def migrateScriptFiber(
+        script:     Records.ScriptFiberRecord,
+        newProgram: JsonLogicExpression,
+        newBinding: SchemaBinding,
+        migration:  Option[JsonLogicExpression]
+      ): FiberT[F, TransactionResult] = {
+        val currentState = script.stateData.getOrElse(NullValue)
+        val evalMigration: FiberT[F, Either[FailureReason, JsonLogicValue]] =
+          migration match {
+            case None       => (currentState: JsonLogicValue).asRight[FailureReason].pure[FiberT[F, *]]
+            case Some(expr) => MeteredEvaluator.eval[F, FiberT[F, *]](expr, currentState, GasExhaustionPhase.Migration)
+          }
+
+        evalMigration.flatMap {
+          case Left(reason)     => aborted(reason)
+          case Right(NullValue) =>
+            // Migration produced null: clear the state
+            for {
+              gasUsed <- ExecutionOps.getGasUsed[FiberT[F, *]]
+              receipt = UpgradeReceipt(
+                fiberId = script.fiberId,
+                ordinal = ordinal,
+                fromBinding = script.schemaBinding,
+                toBinding = newBinding,
+                gasUsed = gasUsed,
+                migrated = migration.isDefined
+              )
+              _ <- ExecutionOps.appendLog[FiberT[F, *]](receipt)
+              updated = script.copy(
+                latestUpdateOrdinal = ordinal,
+                scriptProgram = newProgram,
+                stateData = None,
+                stateDataHash = None,
+                sequenceNumber = script.sequenceNumber.next,
+                schemaBinding = Some(newBinding)
+              )
+              logs <- ExecutionOps.getLogs[FiberT[F, *]]
+            } yield TransactionResult.Committed(
+              updatedStateMachines = Map.empty,
+              updatedOracles = Map(script.fiberId -> updated),
+              logEntries = logs.toList,
+              totalGasUsed = gasUsed
+            ): TransactionResult
+          case Right(newState) =>
+            for {
+              hash    <- newState.computeDigest.liftFiber
+              gasUsed <- ExecutionOps.getGasUsed[FiberT[F, *]]
+              receipt = UpgradeReceipt(
+                fiberId = script.fiberId,
+                ordinal = ordinal,
+                fromBinding = script.schemaBinding,
+                toBinding = newBinding,
+                gasUsed = gasUsed,
+                migrated = migration.isDefined
+              )
+              _ <- ExecutionOps.appendLog[FiberT[F, *]](receipt)
+              updated = script.copy(
+                latestUpdateOrdinal = ordinal,
+                scriptProgram = newProgram,
+                stateData = Some(newState),
+                stateDataHash = Some(hash),
+                sequenceNumber = script.sequenceNumber.next,
+                schemaBinding = Some(newBinding)
+              )
+              logs <- ExecutionOps.getLogs[FiberT[F, *]]
+            } yield TransactionResult.Committed(
+              updatedStateMachines = Map.empty,
+              updatedOracles = Map(script.fiberId -> updated),
+              logEntries = logs.toList,
+              totalGasUsed = gasUsed
+            ): TransactionResult
+        }
+      }
 
       private def aborted(reason: FailureReason): FiberT[F, TransactionResult] =
         ExecutionOps.getGasUsed[FiberT[F, *]].map(TransactionResult.Aborted(reason, _): TransactionResult)

--- a/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/fiber/evaluation/ScriptProcessor.scala
+++ b/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/fiber/evaluation/ScriptProcessor.scala
@@ -16,6 +16,7 @@ import io.constellationnetwork.security.signature.Signed
 
 import xyz.kd5ujc.schema._
 import xyz.kd5ujc.schema.fiber.{FiberOrdinal, _}
+import xyz.kd5ujc.schema.registry.SchemaBinding
 import xyz.kd5ujc.shared_data.syntax.all._
 
 object ScriptProcessor {
@@ -43,7 +44,8 @@ object ScriptProcessor {
   def createScript[F[_]: Async: SecurityProvider](
     current:        DataState[OnChain, CalculatedState],
     update:         Signed[Updates.CreateScript],
-    currentOrdinal: SnapshotOrdinal
+    currentOrdinal: SnapshotOrdinal,
+    binding:        Option[SchemaBinding] = None
   ): F[DataState[OnChain, CalculatedState]] = for {
     owners <- update.proofs.toList.traverse(_.id.toAddress).map(Set.from)
 
@@ -59,7 +61,8 @@ object ScriptProcessor {
       accessControl = update.accessControl,
       sequenceNumber = FiberOrdinal.MinValue,
       owners = owners,
-      status = FiberStatus.Active
+      status = FiberStatus.Active,
+      schemaBinding = binding
     )
 
     result <- current.withRecord[F](update.fiberId, oracleRecord)

--- a/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/genesis/GenesisBuilder.scala
+++ b/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/genesis/GenesisBuilder.scala
@@ -24,21 +24,21 @@ import xyz.kd5ujc.shared_data.syntax.DataStateOps._
  * uses (`DataStateOps.withAlias` / `withFibersAndOracles`, and `computeDigest` for package entries), so a
  * crafted genesis is byte-consistent with on-chain state — the node can boot from it and prove against it.
  *
- * Package/alias/fiber *content* (schemaHash, schemaShape, logicHash, fiber records) comes from a pinned
+ * Package/alias/fiber *content* (schemaHash, machineShape, logicHash, fiber records) comes from a pinned
  * ottochain-sdk release (genesis-prep) or a test fixture (e2e); this layer only guarantees consistency.
  */
 object GenesisBuilder {
 
   /** A package to pre-register at genesis (one initial version; further versions are published on-chain). */
   final case class PackageSpec(
-    name:        RegistryName,
-    version:     SemVer,
-    schemaHash:  Hash,
-    logicHash:   Hash,
-    schemaShape: SchemaShape,
-    owner:       Set[Address],
-    strict:      Boolean = false,
-    metadata:    SortedMap[String, String] = SortedMap.empty
+    name:         RegistryName,
+    version:      SemVer,
+    schemaHash:   Hash,
+    logicHash:    Hash,
+    machineShape: SchemaShape,
+    owner:        Set[Address],
+    strict:       Boolean = false,
+    metadata:     SortedMap[String, String] = SortedMap.empty
   )
 
   /** A nickname for a fiber instance to pre-register at genesis (#29): forward entry + reverse record. */
@@ -82,7 +82,15 @@ object GenesisBuilder {
     specs
       .traverse { s =>
         val rv =
-          RegisteredVersion(s.version, s.schemaHash, s.logicHash, s.schemaShape, RegistryStatus.Active, at, s.strict)
+          RegisteredVersion(
+            s.version,
+            s.schemaHash,
+            s.logicHash,
+            RegistryShape.Machine(s.machineShape),
+            RegistryStatus.Active,
+            at,
+            s.strict
+          )
         val entry = RegistryEntry(s.name, s.owner, RegistryTarget.SchemaPackage(VersionLineage.of(rv)), s.metadata)
         entry.computeDigest.map(hash => (s.name, entry, hash))
       }

--- a/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/genesis/GenesisBuilder.scala
+++ b/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/genesis/GenesisBuilder.scala
@@ -35,7 +35,7 @@ object GenesisBuilder {
     version:      SemVer,
     schemaHash:   Hash,
     logicHash:    Hash,
-    machineShape: SchemaShape,
+    machineShape: MachineShape,
     owner:        Set[Address],
     strict:       Boolean = false,
     metadata:     SortedMap[String, String] = SortedMap.empty

--- a/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/genesis/GenesisManifestLoader.scala
+++ b/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/genesis/GenesisManifestLoader.scala
@@ -30,13 +30,13 @@ object GenesisManifestLoader {
       .traverse { p =>
         for {
           logicHash  <- p.definition.computeDigest
-          schemaHash <- p.schemaShape.computeDigest
+          schemaHash <- p.machineShape.computeDigest
         } yield GenesisBuilder.PackageSpec(
           name = p.name,
           version = p.semver,
           schemaHash = schemaHash,
           logicHash = logicHash,
-          schemaShape = p.schemaShape,
+          machineShape = p.machineShape,
           owner = owner,
           strict = p.strict,
           metadata = p.metadata

--- a/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/Combiner.scala
+++ b/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/Combiner.scala
@@ -64,7 +64,9 @@ object Combiner {
           case u: Updates.UpgradeFiber           => fiberCombiner.upgradeFiber(Signed(u, update.proofs))
           case u: Updates.CreateScript           => oracleCombiner.createScript(Signed(u, update.proofs))
           case u: Updates.InvokeScript           => oracleCombiner.invokeScript(Signed(u, update.proofs))
-          case u: Updates.PublishVersion         => registryCombiner.publishVersion(Signed(u, update.proofs))
+          case u: Updates.UpgradeScript          => oracleCombiner.upgradeScript(Signed(u, update.proofs))
+          case u: Updates.PublishMachineVersion  => registryCombiner.publishMachineVersion(Signed(u, update.proofs))
+          case u: Updates.PublishScriptVersion   => registryCombiner.publishScriptVersion(Signed(u, update.proofs))
           case u: Updates.SetVersionStatus       => registryCombiner.setVersionStatus(Signed(u, update.proofs))
           case u: Updates.RegisterAlias          => registryCombiner.registerAlias(Signed(u, update.proofs))
         }

--- a/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/Validator.scala
+++ b/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/Validator.scala
@@ -79,7 +79,9 @@ object Validator {
               case u: UpgradeFiber           => u.fiberId.toString
               case u: CreateScript           => u.fiberId.toString
               case u: InvokeScript           => u.fiberId.toString
-              case u: PublishVersion         => u.fiberId.toString
+              case u: UpgradeScript          => u.fiberId.toString
+              case u: PublishMachineVersion  => u.fiberId.toString
+              case u: PublishScriptVersion   => u.fiberId.toString
               case u: SetVersionStatus       => u.fiberId.toString
               case u: RegisterAlias          => u.fiberId.toString
             }
@@ -98,7 +100,9 @@ object Validator {
                 case u: UpgradeFiber           => fiberL1.upgrade(u)
                 case u: CreateScript           => oracleL1.createOracle(u)
                 case u: InvokeScript           => oracleL1.invokeOracle(u)
-                case u: PublishVersion         => registryL1.publish(u)
+                case u: UpgradeScript          => oracleL1.upgradeScript(u)
+                case u: PublishMachineVersion  => registryL1.publishMachineVersion(u)
+                case u: PublishScriptVersion   => registryL1.publishScriptVersion(u)
                 case u: SetVersionStatus       => registryL1.setStatus(u)
                 case u: RegisterAlias          => registryL1.registerAlias(u)
               }
@@ -144,7 +148,9 @@ object Validator {
             case u: UpgradeFiber           => fiberCombined.upgrade(u)
             case u: CreateScript           => oracleCombined.createOracle(u)
             case u: InvokeScript           => oracleCombined.invokeOracle(u)
-            case u: PublishVersion         => registryL1.publish(u)
+            case u: UpgradeScript          => oracleCombined.upgradeScript(u)
+            case u: PublishMachineVersion  => registryL1.publishMachineVersion(u)
+            case u: PublishScriptVersion   => registryL1.publishScriptVersion(u)
             case u: SetVersionStatus       => registryL1.setStatus(u)
             case u: RegisterAlias          => registryL1.registerAlias(u)
           }

--- a/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/combine/RegistryCombiner.scala
+++ b/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/combine/RegistryCombiner.scala
@@ -22,7 +22,7 @@ import org.typelevel.log4cats.slf4j.Slf4jLogger
 /**
  * Combiner for the registry. The chain enforces structural invariants — append-only / immutable /
  * strictly-monotonic via [[VersionLineage]], ownership, and a descriptor size bound — and never PARSES the
- * protobuf descriptor (it hashes `schemaB64` into `schemaHash` and drops the bytes; the typed `schemaShape`
+ * protobuf descriptor (it hashes `schemaB64` into `schemaHash` and drops the bytes; the typed `machineShape`
  * projection is stored as advisory domain metadata). The JSON-Logic `definition` IS typed: it is hashed via
  * `computeDigest` into `logicHash` — the same canonical digest a fiber computes — so a referencing fiber's
  * definition can be verified on-chain (#37). `VersionLineage`'s `Either` is the authoritative invariant
@@ -38,7 +38,7 @@ class RegistryCombiner[F[_]: Async: SecurityProvider](
   maxBundleBytes: Long
 ) {
 
-  def publishVersion(update: Signed[Updates.PublishVersion]): F[DataState[OnChain, CalculatedState]] = {
+  def publishMachineVersion(update: Signed[Updates.PublishMachineVersion]): F[DataState[OnChain, CalculatedState]] = {
     val pv = update.value
     for {
       currentOrdinal <- ctx.getCurrentOrdinal
@@ -65,7 +65,7 @@ class RegistryCombiner[F[_]: Async: SecurityProvider](
         version = pv.version,
         schemaHash = schemaHash,
         logicHash = logicHash,
-        schemaShape = pv.schemaShape,
+        shape = RegistryShape.Machine(pv.machineShape),
         status = RegistryStatus.Active,
         registeredAt = currentOrdinal,
         strict = pv.strict
@@ -100,7 +100,70 @@ class RegistryCombiner[F[_]: Async: SecurityProvider](
             }
       }
       result <- current.withRegistryEntry[F](pv.name, updatedEntry)
-      _      <- Slf4jLogger.getLogger[F].info(s"[registry-publish] applied ${pv.name.render}@${pv.version.render}")
+      _ <- Slf4jLogger.getLogger[F].info(s"[registry-publish-machine] applied ${pv.name.render}@${pv.version.render}")
+    } yield result
+  }
+
+  def publishScriptVersion(update: Signed[Updates.PublishScriptVersion]): F[DataState[OnChain, CalculatedState]] = {
+    val pv = update.value
+    for {
+      currentOrdinal <- ctx.getCurrentOrdinal
+      signers        <- update.proofs.toList.traverse(_.id.toAddress).map(Set.from)
+      _ <- Async[F]
+        .raiseError[Unit](CombineRejected(s"registry name ${pv.name.render} uses a reserved label"))
+        .whenA(RegistryName.isReserved(pv.name))
+      _ <- Async[F]
+        .raiseError[Unit](
+          CombineRejected(s"registry descriptor for ${pv.name.render} exceeds $maxBundleBytes bytes")
+        )
+        .whenA(pv.schemaB64.length.toLong > maxBundleBytes)
+      _ <- RegistryMetadata
+        .validate(pv.metadata.getOrElse(SortedMap.empty[String, String]))
+        .fold(
+          e => Async[F].raiseError[Unit](CombineRejected(s"invalid metadata for ${pv.name.render}: $e")),
+          _ => Async[F].unit
+        )
+      schemaHash <- pv.schemaB64.computeDigest
+      logicHash  <- pv.scriptProgram.computeDigest
+      rv = RegisteredVersion(
+        version = pv.version,
+        schemaHash = schemaHash,
+        logicHash = logicHash,
+        shape = RegistryShape.Script(pv.scriptShape),
+        status = RegistryStatus.Active,
+        registeredAt = currentOrdinal,
+        strict = pv.strict
+      )
+      updatedEntry <- current.calculated.registry.get(pv.name) match {
+        case None =>
+          (RegistryEntry(
+            pv.name,
+            signers,
+            RegistryTarget.SchemaPackage(VersionLineage.of(rv)),
+            pv.metadata.getOrElse(SortedMap.empty[String, String])
+          ): RegistryEntry).pure[F]
+        case Some(entry) =>
+          if (!signers.exists(entry.owner.contains))
+            Async[F].raiseError[RegistryEntry](CombineRejected(s"unauthorized publish to ${pv.name.render}"))
+          else
+            entry.target match {
+              case RegistryTarget.SchemaPackage(lineage) =>
+                lineage
+                  .publish(rv)
+                  .fold(
+                    e =>
+                      Async[F]
+                        .raiseError[RegistryEntry](CombineRejected(s"publish rejected for ${pv.name.render}: $e")),
+                    l => entry.copy(target = RegistryTarget.SchemaPackage(l)).pure[F]
+                  )
+              case other =>
+                Async[F].raiseError[RegistryEntry](
+                  CombineRejected(s"${pv.name.render} is not a schema package (${other.getClass.getSimpleName})")
+                )
+            }
+      }
+      result <- current.withRegistryEntry[F](pv.name, updatedEntry)
+      _ <- Slf4jLogger.getLogger[F].info(s"[registry-publish-script] applied ${pv.name.render}@${pv.version.render}")
     } yield result
   }
 
@@ -191,7 +254,9 @@ class RegistryCombiner[F[_]: Async: SecurityProvider](
           )(_.owners.pure[F])
       case NameTld.Package =>
         Async[F].raiseError[Set[Address]](
-          CombineRejected("cannot register a .package name as a fiber alias (use PublishVersion)")
+          CombineRejected(
+            "cannot register a .package name as a fiber alias (use PublishMachineVersion/PublishScriptVersion)"
+          )
         )
     }
 }

--- a/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/combine/ScriptCombiner.scala
+++ b/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/combine/ScriptCombiner.scala
@@ -4,11 +4,14 @@ import cats.effect.Async
 import cats.syntax.all._
 
 import io.constellationnetwork.currency.dataApplication.{DataState, L0NodeContext}
+import io.constellationnetwork.metagraph_sdk.json_logic.JsonLogicExpression
+import io.constellationnetwork.metagraph_sdk.std.JsonBinaryHasher.HasherOps
 import io.constellationnetwork.schema.address.Address
 import io.constellationnetwork.security.SecurityProvider
 import io.constellationnetwork.security.signature.Signed
 
 import xyz.kd5ujc.schema.fiber._
+import xyz.kd5ujc.schema.registry._
 import xyz.kd5ujc.schema.{CalculatedState, OnChain, Records, Updates}
 import xyz.kd5ujc.shared_data.fiber.FiberEngine
 import xyz.kd5ujc.shared_data.fiber.evaluation.ScriptProcessor
@@ -30,15 +33,14 @@ class ScriptCombiner[F[_]: Async: SecurityProvider](
 ) {
 
   /**
-   * Creates a new script from the update.
-   *
-   * Delegates to ScriptProcessor for the actual creation logic.
+   * Creates a new script from the update, resolving an optional registry binding.
    */
   def createScript(
     update: Signed[Updates.CreateScript]
   ): CombineResult[F] = for {
     currentOrdinal <- ctx.getCurrentOrdinal
-    result         <- ScriptProcessor.createScript(current, update, currentOrdinal)
+    binding        <- resolveScriptBinding(update.schemaRef, update.scriptProgram)
+    result         <- ScriptProcessor.createScript(current, update, currentOrdinal, binding)
   } yield result
 
   /**
@@ -108,6 +110,141 @@ class ScriptCombiner[F[_]: Async: SecurityProvider](
         Async[F].raiseError(CombineRejected(s"Oracle invocation failed: ${reason.toMessage}"))
     }
   } yield newState
+
+  /**
+   * Upgrades an existing script fiber to a different registered version of the SAME package: verifies the
+   * new program's hash against the target version (verified re-bind), applies the optional migration (a
+   * JSON-Logic transform of the prior stateData) via the engine's metered evaluator, re-pins the binding,
+   * and advances the sequence number.
+   */
+  def upgradeScript(
+    update: Signed[Updates.UpgradeScript]
+  ): CombineResult[F] = for {
+    currentOrdinal   <- ctx.getCurrentOrdinal
+    lastSnapshotHash <- ctx.getLastSnapshotHash
+    epochProgress    <- ctx.getEpochProgress
+
+    scriptRecord <- current.calculated.scripts
+      .get(update.fiberId)
+      .fold(
+        Async[F].raiseError[Records.ScriptFiberRecord](
+          CombineRejected(s"Script ${update.fiberId} not found")
+        )
+      )(_.pure[F])
+
+    _ <- Async[F]
+      .raiseError(
+        CombineRejected(
+          s"Sequence number mismatch: target=${update.targetSequenceNumber}, actual=${scriptRecord.sequenceNumber}"
+        )
+      )
+      .whenA(scriptRecord.sequenceNumber =!= update.targetSequenceNumber)
+
+    // Must currently be bound, and the upgrade must target the SAME package.
+    _ <- scriptRecord.schemaBinding match {
+      case Some(b) if b.name === update.targetRef.name => Async[F].unit
+      case Some(b) =>
+        Async[F].raiseError[Unit](
+          CombineRejected(
+            s"cannot upgrade ${b.name.render} script to a different package ${update.targetRef.name.render}"
+          )
+        )
+      case None =>
+        Async[F].raiseError[Unit](CombineRejected(s"script ${update.fiberId} has no binding to upgrade"))
+    }
+
+    // Resolve the target version and verify the new program's hash.
+    maybeBinding <- resolveScriptBinding(Some(update.targetRef), update.newProgram)
+    newBinding <- maybeBinding.fold(
+      Async[F].raiseError[SchemaBinding](
+        CombineRejected(s"upgrade target ${update.targetRef.name.render} did not resolve")
+      )
+    )(_.pure[F])
+
+    // Monotonic upgrade: version may only ADVANCE.
+    _ <- scriptRecord.schemaBinding match {
+      case Some(b) if SemVer.ordering.gt(newBinding.version, b.version) => Async[F].unit
+      case Some(b) =>
+        Async[F].raiseError[Unit](
+          CombineRejected(
+            s"cannot downgrade ${b.name.render} script from ${b.version.render} to ${newBinding.version.render}"
+          )
+        )
+      case None => Async[F].unit
+    }
+
+    // Apply optional migration through the metered evaluator.
+    orchestrator = FiberEngine.make[F](
+      calculatedState = current.calculated,
+      ordinal = currentOrdinal,
+      limits = executionLimits,
+      lastSnapshotHash = lastSnapshotHash,
+      epochProgress = epochProgress
+    )
+
+    outcome <- orchestrator.migrateScript(update.fiberId, update.newProgram, newBinding, update.migration)
+
+    newState <- outcome match {
+      case TransactionResult.Committed(_, updatedOracles, logEntries, _, _, _) =>
+        updatedOracles.get(update.fiberId) match {
+          case Some(updated) => current.withRecord[F](update.fiberId, updated).map(_.appendLogs(logEntries))
+          case None =>
+            Async[F].raiseError(CombineRejected(s"Script ${update.fiberId} not in orchestrator result"))
+        }
+      case TransactionResult.Aborted(reason, gasUsed, _) =>
+        Async[F].raiseError(
+          CombineRejected(s"Script upgrade failed (gas=$gasUsed): ${reason.toMessage}")
+        )
+    }
+  } yield newState
+
+  // ============================================================================
+  // Private Helpers
+  // ============================================================================
+
+  /**
+   * Resolve an optional schema reference against the current registry for a SCRIPT fiber. Mirrors
+   * FiberCombiner.resolveBinding but hashes the scriptProgram instead of a StateMachineDefinition.
+   * Aborts if the name/version doesn't resolve or the program hash mismatches the registered logicHash.
+   */
+  private def resolveScriptBinding(
+    ref:     Option[SchemaRef],
+    program: JsonLogicExpression
+  ): F[Option[SchemaBinding]] =
+    ref match {
+      case None => none[SchemaBinding].pure[F]
+      case Some(SchemaRef(name, versionReq)) =>
+        current.calculated.registry
+          .get(name)
+          .map(_.target)
+          .collect { case RegistryTarget.SchemaPackage(l) => l } match {
+          case None =>
+            Async[F].raiseError[Option[SchemaBinding]](
+              CombineRejected(s"schemaRef refers to unknown registry name ${name.render}")
+            )
+          case Some(lineage) =>
+            lineage
+              .resolve(versionReq)
+              .fold(
+                e =>
+                  Async[F].raiseError[Option[SchemaBinding]](
+                    CombineRejected(s"schemaRef unresolvable for ${name.render}: $e")
+                  ),
+                rv =>
+                  program.computeDigest.flatMap { digest =>
+                    if (digest === rv.logicHash)
+                      SchemaBinding(name, rv.version, rv.schemaHash, rv.logicHash).some.pure[F]
+                    else
+                      Async[F].raiseError[Option[SchemaBinding]](
+                        CombineRejected(
+                          s"schemaRef logic mismatch for ${name.render}@${rv.version.render}: program hash " +
+                          s"${digest.value} != registered logicHash ${rv.logicHash.value}"
+                        )
+                      )
+                  }
+              )
+        }
+    }
 
 }
 

--- a/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/validate/FiberValidator.scala
+++ b/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/validate/FiberValidator.scala
@@ -11,7 +11,7 @@ import io.constellationnetwork.security.signature.signature.SignatureProof
 
 import xyz.kd5ujc.schema.Updates.{ArchiveStateMachine, CreateStateMachine, TransitionStateMachine, UpgradeFiber}
 import xyz.kd5ujc.schema.{CalculatedState, OnChain}
-import xyz.kd5ujc.shared_data.lifecycle.validate.rules.{CommonRules, FiberRules, RegistryRules}
+import xyz.kd5ujc.shared_data.lifecycle.validate.rules.{CommonRules, FiberRules}
 
 /**
  * Validators for state machine fiber operations.
@@ -109,8 +109,7 @@ object FiberValidator {
       for {
         hasProofs    <- FiberRules.L0.hasProofs(proofs)
         parentActive <- FiberRules.L0.parentFiberActive(update.parentFiberId, state.calculated)
-        schemaRefOk  <- RegistryRules.L0.refResolvesAndMatches(update.schemaRef, update.definition, state.calculated)
-      } yield List(hasProofs, parentActive, schemaRefOk).combineAll
+      } yield List(hasProofs, parentActive).combineAll
 
     /** Validates a ProcessFiberEvent update (L0 specific checks) */
     def processEvent(update: TransitionStateMachine): F[ValidationResult] =
@@ -134,13 +133,8 @@ object FiberValidator {
         fiberActive   <- FiberRules.L0.fiberIsActive(update.fiberId, state.calculated)
         signedByOwner <- FiberRules.L0.updateSignedByOwners(update.fiberId, proofs, state.calculated)
         bindingOk     <- FiberRules.L0.bindingNameMatches(update.fiberId, update.targetRef.name, state.calculated)
-        targetOk <- RegistryRules.L0.refResolvesAndMatches(
-          Some(update.targetRef),
-          update.newDefinition,
-          state.calculated
-        )
-        stateOk <- FiberRules.L0.currentStateInDefinition(update.fiberId, update.newDefinition, state.calculated)
-      } yield List(fiberActive, signedByOwner, bindingOk, targetOk, stateOk).combineAll
+        stateOk       <- FiberRules.L0.currentStateInDefinition(update.fiberId, update.newDefinition, state.calculated)
+      } yield List(fiberActive, signedByOwner, bindingOk, stateOk).combineAll
   }
 
   /**

--- a/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/validate/RegistryValidator.scala
+++ b/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/validate/RegistryValidator.scala
@@ -9,7 +9,7 @@ import io.constellationnetwork.currency.dataApplication.{DataApplicationValidati
 import io.constellationnetwork.security.SecurityProvider
 import io.constellationnetwork.security.signature.signature.SignatureProof
 
-import xyz.kd5ujc.schema.Updates.{PublishVersion, RegisterAlias, SetVersionStatus}
+import xyz.kd5ujc.schema.Updates.{PublishMachineVersion, PublishScriptVersion, RegisterAlias, SetVersionStatus}
 import xyz.kd5ujc.schema.{CalculatedState, OnChain}
 import xyz.kd5ujc.shared_data.lifecycle.validate.rules.{FiberRules, RegistryRules}
 
@@ -24,11 +24,11 @@ object RegistryValidator {
   /** L1 structural checks (no state needed). */
   class L1Validator[F[_]: Monad] {
 
-    def publish(update: PublishVersion): F[ValidationResult] =
+    def publishMachineVersion(update: PublishMachineVersion): F[ValidationResult] =
       for {
         schemaOk     <- RegistryRules.L1.validBase64("schemaB64", update.schemaB64)
-        shapeOk      <- RegistryRules.L1.schemaShapeWellFormed(update.schemaShape)
-        bundleOk     <- RegistryRules.L1.bundleWithinLimit(update)
+        shapeOk      <- RegistryRules.L1.machineShapeWellFormed(update.machineShape)
+        bundleOk     <- RegistryRules.L1.bundleWithinLimitMachine(update)
         reservedOk   <- RegistryRules.L1.notReserved(update.name)
         metaOk       <- RegistryRules.L1.metadataConforms(update.metadata.getOrElse(Map.empty[String, String]))
         definitionOk <- FiberRules.L1.validStateMachineDefinition(update.definition)
@@ -39,6 +39,14 @@ object RegistryValidator {
       val _ = update
       ().validNec[DataApplicationValidationError].pure[F]
     }
+
+    def publishScriptVersion(update: PublishScriptVersion): F[ValidationResult] =
+      for {
+        schemaOk   <- RegistryRules.L1.validBase64("schemaB64", update.schemaB64)
+        bundleOk   <- RegistryRules.L1.bundleWithinLimitScript(update)
+        reservedOk <- RegistryRules.L1.notReserved(update.name)
+        metaOk     <- RegistryRules.L1.metadataConforms(update.metadata.getOrElse(Map.empty[String, String]))
+      } yield List(schemaOk, bundleOk, reservedOk, metaOk).combineAll
 
     def registerAlias(update: RegisterAlias): F[ValidationResult] =
       for {
@@ -54,7 +62,7 @@ object RegistryValidator {
     proofs: NonEmptySet[SignatureProof]
   ) {
 
-    def publish(update: PublishVersion): F[ValidationResult] =
+    def publishMachineVersion(update: PublishMachineVersion): F[ValidationResult] =
       for {
         authd      <- RegistryRules.L0.authorizedPublisher(update.name, proofs, state.calculated)
         appendable <- RegistryRules.L0.versionAppendable(update.name, update.version, state.calculated)
@@ -66,6 +74,12 @@ object RegistryValidator {
         legal <- RegistryRules.L0.statusTransitionLegal(update.name, update.version, update.status, state.calculated)
       } yield authd |+| legal
 
+    def publishScriptVersion(update: PublishScriptVersion): F[ValidationResult] =
+      for {
+        authd      <- RegistryRules.L0.authorizedPublisher(update.name, proofs, state.calculated)
+        appendable <- RegistryRules.L0.versionAppendable(update.name, update.version, state.calculated)
+      } yield authd |+| appendable
+
     def registerAlias(update: RegisterAlias): F[ValidationResult] =
       for {
         kindOk  <- RegistryRules.L0.aliasTargetIsKind(update.name, update.targetFiberId, state.calculated)
@@ -74,7 +88,12 @@ object RegistryValidator {
       } yield List(kindOk, ownerOk, nameOk).combineAll
   }
 
-  /** Combined L1 + L0, used at the L0 layer. */
+  /**
+   * Advisory pre-validation only — MUST NOT be used from `validateSignedUpdate`.
+   * Registry stateful checks (lineage, ownership) in validateSignedUpdate cause block-poisoning:
+   * a TOCTOU race returns Invalid → the entire block is dropped. See Validator.scala and CLAUDE.md.
+   * Use only for L0 node pre-screening during block BUILDING, never block ACCEPTANCE.
+   */
   class CombinedValidator[F[_]: Async: SecurityProvider](
     state:  DataState[OnChain, CalculatedState],
     proofs: NonEmptySet[SignatureProof]
@@ -82,16 +101,22 @@ object RegistryValidator {
     private val l1 = new L1Validator[F]
     private val l0 = new L0Validator[F](state, proofs)
 
-    def publish(update: PublishVersion): F[ValidationResult] =
+    def publishMachineVersion(update: PublishMachineVersion): F[ValidationResult] =
       for {
-        l1Result <- l1.publish(update)
-        l0Result <- l0.publish(update)
+        l1Result <- l1.publishMachineVersion(update)
+        l0Result <- l0.publishMachineVersion(update)
       } yield l1Result |+| l0Result
 
     def setStatus(update: SetVersionStatus): F[ValidationResult] =
       for {
         l1Result <- l1.setStatus(update)
         l0Result <- l0.setStatus(update)
+      } yield l1Result |+| l0Result
+
+    def publishScriptVersion(update: PublishScriptVersion): F[ValidationResult] =
+      for {
+        l1Result <- l1.publishScriptVersion(update)
+        l0Result <- l0.publishScriptVersion(update)
       } yield l1Result |+| l0Result
 
     def registerAlias(update: RegisterAlias): F[ValidationResult] =

--- a/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/validate/ScriptValidator.scala
+++ b/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/validate/ScriptValidator.scala
@@ -9,9 +9,9 @@ import io.constellationnetwork.currency.dataApplication.DataState
 import io.constellationnetwork.security.SecurityProvider
 import io.constellationnetwork.security.signature.signature.SignatureProof
 
-import xyz.kd5ujc.schema.Updates.{CreateScript, InvokeScript}
+import xyz.kd5ujc.schema.Updates.{CreateScript, InvokeScript, UpgradeScript}
 import xyz.kd5ujc.schema.{CalculatedState, OnChain}
-import xyz.kd5ujc.shared_data.lifecycle.validate.rules.{CommonRules, ScriptRules}
+import xyz.kd5ujc.shared_data.lifecycle.validate.rules.{CommonRules, RegistryRules, ScriptRules}
 
 /**
  * Validators for script operations.
@@ -59,6 +59,14 @@ object ScriptValidator {
           "args"
         )
       } yield List(cidExists, seqNumOk, argsStructure, argsSize).combineAll
+
+    /** Validates an UpgradeScript update (structural: script exists, new program depth, sequence) */
+    def upgradeScript(update: UpgradeScript): F[ValidationResult] =
+      for {
+        cidExists <- CommonRules.cidIsFound(update.fiberId, state)
+        seqNumOk  <- ScriptRules.L1.sequenceNumberMatches(update.fiberId, update.targetSequenceNumber, state)
+        programOk <- CommonRules.expressionWithinDepthLimit(update.newProgram, "newProgram", Limits.MaxExpressionDepth)
+      } yield List(cidExists, seqNumOk, programOk).combineAll
   }
 
   /**
@@ -76,13 +84,24 @@ object ScriptValidator {
 
     /** Validates a CreateScript update (L0 specific checks) */
     def createOracle(update: CreateScript): F[ValidationResult] =
-      // CreateScript has no L0-specific validation requirements currently.
-      // Anyone can create an oracle; access control applies to invocations.
-      ().validNec[io.constellationnetwork.currency.dataApplication.DataApplicationValidationError].pure[F]
+      RegistryRules.L0.scriptRefResolvesAndMatches(update.schemaRef, update.scriptProgram, state.calculated)
 
     /** Validates an InvokeScript update (L0 specific checks) */
     def invokeOracle(update: InvokeScript): F[ValidationResult] =
       ScriptRules.L0.accessControlCheck(update.fiberId, proofs, state.calculated)
+
+    /** Validates an UpgradeScript update (active, owner, same-package re-bind + verified hash) */
+    def upgradeScript(update: UpgradeScript): F[ValidationResult] =
+      for {
+        scriptActive  <- ScriptRules.L0.scriptIsActive(update.fiberId, state.calculated)
+        signedByOwner <- ScriptRules.L0.scriptSignedByOwners(update.fiberId, proofs, state.calculated)
+        bindingOk <- ScriptRules.L0.bindingNameMatchesScript(update.fiberId, update.targetRef.name, state.calculated)
+        targetOk <- RegistryRules.L0.scriptRefResolvesAndMatches(
+          Some(update.targetRef),
+          update.newProgram,
+          state.calculated
+        )
+      } yield List(scriptActive, signedByOwner, bindingOk, targetOk).combineAll
   }
 
   /**
@@ -109,6 +128,13 @@ object ScriptValidator {
       for {
         l1Result <- l1.invokeOracle(update)
         l0Result <- l0.invokeOracle(update)
+      } yield l1Result |+| l0Result
+
+    /** Validates an UpgradeScript update (all checks) */
+    def upgradeScript(update: UpgradeScript): F[ValidationResult] =
+      for {
+        l1Result <- l1.upgradeScript(update)
+        l0Result <- l0.upgradeScript(update)
       } yield l1Result |+| l0Result
   }
 }

--- a/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/validate/rules/RegistryRules.scala
+++ b/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/validate/rules/RegistryRules.scala
@@ -97,7 +97,7 @@ object RegistryRules {
      * (This validates the *shape* only — it does not check the logic conforms to it; conformance is the
      * separate opt-in dial. See strong-typing-and-conformance.md §0.5.)
      */
-    def machineShapeWellFormed[F[_]: Applicative](shape: SchemaShape): F[ValidationResult] = {
+    def machineShapeWellFormed[F[_]: Applicative](shape: MachineShape): F[ValidationResult] = {
       val emptyCmdNames = shape.commands.keys.filter(_.trim.isEmpty).map(_ => "a command name is empty").toList
       val problems = emptyCmdNames ::: shape.allMessages.flatMap(messageProblems)
       problems match {

--- a/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/validate/rules/RegistryRules.scala
+++ b/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/validate/rules/RegistryRules.scala
@@ -8,13 +8,14 @@ import cats.effect.Async
 import cats.syntax.all._
 
 import io.constellationnetwork.currency.dataApplication.DataApplicationValidationError
+import io.constellationnetwork.metagraph_sdk.json_logic.JsonLogicExpression
 import io.constellationnetwork.metagraph_sdk.std.JsonBinaryHasher.HasherOps
 import io.constellationnetwork.schema.address.Address
 import io.constellationnetwork.security.SecurityProvider
 import io.constellationnetwork.security.signature.signature.SignatureProof
 
 import xyz.kd5ujc.schema.CalculatedState
-import xyz.kd5ujc.schema.Updates.PublishVersion
+import xyz.kd5ujc.schema.Updates.{PublishMachineVersion, PublishScriptVersion}
 import xyz.kd5ujc.schema.fiber.StateMachineDefinition
 import xyz.kd5ujc.schema.registry._
 import xyz.kd5ujc.shared_data.lifecycle.validate.{Limits, ValidationResult}
@@ -40,7 +41,7 @@ object RegistryRules {
           _ => ().validNec[DataApplicationValidationError].pure[F]
         )
 
-    def bundleWithinLimit[F[_]: Applicative](pv: PublishVersion): F[ValidationResult] = {
+    def bundleWithinLimitMachine[F[_]: Applicative](pv: PublishMachineVersion): F[ValidationResult] = {
       val size = pv.schemaB64.length.toLong
       Validated
         .condNec(
@@ -51,7 +52,18 @@ object RegistryRules {
         .pure[F]
     }
 
-    /** An alias name must use a fiber TLD (`.machine`/`.script`), not `.package` (that is PublishVersion). */
+    def bundleWithinLimitScript[F[_]: Applicative](pv: PublishScriptVersion): F[ValidationResult] = {
+      val size = pv.schemaB64.length.toLong
+      Validated
+        .condNec(
+          size <= Limits.MaxRegistryBundleBytes,
+          (),
+          Errors.BundleTooLarge(size, Limits.MaxRegistryBundleBytes): DataApplicationValidationError
+        )
+        .pure[F]
+    }
+
+    /** An alias name must use a fiber TLD (`.machine`/`.script`), not `.package` (that is PublishMachineVersion/PublishScriptVersion). */
     def aliasTldIsFiber[F[_]: Applicative](name: RegistryName): F[ValidationResult] =
       Validated
         .condNec(name.tld != NameTld.Package, (), Errors.AliasTldNotFiber(name.render): DataApplicationValidationError)
@@ -85,12 +97,12 @@ object RegistryRules {
      * (This validates the *shape* only — it does not check the logic conforms to it; conformance is the
      * separate opt-in dial. See strong-typing-and-conformance.md §0.5.)
      */
-    def schemaShapeWellFormed[F[_]: Applicative](shape: SchemaShape): F[ValidationResult] = {
+    def machineShapeWellFormed[F[_]: Applicative](shape: SchemaShape): F[ValidationResult] = {
       val emptyCmdNames = shape.commands.keys.filter(_.trim.isEmpty).map(_ => "a command name is empty").toList
       val problems = emptyCmdNames ::: shape.allMessages.flatMap(messageProblems)
       problems match {
         case Nil => ().validNec[DataApplicationValidationError]
-        case ps  => (Errors.MalformedSchemaShape(ps.mkString("; ")): DataApplicationValidationError).invalidNec[Unit]
+        case ps  => (Errors.MalformedMachineShape(ps.mkString("; ")): DataApplicationValidationError).invalidNec[Unit]
       }
     }.pure[F]
 
@@ -229,6 +241,37 @@ object RegistryRules {
           }
       }
 
+    /**
+     * A script's optional schemaRef must resolve against the registry AND the script program must hash to
+     * the resolved version's `logicHash` — mirrors [[refResolvesAndMatches]] but for `JsonLogicExpression`.
+     */
+    def scriptRefResolvesAndMatches[F[_]: Async](
+      ref:     Option[SchemaRef],
+      program: JsonLogicExpression,
+      state:   CalculatedState
+    ): F[ValidationResult] =
+      ref match {
+        case None => ().validNec[DataApplicationValidationError].pure[F]
+        case Some(SchemaRef(name, versionReq)) =>
+          lineageOf(name, state) match {
+            case None =>
+              (Errors.SchemaRefUnknownName(name.render): DataApplicationValidationError).invalidNec[Unit].pure[F]
+            case Some(lineage) =>
+              lineage.resolve(versionReq) match {
+                case Left(_) =>
+                  (Errors.SchemaRefUnresolvable(name.render): DataApplicationValidationError).invalidNec[Unit].pure[F]
+                case Right(rv) =>
+                  program.computeDigest.map { digest =>
+                    Validated.condNec(
+                      digest === rv.logicHash,
+                      (),
+                      Errors.SchemaRefLogicMismatch(name.render, rv.version.render): DataApplicationValidationError
+                    )
+                  }
+              }
+          }
+      }
+
     /** An alias's target fiber must exist as the kind its TLD requires (.machine -> SM, .script -> oracle). */
     def aliasTargetIsKind[F[_]: Applicative](
       name:          RegistryName,
@@ -302,8 +345,8 @@ object RegistryRules {
       override val message: String = s"registry descriptor of $size bytes exceeds limit $max"
     }
 
-    final case class MalformedSchemaShape(reason: String) extends DataApplicationValidationError {
-      override val message: String = s"registry schemaShape is malformed: $reason"
+    final case class MalformedMachineShape(reason: String) extends DataApplicationValidationError {
+      override val message: String = s"registry machineShape is malformed: $reason"
     }
 
     final case class NotRegistryOwner(name: String) extends DataApplicationValidationError {

--- a/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/validate/rules/ScriptRules.scala
+++ b/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/validate/rules/ScriptRules.scala
@@ -3,7 +3,7 @@ package xyz.kd5ujc.shared_data.lifecycle.validate.rules
 import java.util.UUID
 
 import cats.Applicative
-import cats.data.{EitherT, NonEmptySet}
+import cats.data.{EitherT, NonEmptySet, Validated}
 import cats.effect.Async
 import cats.syntax.all._
 
@@ -12,7 +12,8 @@ import io.constellationnetwork.schema.address.Address
 import io.constellationnetwork.security.SecurityProvider
 import io.constellationnetwork.security.signature.signature.SignatureProof
 
-import xyz.kd5ujc.schema.fiber.{AccessControlPolicy, FiberOrdinal}
+import xyz.kd5ujc.schema.fiber.{AccessControlPolicy, FiberOrdinal, FiberStatus}
+import xyz.kd5ujc.schema.registry.RegistryName
 import xyz.kd5ujc.schema.{CalculatedState, OnChain}
 import xyz.kd5ujc.shared_data.lifecycle.validate.ValidationResult
 import xyz.kd5ujc.shared_data.syntax.all._
@@ -80,6 +81,70 @@ object ScriptRules {
           (Errors.OracleNotFound(oracleId): DataApplicationValidationError).invalidNec[Unit].pure[F]
         )(_ => ().validNec[DataApplicationValidationError].pure[F])
 
+    /** Validates that a script fiber is in Active status. */
+    def scriptIsActive[F[_]: Applicative](
+      scriptId: UUID,
+      state:    CalculatedState
+    ): F[ValidationResult] =
+      state.scripts.get(scriptId) match {
+        case None =>
+          (Errors.OracleNotFound(scriptId): DataApplicationValidationError).invalidNec[Unit].pure[F]
+        case Some(record) =>
+          Validated
+            .condNec(
+              record.status == FiberStatus.Active,
+              (),
+              Errors.ScriptNotActive(scriptId): DataApplicationValidationError
+            )
+            .pure[F]
+      }
+
+    /** Validates that the update is signed by at least one script owner. */
+    def scriptSignedByOwners[F[_]: Async: SecurityProvider](
+      scriptId: UUID,
+      proofs:   NonEmptySet[SignatureProof],
+      state:    CalculatedState
+    ): F[ValidationResult] =
+      state.scripts.get(scriptId) match {
+        case None =>
+          (Errors.OracleNotFound(scriptId): DataApplicationValidationError).invalidNec[Unit].pure[F]
+        case Some(record) =>
+          proofs.toList.traverse(_.id.toAddress).map { signerList =>
+            val signers = signerList.toSet
+            Validated.condNec(
+              signers.intersect(record.owners).nonEmpty,
+              (),
+              Errors.ScriptNotSignedByOwner(scriptId): DataApplicationValidationError
+            )
+          }
+      }
+
+    /**
+     * An UpgradeScript target must stay within the SAME package: the script must already be bound, and the
+     * target name must equal its current binding's name (no cross-package switch).
+     */
+    def bindingNameMatchesScript[F[_]: Applicative](
+      scriptId:   UUID,
+      targetName: RegistryName,
+      state:      CalculatedState
+    ): F[ValidationResult] =
+      state.scripts.get(scriptId) match {
+        case None =>
+          (Errors.OracleNotFound(scriptId): DataApplicationValidationError).invalidNec[Unit].pure[F]
+        case Some(record) =>
+          record.schemaBinding match {
+            case Some(b) if b.name === targetName => ().validNec[DataApplicationValidationError].pure[F]
+            case Some(b) =>
+              (Errors.UpgradeScriptCrossPackage(
+                scriptId,
+                b.name.render,
+                targetName.render
+              ): DataApplicationValidationError).invalidNec[Unit].pure[F]
+            case None =>
+              (Errors.CannotUpgradeUnboundScript(scriptId): DataApplicationValidationError).invalidNec[Unit].pure[F]
+          }
+      }
+
     // ============== Private Helpers ==============
 
     private def isAuthorized(
@@ -113,6 +178,25 @@ object ScriptRules {
     final case class OracleAccessDenied(oracleId: UUID, policy: AccessControlPolicy)
         extends DataApplicationValidationError {
       override val message: String = s"Access denied to oracle $oracleId (policy: $policy)"
+    }
+
+    final case class ScriptNotActive(scriptId: UUID) extends DataApplicationValidationError {
+      override val message: String = s"Script $scriptId is not active"
+    }
+
+    final case class ScriptNotSignedByOwner(scriptId: UUID) extends DataApplicationValidationError {
+      override val message: String = s"Update to script $scriptId not signed by any owner"
+    }
+
+    final case class CannotUpgradeUnboundScript(scriptId: UUID) extends DataApplicationValidationError {
+      override val message: String = s"Script $scriptId has no registry binding and cannot be upgraded"
+    }
+
+    final case class UpgradeScriptCrossPackage(scriptId: UUID, from: String, to: String)
+        extends DataApplicationValidationError {
+
+      override val message: String =
+        s"Script $scriptId is bound to '$from'; cannot upgrade to a different package '$to'"
     }
   }
 }

--- a/modules/shared-data/src/test/resources/genesis/std-manifest.json
+++ b/modules/shared-data/src/test/resources/genesis/std-manifest.json
@@ -6,7 +6,7 @@
       "semver": "1.0.0",
       "strict": false,
       "metadata": {},
-      "schemaShape": {
+      "machineShape": {
         "stateMessage": {
           "typeName": "ottochain.apps.identity.v1.Identity",
           "fields": [
@@ -211,7 +211,7 @@
       "semver": "1.0.0",
       "strict": false,
       "metadata": {},
-      "schemaShape": {
+      "machineShape": {
         "stateMessage": {
           "typeName": "ottochain.apps.governance.v1.Proposal",
           "fields": [
@@ -438,7 +438,7 @@
       "semver": "1.0.0",
       "strict": false,
       "metadata": {},
-      "schemaShape": {
+      "machineShape": {
         "stateMessage": {
           "typeName": "ottochain.apps.markets.v1.Market",
           "fields": [

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/BasicStateMachineSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/BasicStateMachineSuite.scala
@@ -50,7 +50,8 @@ object BasicStateMachineSuite extends SimpleIOSuite with Checkers {
                 "active"  -> BoolValue(true)
               )
             )
-          )
+          ),
+          dependencies = Set.empty
         ),
         Transition(
           from = countingState,
@@ -84,7 +85,8 @@ object BasicStateMachineSuite extends SimpleIOSuite with Checkers {
                 )
               )
             )
-          )
+          ),
+          dependencies = Set.empty
         ),
         Transition(
           from = countingState,
@@ -108,7 +110,8 @@ object BasicStateMachineSuite extends SimpleIOSuite with Checkers {
                 )
               )
             )
-          )
+          ),
+          dependencies = Set.empty
         )
       )
     )
@@ -552,8 +555,8 @@ object BasicStateMachineSuite extends SimpleIOSuite with Checkers {
 
         definition = StateMachineDefinition(
           states = Map(
-            StateId("open")   -> State(StateId("open")),
-            StateId("locked") -> State(StateId("locked"))
+            StateId("open")   -> State(StateId("open"), isFinal = false),
+            StateId("locked") -> State(StateId("locked"), isFinal = false)
           ),
           initialState = StateId("open"),
           transitions = List(
@@ -574,7 +577,8 @@ object BasicStateMachineSuite extends SimpleIOSuite with Checkers {
                     "locked" -> BoolValue(true)
                   )
                 )
-              )
+              ),
+              dependencies = Set.empty
             )
           )
         )
@@ -627,8 +631,8 @@ object BasicStateMachineSuite extends SimpleIOSuite with Checkers {
 
         definition = StateMachineDefinition(
           states = Map(
-            StateId("open")   -> State(StateId("open")),
-            StateId("locked") -> State(StateId("locked"))
+            StateId("open")   -> State(StateId("open"), isFinal = false),
+            StateId("locked") -> State(StateId("locked"), isFinal = false)
           ),
           initialState = StateId("open"),
           transitions = List(
@@ -643,7 +647,8 @@ object BasicStateMachineSuite extends SimpleIOSuite with Checkers {
                   ConstExpression(BoolValue(true))
                 )
               ),
-              effect = ConstExpression(MapValue(Map("locked" -> BoolValue(true))))
+              effect = ConstExpression(MapValue(Map("locked" -> BoolValue(true)))),
+              dependencies = Set.empty
             )
           )
         )

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/ConformanceCheckerSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/ConformanceCheckerSuite.scala
@@ -10,7 +10,7 @@ import xyz.kd5ujc.shared_data.fiber.ConformanceChecker
 import weaver.SimpleIOSuite
 
 /**
- * Unit tests for the shallow runtime conformance gate (#33): produced state vs the on-chain SchemaShape.
+ * Unit tests for the shallow runtime conformance gate (#33): produced state vs the on-chain MachineShape.
  */
 object ConformanceCheckerSuite extends SimpleIOSuite {
 

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/CrossMachineStateMachineSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/CrossMachineStateMachineSuite.scala
@@ -34,8 +34,8 @@ object CrossMachineStateMachineSuite extends SimpleIOSuite {
         sellerfiberId <- UUIDGen.randomUUID[IO]
         sellerDef = StateMachineDefinition(
           states = Map(
-            StateId("holding")  -> State(StateId("holding")),
-            StateId("released") -> State(StateId("released"))
+            StateId("holding")  -> State(StateId("holding"), isFinal = false),
+            StateId("released") -> State(StateId("released"), isFinal = false)
           ),
           initialState = StateId("holding"),
           transitions = List.empty
@@ -66,8 +66,8 @@ object CrossMachineStateMachineSuite extends SimpleIOSuite {
         buyerfiberId <- UUIDGen.randomUUID[IO]
         buyerDef = StateMachineDefinition(
           states = Map(
-            StateId("PENDING")   -> State(StateId("PENDING")),
-            StateId("purchased") -> State(StateId("purchased"))
+            StateId("PENDING")   -> State(StateId("PENDING"), isFinal = false),
+            StateId("purchased") -> State(StateId("purchased"), isFinal = false)
           ),
           initialState = StateId("PENDING"),
           transitions = List(

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/DepthAndHashSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/DepthAndHashSuite.scala
@@ -55,8 +55,8 @@ object DepthAndHashSuite extends SimpleIOSuite {
         // Parent spawns child
         parentDefinition = StateMachineDefinition(
           states = Map(
-            StateId("ready")   -> State(StateId("ready")),
-            StateId("spawned") -> State(StateId("spawned"))
+            StateId("ready")   -> State(StateId("ready"), isFinal = false),
+            StateId("spawned") -> State(StateId("spawned"), isFinal = false)
           ),
           initialState = StateId("ready"),
           transitions = List(
@@ -82,7 +82,8 @@ object DepthAndHashSuite extends SimpleIOSuite {
                     )
                   )
                 )
-              )
+              ),
+              dependencies = Set.empty
             )
           )
         )
@@ -146,7 +147,7 @@ object DepthAndHashSuite extends SimpleIOSuite {
         // State machine with no valid transitions
         definition = StateMachineDefinition(
           states = Map(
-            StateId("locked") -> State(StateId("locked"))
+            StateId("locked") -> State(StateId("locked"), isFinal = false)
           ),
           initialState = StateId("locked"),
           transitions = List.empty
@@ -226,8 +227,8 @@ object DepthAndHashSuite extends SimpleIOSuite {
         // Chain: 1 -> 2 -> 3 with maxDepth=2 should fail at 3
         def1 = StateMachineDefinition(
           states = Map(
-            StateId("a") -> State(StateId("a")),
-            StateId("b") -> State(StateId("b"))
+            StateId("a") -> State(StateId("a"), isFinal = false),
+            StateId("b") -> State(StateId("b"), isFinal = false)
           ),
           initialState = StateId("a"),
           transitions = List(
@@ -253,15 +254,16 @@ object DepthAndHashSuite extends SimpleIOSuite {
                     )
                   )
                 )
-              )
+              ),
+              dependencies = Set.empty
             )
           )
         )
 
         def2 = StateMachineDefinition(
           states = Map(
-            StateId("a") -> State(StateId("a")),
-            StateId("b") -> State(StateId("b"))
+            StateId("a") -> State(StateId("a"), isFinal = false),
+            StateId("b") -> State(StateId("b"), isFinal = false)
           ),
           initialState = StateId("a"),
           transitions = List(
@@ -287,15 +289,16 @@ object DepthAndHashSuite extends SimpleIOSuite {
                     )
                   )
                 )
-              )
+              ),
+              dependencies = Set.empty
             )
           )
         )
 
         def3 = StateMachineDefinition(
           states = Map(
-            StateId("a") -> State(StateId("a")),
-            StateId("b") -> State(StateId("b"))
+            StateId("a") -> State(StateId("a"), isFinal = false),
+            StateId("b") -> State(StateId("b"), isFinal = false)
           ),
           initialState = StateId("a"),
           transitions = List(
@@ -304,7 +307,8 @@ object DepthAndHashSuite extends SimpleIOSuite {
               to = StateId("b"),
               eventName = "go",
               guard = ConstExpression(BoolValue(true)),
-              effect = ConstExpression(MapValue(Map("step" -> IntValue(3))))
+              effect = ConstExpression(MapValue(Map("step" -> IntValue(3)))),
+              dependencies = Set.empty
             )
           )
         )

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/DeterministicExecutionSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/DeterministicExecutionSuite.scala
@@ -43,8 +43,8 @@ object DeterministicExecutionSuite extends SimpleIOSuite with Checkers {
         // Create a simple state machine
         definition = StateMachineDefinition(
           states = Map(
-            StateId("idle")   -> State(StateId("idle")),
-            StateId("ACTIVE") -> State(StateId("ACTIVE"))
+            StateId("idle")   -> State(StateId("idle"), isFinal = false),
+            StateId("ACTIVE") -> State(StateId("ACTIVE"), isFinal = false)
           ),
           initialState = StateId("idle"),
           transitions = List(
@@ -53,7 +53,8 @@ object DeterministicExecutionSuite extends SimpleIOSuite with Checkers {
               to = StateId("ACTIVE"),
               eventName = "activate",
               guard = ConstExpression(BoolValue(true)),
-              effect = ConstExpression(MapValue(Map("activated" -> BoolValue(true))))
+              effect = ConstExpression(MapValue(Map("activated" -> BoolValue(true)))),
+              dependencies = Set.empty
             )
           )
         )
@@ -132,7 +133,7 @@ object DeterministicExecutionSuite extends SimpleIOSuite with Checkers {
 
         definition = StateMachineDefinition(
           states = Map(
-            StateId("idle") -> State(StateId("idle"))
+            StateId("idle") -> State(StateId("idle"), isFinal = false)
           ),
           initialState = StateId("idle"),
           transitions = List(
@@ -141,7 +142,8 @@ object DeterministicExecutionSuite extends SimpleIOSuite with Checkers {
               to = StateId("idle"),
               eventName = "process",
               guard = guardExpr,
-              effect = ConstExpression(MapValue(Map("processed" -> BoolValue(true))))
+              effect = ConstExpression(MapValue(Map("processed" -> BoolValue(true)))),
+              dependencies = Set.empty
             )
           )
         )
@@ -237,8 +239,8 @@ object DeterministicExecutionSuite extends SimpleIOSuite with Checkers {
         // Create a state machine that triggers itself with the same event type
         definition = StateMachineDefinition(
           states = Map(
-            StateId("loop1") -> State(StateId("loop1")),
-            StateId("loop2") -> State(StateId("loop2"))
+            StateId("loop1") -> State(StateId("loop1"), isFinal = false),
+            StateId("loop2") -> State(StateId("loop2"), isFinal = false)
           ),
           initialState = StateId("loop1"),
           transitions = List(
@@ -265,7 +267,8 @@ object DeterministicExecutionSuite extends SimpleIOSuite with Checkers {
                     )
                   )
                 )
-              )
+              ),
+              dependencies = Set.empty
             ),
             Transition(
               from = StateId("loop2"),
@@ -290,7 +293,8 @@ object DeterministicExecutionSuite extends SimpleIOSuite with Checkers {
                     )
                   )
                 )
-              )
+              ),
+              dependencies = Set.empty
             )
           )
         )
@@ -348,8 +352,8 @@ object DeterministicExecutionSuite extends SimpleIOSuite with Checkers {
         makeDef = (targetId: java.util.UUID) =>
           StateMachineDefinition(
             states = Map(
-              StateId("s1") -> State(StateId("s1")),
-              StateId("s2") -> State(StateId("s2"))
+              StateId("s1") -> State(StateId("s1"), isFinal = false),
+              StateId("s2") -> State(StateId("s2"), isFinal = false)
             ),
             initialState = StateId("s1"),
             transitions = List(
@@ -375,7 +379,8 @@ object DeterministicExecutionSuite extends SimpleIOSuite with Checkers {
                       )
                     )
                   )
-                )
+                ),
+                dependencies = Set.empty
               ),
               Transition(
                 from = StateId("s2"),
@@ -399,7 +404,8 @@ object DeterministicExecutionSuite extends SimpleIOSuite with Checkers {
                       )
                     )
                   )
-                )
+                ),
+                dependencies = Set.empty
               )
             )
           )
@@ -480,8 +486,8 @@ object DeterministicExecutionSuite extends SimpleIOSuite with Checkers {
 
         simpleDef = StateMachineDefinition(
           states = Map(
-            StateId("state1") -> State(StateId("state1")),
-            StateId("state2") -> State(StateId("state2"))
+            StateId("state1") -> State(StateId("state1"), isFinal = false),
+            StateId("state2") -> State(StateId("state2"), isFinal = false)
           ),
           initialState = StateId("state1"),
           transitions = List(
@@ -490,7 +496,8 @@ object DeterministicExecutionSuite extends SimpleIOSuite with Checkers {
               to = StateId("state2"),
               eventName = "advance",
               guard = ConstExpression(BoolValue(true)),
-              effect = ConstExpression(MapValue(Map("advanced" -> BoolValue(true))))
+              effect = ConstExpression(MapValue(Map("advanced" -> BoolValue(true)))),
+              dependencies = Set.empty
             )
           )
         )
@@ -596,7 +603,7 @@ object DeterministicExecutionSuite extends SimpleIOSuite with Checkers {
 
         definition = StateMachineDefinition(
           states = Map(
-            StateId("initial") -> State(StateId("initial"))
+            StateId("initial") -> State(StateId("initial"), isFinal = false)
           ),
           initialState = StateId("initial"),
           transitions = List.empty // No valid transitions
@@ -655,8 +662,8 @@ object DeterministicExecutionSuite extends SimpleIOSuite with Checkers {
         // First two guards will fail, third will pass
         definition = StateMachineDefinition(
           states = Map(
-            StateId("start") -> State(StateId("start")),
-            StateId("end")   -> State(StateId("end"))
+            StateId("start") -> State(StateId("start"), isFinal = false),
+            StateId("end")   -> State(StateId("end"), isFinal = false)
           ),
           initialState = StateId("start"),
           transitions = List(
@@ -672,7 +679,8 @@ object DeterministicExecutionSuite extends SimpleIOSuite with Checkers {
                   ConstExpression(IntValue(999)) // 1+1 != 999, so false
                 )
               ),
-              effect = ConstExpression(MapValue(Map("path" -> StrValue("first"))))
+              effect = ConstExpression(MapValue(Map("path" -> StrValue("first")))),
+              dependencies = Set.empty
             ),
             // Second guard: also returns false
             Transition(
@@ -686,7 +694,8 @@ object DeterministicExecutionSuite extends SimpleIOSuite with Checkers {
                   ConstExpression(IntValue(999)) // 2+2 != 999, so false
                 )
               ),
-              effect = ConstExpression(MapValue(Map("path" -> StrValue("second"))))
+              effect = ConstExpression(MapValue(Map("path" -> StrValue("second")))),
+              dependencies = Set.empty
             ),
             // Third guard: returns true
             Transition(
@@ -694,7 +703,8 @@ object DeterministicExecutionSuite extends SimpleIOSuite with Checkers {
               to = StateId("end"),
               eventName = "go",
               guard = ConstExpression(BoolValue(true)),
-              effect = ConstExpression(MapValue(Map("path" -> StrValue("third"))))
+              effect = ConstExpression(MapValue(Map("path" -> StrValue("third")))),
+              dependencies = Set.empty
             )
           )
         )
@@ -774,8 +784,8 @@ object DeterministicExecutionSuite extends SimpleIOSuite with Checkers {
 
         definition = StateMachineDefinition(
           states = Map(
-            StateId("start") -> State(StateId("start")),
-            StateId("end")   -> State(StateId("end"))
+            StateId("start") -> State(StateId("start"), isFinal = false),
+            StateId("end")   -> State(StateId("end"), isFinal = false)
           ),
           initialState = StateId("start"),
           transitions = List(
@@ -784,7 +794,8 @@ object DeterministicExecutionSuite extends SimpleIOSuite with Checkers {
               to = StateId("end"),
               eventName = "go",
               guard = ApplyExpression(EqOp, List(expensiveGuard, ConstExpression(IntValue(50)))),
-              effect = ConstExpression(MapValue(Map("done" -> BoolValue(true))))
+              effect = ConstExpression(MapValue(Map("done" -> BoolValue(true)))),
+              dependencies = Set.empty
             )
           )
         )
@@ -849,8 +860,8 @@ object DeterministicExecutionSuite extends SimpleIOSuite with Checkers {
         // A triggers B
         defA = StateMachineDefinition(
           states = Map(
-            StateId("idle")      -> State(StateId("idle")),
-            StateId("triggered") -> State(StateId("triggered"))
+            StateId("idle")      -> State(StateId("idle"), isFinal = false),
+            StateId("triggered") -> State(StateId("triggered"), isFinal = false)
           ),
           initialState = StateId("idle"),
           transitions = List(
@@ -876,7 +887,8 @@ object DeterministicExecutionSuite extends SimpleIOSuite with Checkers {
                     )
                   )
                 )
-              )
+              ),
+              dependencies = Set.empty
             ),
             // Transition to handle incoming loop - triggers B again to create cycle
             Transition(
@@ -901,7 +913,8 @@ object DeterministicExecutionSuite extends SimpleIOSuite with Checkers {
                     )
                   )
                 )
-              )
+              ),
+              dependencies = Set.empty
             ),
             // Also handle loop in idle state to keep cycle going
             Transition(
@@ -926,7 +939,8 @@ object DeterministicExecutionSuite extends SimpleIOSuite with Checkers {
                     )
                   )
                 )
-              )
+              ),
+              dependencies = Set.empty
             )
           )
         )
@@ -934,8 +948,8 @@ object DeterministicExecutionSuite extends SimpleIOSuite with Checkers {
         // B triggers C (with self-transition to allow cycle to continue)
         defB = StateMachineDefinition(
           states = Map(
-            StateId("waiting")   -> State(StateId("waiting")),
-            StateId("continued") -> State(StateId("continued"))
+            StateId("waiting")   -> State(StateId("waiting"), isFinal = false),
+            StateId("continued") -> State(StateId("continued"), isFinal = false)
           ),
           initialState = StateId("waiting"),
           transitions = List(
@@ -961,7 +975,8 @@ object DeterministicExecutionSuite extends SimpleIOSuite with Checkers {
                     )
                   )
                 )
-              )
+              ),
+              dependencies = Set.empty
             ),
             // Self-transition to handle continue event in cycle
             Transition(
@@ -986,7 +1001,8 @@ object DeterministicExecutionSuite extends SimpleIOSuite with Checkers {
                     )
                   )
                 )
-              )
+              ),
+              dependencies = Set.empty
             )
           )
         )
@@ -994,8 +1010,8 @@ object DeterministicExecutionSuite extends SimpleIOSuite with Checkers {
         // C triggers A (completes the cycle, with self-transition to allow cycle to continue)
         defC = StateMachineDefinition(
           states = Map(
-            StateId("PENDING")  -> State(StateId("PENDING")),
-            StateId("finished") -> State(StateId("finished"))
+            StateId("PENDING")  -> State(StateId("PENDING"), isFinal = false),
+            StateId("finished") -> State(StateId("finished"), isFinal = false)
           ),
           initialState = StateId("PENDING"),
           transitions = List(
@@ -1021,7 +1037,8 @@ object DeterministicExecutionSuite extends SimpleIOSuite with Checkers {
                     )
                   )
                 )
-              )
+              ),
+              dependencies = Set.empty
             ),
             // Self-transition to handle finish event in cycle
             Transition(
@@ -1046,7 +1063,8 @@ object DeterministicExecutionSuite extends SimpleIOSuite with Checkers {
                     )
                   )
                 )
-              )
+              ),
+              dependencies = Set.empty
             )
           )
         )
@@ -1144,8 +1162,8 @@ object DeterministicExecutionSuite extends SimpleIOSuite with Checkers {
         // A sends "ping" to B, B sends "pong" to A, A sends "ping" to B...
         defA = StateMachineDefinition(
           states = Map(
-            StateId("s1") -> State(StateId("s1")),
-            StateId("s2") -> State(StateId("s2"))
+            StateId("s1") -> State(StateId("s1"), isFinal = false),
+            StateId("s2") -> State(StateId("s2"), isFinal = false)
           ),
           initialState = StateId("s1"),
           transitions = List(
@@ -1171,7 +1189,8 @@ object DeterministicExecutionSuite extends SimpleIOSuite with Checkers {
                     )
                   )
                 )
-              )
+              ),
+              dependencies = Set.empty
             ),
             Transition(
               from = StateId("s2"),
@@ -1195,15 +1214,16 @@ object DeterministicExecutionSuite extends SimpleIOSuite with Checkers {
                     )
                   )
                 )
-              )
+              ),
+              dependencies = Set.empty
             )
           )
         )
 
         defB = StateMachineDefinition(
           states = Map(
-            StateId("idle")     -> State(StateId("idle")),
-            StateId("received") -> State(StateId("received"))
+            StateId("idle")     -> State(StateId("idle"), isFinal = false),
+            StateId("received") -> State(StateId("received"), isFinal = false)
           ),
           initialState = StateId("idle"),
           transitions = List(
@@ -1229,7 +1249,8 @@ object DeterministicExecutionSuite extends SimpleIOSuite with Checkers {
                     )
                   )
                 )
-              )
+              ),
+              dependencies = Set.empty
             ),
             Transition(
               from = StateId("received"),
@@ -1253,7 +1274,8 @@ object DeterministicExecutionSuite extends SimpleIOSuite with Checkers {
                     )
                   )
                 )
-              )
+              ),
+              dependencies = Set.empty
             )
           )
         )
@@ -1337,8 +1359,8 @@ object DeterministicExecutionSuite extends SimpleIOSuite with Checkers {
         // Child triggers parent on activate, creating half of the cycle
         childDefinition = StateMachineDefinition(
           states = Map(
-            StateId("init")      -> State(StateId("init")),
-            StateId("triggered") -> State(StateId("triggered"))
+            StateId("init")      -> State(StateId("init"), isFinal = false),
+            StateId("triggered") -> State(StateId("triggered"), isFinal = false)
           ),
           initialState = StateId("init"),
           transitions = List(
@@ -1364,7 +1386,8 @@ object DeterministicExecutionSuite extends SimpleIOSuite with Checkers {
                     )
                   )
                 )
-              )
+              ),
+              dependencies = Set.empty
             ),
             // Self-transition to handle activate when already triggered (for cycle)
             Transition(
@@ -1389,7 +1412,8 @@ object DeterministicExecutionSuite extends SimpleIOSuite with Checkers {
                     )
                   )
                 )
-              )
+              ),
+              dependencies = Set.empty
             )
           )
         )
@@ -1397,9 +1421,9 @@ object DeterministicExecutionSuite extends SimpleIOSuite with Checkers {
         // Parent triggers child, creating the other half of the cycle
         parentDefinition = StateMachineDefinition(
           states = Map(
-            StateId("ready")    -> State(StateId("ready")),
-            StateId("ACTIVE")   -> State(StateId("ACTIVE")),
-            StateId("callback") -> State(StateId("callback"))
+            StateId("ready")    -> State(StateId("ready"), isFinal = false),
+            StateId("ACTIVE")   -> State(StateId("ACTIVE"), isFinal = false),
+            StateId("callback") -> State(StateId("callback"), isFinal = false)
           ),
           initialState = StateId("ready"),
           transitions = List(
@@ -1426,7 +1450,8 @@ object DeterministicExecutionSuite extends SimpleIOSuite with Checkers {
                     )
                   )
                 )
-              )
+              ),
+              dependencies = Set.empty
             ),
             // Callback from child triggers child again - creates cycle!
             Transition(
@@ -1451,7 +1476,8 @@ object DeterministicExecutionSuite extends SimpleIOSuite with Checkers {
                     )
                   )
                 )
-              )
+              ),
+              dependencies = Set.empty
             ),
             // Handle callback from callback state to continue cycle
             Transition(
@@ -1476,7 +1502,8 @@ object DeterministicExecutionSuite extends SimpleIOSuite with Checkers {
                     )
                   )
                 )
-              )
+              ),
+              dependencies = Set.empty
             )
           )
         )
@@ -1555,8 +1582,8 @@ object DeterministicExecutionSuite extends SimpleIOSuite with Checkers {
         // State machine with a dependency on a non-existent machine
         definition = StateMachineDefinition(
           states = Map(
-            StateId("start") -> State(StateId("start")),
-            StateId("end")   -> State(StateId("end"))
+            StateId("start") -> State(StateId("start"), isFinal = false),
+            StateId("end")   -> State(StateId("end"), isFinal = false)
           ),
           initialState = StateId("start"),
           transitions = List(

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/FailureReasonSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/FailureReasonSuite.scala
@@ -40,8 +40,8 @@ object FailureReasonSuite extends SimpleIOSuite {
         // State machine with only one event type defined
         definition = StateMachineDefinition(
           states = Map(
-            StateId("idle")   -> State(StateId("idle")),
-            StateId("ACTIVE") -> State(StateId("ACTIVE"))
+            StateId("idle")   -> State(StateId("idle"), isFinal = false),
+            StateId("ACTIVE") -> State(StateId("ACTIVE"), isFinal = false)
           ),
           initialState = StateId("idle"),
           transitions = List(
@@ -50,7 +50,8 @@ object FailureReasonSuite extends SimpleIOSuite {
               to = StateId("ACTIVE"),
               eventName = "activate",
               guard = ConstExpression(BoolValue(true)),
-              effect = ConstExpression(MapValue(Map("activated" -> BoolValue(true))))
+              effect = ConstExpression(MapValue(Map("activated" -> BoolValue(true)))),
+              dependencies = Set.empty
             )
           )
         )
@@ -115,8 +116,8 @@ object FailureReasonSuite extends SimpleIOSuite {
         // Multiple transitions for same event, all guards return false
         definition = StateMachineDefinition(
           states = Map(
-            StateId("start") -> State(StateId("start")),
-            StateId("end")   -> State(StateId("end"))
+            StateId("start") -> State(StateId("start"), isFinal = false),
+            StateId("end")   -> State(StateId("end"), isFinal = false)
           ),
           initialState = StateId("start"),
           transitions = List(
@@ -125,14 +126,16 @@ object FailureReasonSuite extends SimpleIOSuite {
               to = StateId("end"),
               eventName = "go",
               guard = ConstExpression(BoolValue(false)), // Always false
-              effect = ConstExpression(MapValue(Map("path" -> StrValue("first"))))
+              effect = ConstExpression(MapValue(Map("path" -> StrValue("first")))),
+              dependencies = Set.empty
             ),
             Transition(
               from = StateId("start"),
               to = StateId("end"),
               eventName = "go",
               guard = ConstExpression(BoolValue(false)), // Always false
-              effect = ConstExpression(MapValue(Map("path" -> StrValue("second"))))
+              effect = ConstExpression(MapValue(Map("path" -> StrValue("second")))),
+              dependencies = Set.empty
             )
           )
         )
@@ -192,8 +195,8 @@ object FailureReasonSuite extends SimpleIOSuite {
         // State machine that triggers a non-existent target
         definition = StateMachineDefinition(
           states = Map(
-            StateId("idle")      -> State(StateId("idle")),
-            StateId("triggered") -> State(StateId("triggered"))
+            StateId("idle")      -> State(StateId("idle"), isFinal = false),
+            StateId("triggered") -> State(StateId("triggered"), isFinal = false)
           ),
           initialState = StateId("idle"),
           transitions = List(
@@ -219,7 +222,8 @@ object FailureReasonSuite extends SimpleIOSuite {
                     )
                   )
                 )
-              )
+              ),
+              dependencies = Set.empty
             )
           )
         )
@@ -279,8 +283,8 @@ object FailureReasonSuite extends SimpleIOSuite {
         // State machine triggers itself with same event type
         definition = StateMachineDefinition(
           states = Map(
-            StateId("a") -> State(StateId("a")),
-            StateId("b") -> State(StateId("b"))
+            StateId("a") -> State(StateId("a"), isFinal = false),
+            StateId("b") -> State(StateId("b"), isFinal = false)
           ),
           initialState = StateId("a"),
           transitions = List(
@@ -306,7 +310,8 @@ object FailureReasonSuite extends SimpleIOSuite {
                     )
                   )
                 )
-              )
+              ),
+              dependencies = Set.empty
             ),
             Transition(
               from = StateId("b"),
@@ -330,7 +335,8 @@ object FailureReasonSuite extends SimpleIOSuite {
                     )
                   )
                 )
-              )
+              ),
+              dependencies = Set.empty
             )
           )
         )
@@ -390,8 +396,8 @@ object FailureReasonSuite extends SimpleIOSuite {
 
         definition = StateMachineDefinition(
           states = Map(
-            StateId("start") -> State(StateId("start")),
-            StateId("end")   -> State(StateId("end"))
+            StateId("start") -> State(StateId("start"), isFinal = false),
+            StateId("end")   -> State(StateId("end"), isFinal = false)
           ),
           initialState = StateId("start"),
           transitions = List(
@@ -400,7 +406,8 @@ object FailureReasonSuite extends SimpleIOSuite {
               to = StateId("end"),
               eventName = "go",
               guard = ApplyExpression(EqOp, List(expensiveGuard, ConstExpression(IntValue(100)))),
-              effect = ConstExpression(MapValue(Map("done" -> BoolValue(true))))
+              effect = ConstExpression(MapValue(Map("done" -> BoolValue(true)))),
+              dependencies = Set.empty
             )
           )
         )
@@ -471,8 +478,8 @@ object FailureReasonSuite extends SimpleIOSuite {
 
         definition = StateMachineDefinition(
           states = Map(
-            StateId("start") -> State(StateId("start")),
-            StateId("end")   -> State(StateId("end"))
+            StateId("start") -> State(StateId("start"), isFinal = false),
+            StateId("end")   -> State(StateId("end"), isFinal = false)
           ),
           initialState = StateId("start"),
           transitions = List(
@@ -481,7 +488,8 @@ object FailureReasonSuite extends SimpleIOSuite {
               to = StateId("end"),
               eventName = "process",
               guard = ConstExpression(BoolValue(true)),
-              effect = ConstExpression(MapValue(Map("done" -> BoolValue(true))))
+              effect = ConstExpression(MapValue(Map("done" -> BoolValue(true)))),
+              dependencies = Set.empty
             )
           )
         )
@@ -543,7 +551,7 @@ object FailureReasonSuite extends SimpleIOSuite {
 
         definition = StateMachineDefinition(
           states = Map(
-            StateId("idle") -> State(StateId("idle"))
+            StateId("idle") -> State(StateId("idle"), isFinal = false)
           ),
           initialState = StateId("idle"),
           transitions = List.empty

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/GasMeteringPhaseSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/GasMeteringPhaseSuite.scala
@@ -48,8 +48,8 @@ object GasMeteringPhaseSuite extends SimpleIOSuite {
         // Simple state machine
         definition = StateMachineDefinition(
           states = Map(
-            StateId("start") -> State(StateId("start")),
-            StateId("end")   -> State(StateId("end"))
+            StateId("start") -> State(StateId("start"), isFinal = false),
+            StateId("end")   -> State(StateId("end"), isFinal = false)
           ),
           initialState = StateId("start"),
           transitions = List(
@@ -58,7 +58,8 @@ object GasMeteringPhaseSuite extends SimpleIOSuite {
               to = StateId("end"),
               eventName = "go",
               guard = ConstExpression(BoolValue(true)),
-              effect = ConstExpression(MapValue(Map("done" -> BoolValue(true))))
+              effect = ConstExpression(MapValue(Map("done" -> BoolValue(true)))),
+              dependencies = Set.empty
             )
           )
         )
@@ -113,8 +114,8 @@ object GasMeteringPhaseSuite extends SimpleIOSuite {
         // Machine 1 triggers Machine 2
         machine1Definition = StateMachineDefinition(
           states = Map(
-            StateId("a") -> State(StateId("a")),
-            StateId("b") -> State(StateId("b"))
+            StateId("a") -> State(StateId("a"), isFinal = false),
+            StateId("b") -> State(StateId("b"), isFinal = false)
           ),
           initialState = StateId("a"),
           transitions = List(
@@ -140,15 +141,16 @@ object GasMeteringPhaseSuite extends SimpleIOSuite {
                     )
                   )
                 )
-              )
+              ),
+              dependencies = Set.empty
             )
           )
         )
 
         machine2Definition = StateMachineDefinition(
           states = Map(
-            StateId("x") -> State(StateId("x")),
-            StateId("y") -> State(StateId("y"))
+            StateId("x") -> State(StateId("x"), isFinal = false),
+            StateId("y") -> State(StateId("y"), isFinal = false)
           ),
           initialState = StateId("x"),
           transitions = List(
@@ -157,7 +159,8 @@ object GasMeteringPhaseSuite extends SimpleIOSuite {
               to = StateId("y"),
               eventName = "continue",
               guard = ConstExpression(BoolValue(true)),
-              effect = ConstExpression(MapValue(Map("step" -> IntValue(2))))
+              effect = ConstExpression(MapValue(Map("step" -> IntValue(2)))),
+              dependencies = Set.empty
             )
           )
         )
@@ -229,8 +232,8 @@ object GasMeteringPhaseSuite extends SimpleIOSuite {
         // Multiple transitions with guards - first few fail, last succeeds
         definition = StateMachineDefinition(
           states = Map(
-            StateId("start") -> State(StateId("start")),
-            StateId("end")   -> State(StateId("end"))
+            StateId("start") -> State(StateId("start"), isFinal = false),
+            StateId("end")   -> State(StateId("end"), isFinal = false)
           ),
           initialState = StateId("start"),
           transitions = List(
@@ -240,7 +243,8 @@ object GasMeteringPhaseSuite extends SimpleIOSuite {
               to = StateId("end"),
               eventName = "go",
               guard = ConstExpression(BoolValue(false)),
-              effect = ConstExpression(MapValue(Map("path" -> StrValue("first"))))
+              effect = ConstExpression(MapValue(Map("path" -> StrValue("first")))),
+              dependencies = Set.empty
             ),
             // Second guard: fails
             Transition(
@@ -248,7 +252,8 @@ object GasMeteringPhaseSuite extends SimpleIOSuite {
               to = StateId("end"),
               eventName = "go",
               guard = ConstExpression(BoolValue(false)),
-              effect = ConstExpression(MapValue(Map("path" -> StrValue("second"))))
+              effect = ConstExpression(MapValue(Map("path" -> StrValue("second")))),
+              dependencies = Set.empty
             ),
             // Third guard: succeeds
             Transition(
@@ -256,7 +261,8 @@ object GasMeteringPhaseSuite extends SimpleIOSuite {
               to = StateId("end"),
               eventName = "go",
               guard = ConstExpression(BoolValue(true)),
-              effect = ConstExpression(MapValue(Map("path" -> StrValue("third"))))
+              effect = ConstExpression(MapValue(Map("path" -> StrValue("third")))),
+              dependencies = Set.empty
             )
           )
         )
@@ -317,8 +323,8 @@ object GasMeteringPhaseSuite extends SimpleIOSuite {
         // State machine with guard that accesses state (costs 2 gas for varAccess)
         definition = StateMachineDefinition(
           states = Map(
-            StateId("start") -> State(StateId("start")),
-            StateId("end")   -> State(StateId("end"))
+            StateId("start") -> State(StateId("start"), isFinal = false),
+            StateId("end")   -> State(StateId("end"), isFinal = false)
           ),
           initialState = StateId("start"),
           transitions = List(
@@ -328,7 +334,8 @@ object GasMeteringPhaseSuite extends SimpleIOSuite {
               eventName = "go",
               // Guard that reads from state - varAccess costs 2 gas, !! (NOp) costs 1 gas
               guard = ApplyExpression(NOp, List(VarExpression(Left("_state")))),
-              effect = ConstExpression(MapValue(Map("done" -> BoolValue(true))))
+              effect = ConstExpression(MapValue(Map("done" -> BoolValue(true)))),
+              dependencies = Set.empty
             )
           )
         )
@@ -392,8 +399,8 @@ object GasMeteringPhaseSuite extends SimpleIOSuite {
 
         definition = StateMachineDefinition(
           states = Map(
-            StateId("start") -> State(StateId("start")),
-            StateId("end")   -> State(StateId("end"))
+            StateId("start") -> State(StateId("start"), isFinal = false),
+            StateId("end")   -> State(StateId("end"), isFinal = false)
           ),
           initialState = StateId("start"),
           transitions = List(
@@ -402,7 +409,8 @@ object GasMeteringPhaseSuite extends SimpleIOSuite {
               to = StateId("end"),
               eventName = "go",
               guard = ConstExpression(BoolValue(true)), // Simple guard passes
-              effect = expensiveEffect // Expensive effect exhausts gas
+              effect = expensiveEffect, // Expensive effect exhausts gas
+              dependencies = Set.empty
             )
           )
         )
@@ -466,8 +474,8 @@ object GasMeteringPhaseSuite extends SimpleIOSuite {
         // Parent that spawns a child
         parentDefinition = StateMachineDefinition(
           states = Map(
-            StateId("init")    -> State(StateId("init")),
-            StateId("spawned") -> State(StateId("spawned"))
+            StateId("init")    -> State(StateId("init"), isFinal = false),
+            StateId("spawned") -> State(StateId("spawned"), isFinal = false)
           ),
           initialState = StateId("init"),
           transitions = List(
@@ -508,7 +516,8 @@ object GasMeteringPhaseSuite extends SimpleIOSuite {
                     )
                   )
                 )
-              )
+              ),
+              dependencies = Set.empty
             )
           )
         )
@@ -579,8 +588,8 @@ object GasMeteringPhaseSuite extends SimpleIOSuite {
         // Machine 1 triggers Machine 2 with expensive computations
         machine1Definition = StateMachineDefinition(
           states = Map(
-            StateId("a") -> State(StateId("a")),
-            StateId("b") -> State(StateId("b"))
+            StateId("a") -> State(StateId("a"), isFinal = false),
+            StateId("b") -> State(StateId("b"), isFinal = false)
           ),
           initialState = StateId("a"),
           transitions = List(
@@ -606,15 +615,16 @@ object GasMeteringPhaseSuite extends SimpleIOSuite {
                     )
                   )
                 )
-              )
+              ),
+              dependencies = Set.empty
             )
           )
         )
 
         machine2Definition = StateMachineDefinition(
           states = Map(
-            StateId("x") -> State(StateId("x")),
-            StateId("y") -> State(StateId("y"))
+            StateId("x") -> State(StateId("x"), isFinal = false),
+            StateId("y") -> State(StateId("y"), isFinal = false)
           ),
           initialState = StateId("x"),
           transitions = List(
@@ -633,7 +643,8 @@ object GasMeteringPhaseSuite extends SimpleIOSuite {
                   ),
                   "done" -> ConstExpression(BoolValue(true))
                 )
-              )
+              ),
+              dependencies = Set.empty
             )
           )
         )
@@ -716,8 +727,8 @@ object GasMeteringPhaseSuite extends SimpleIOSuite {
         // Machine 1 triggers Machine 2
         machine1Definition = StateMachineDefinition(
           states = Map(
-            StateId("a") -> State(StateId("a")),
-            StateId("b") -> State(StateId("b"))
+            StateId("a") -> State(StateId("a"), isFinal = false),
+            StateId("b") -> State(StateId("b"), isFinal = false)
           ),
           initialState = StateId("a"),
           transitions = List(
@@ -743,15 +754,16 @@ object GasMeteringPhaseSuite extends SimpleIOSuite {
                     )
                   )
                 )
-              )
+              ),
+              dependencies = Set.empty
             )
           )
         )
 
         machine2Definition = StateMachineDefinition(
           states = Map(
-            StateId("x") -> State(StateId("x")),
-            StateId("y") -> State(StateId("y"))
+            StateId("x") -> State(StateId("x"), isFinal = false),
+            StateId("y") -> State(StateId("y"), isFinal = false)
           ),
           initialState = StateId("x"),
           transitions = List(
@@ -760,7 +772,8 @@ object GasMeteringPhaseSuite extends SimpleIOSuite {
               to = StateId("y"),
               eventName = "respond",
               guard = ConstExpression(BoolValue(true)),
-              effect = ConstExpression(MapValue(Map("step" -> IntValue(2))))
+              effect = ConstExpression(MapValue(Map("step" -> IntValue(2)))),
+              dependencies = Set.empty
             )
           )
         )

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/GenesisBuilderSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/GenesisBuilderSuite.scala
@@ -36,7 +36,7 @@ object GenesisBuilderSuite extends SimpleIOSuite {
       version = SemVer(1, 0, 0),
       schemaHash = Hash(s"schema-$label"),
       logicHash = Hash(s"logic-$label"),
-      schemaShape = shape,
+      machineShape = shape,
       owner = Set.empty[Address]
     )
 

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/GenesisBuilderSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/GenesisBuilderSuite.scala
@@ -23,8 +23,8 @@ import weaver.SimpleIOSuite
 
 object GenesisBuilderSuite extends SimpleIOSuite {
 
-  private val shape: SchemaShape =
-    SchemaShape(
+  private val shape: MachineShape =
+    MachineShape(
       stateMessage =
         MessageShape("App.State", List(FieldShape("balance", 1, "int64", repeated = false, optional = false))),
       commands = SortedMap.empty

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/GenesisDataSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/GenesisDataSuite.scala
@@ -36,9 +36,10 @@ object GenesisDataSuite extends SimpleIOSuite {
             version = SemVer(1, 0, 0),
             schemaHash = Hash("schema"),
             logicHash = Hash("logic"),
-            schemaShape = shape,
+            shape = RegistryShape.Machine(shape),
             status = RegistryStatus.Active,
-            registeredAt = SnapshotOrdinal.MinValue
+            registeredAt = SnapshotOrdinal.MinValue,
+            strict = false
           )
         )
       )

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/GenesisDataSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/GenesisDataSuite.scala
@@ -17,8 +17,8 @@ import weaver.SimpleIOSuite
 
 object GenesisDataSuite extends SimpleIOSuite {
 
-  private val shape: SchemaShape =
-    SchemaShape(
+  private val shape: MachineShape =
+    MachineShape(
       stateMessage =
         MessageShape("App.State", List(FieldShape("balance", 1, "int64", repeated = false, optional = false))),
       commands = SortedMap(

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/GenesisLoaderSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/GenesisLoaderSuite.scala
@@ -20,8 +20,8 @@ import weaver.SimpleIOSuite
 
 object GenesisLoaderSuite extends SimpleIOSuite {
 
-  private val shape: SchemaShape =
-    SchemaShape(
+  private val shape: MachineShape =
+    MachineShape(
       stateMessage =
         MessageShape("App.State", List(FieldShape("balance", 1, "int64", repeated = false, optional = false))),
       commands = SortedMap.empty

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/GenesisLoaderSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/GenesisLoaderSuite.scala
@@ -37,9 +37,10 @@ object GenesisLoaderSuite extends SimpleIOSuite {
             version = SemVer(1, 0, 0),
             schemaHash = Hash("schema"),
             logicHash = Hash("logic"),
-            schemaShape = shape,
+            shape = RegistryShape.Machine(shape),
             status = RegistryStatus.Active,
-            registeredAt = SnapshotOrdinal.MinValue
+            registeredAt = SnapshotOrdinal.MinValue,
+            strict = false
           )
         )
       )

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/GenesisManifestLoaderSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/GenesisManifestLoaderSuite.scala
@@ -5,7 +5,7 @@ import cats.effect.IO
 import io.constellationnetwork.metagraph_sdk.std.JsonBinaryHasher.HasherOps
 
 import xyz.kd5ujc.schema.GenesisManifest
-import xyz.kd5ujc.schema.registry.{RegistryName, RegistryTarget}
+import xyz.kd5ujc.schema.registry.{RegistryName, RegistryShape, RegistryTarget}
 import xyz.kd5ujc.shared_data.genesis.GenesisManifestLoader
 
 import io.circe.parser.decode
@@ -17,7 +17,7 @@ object GenesisManifestLoaderSuite extends SimpleIOSuite {
   // (schemaShape + JSON-Logic definition), no consensus hashes. definition is the proven timeLock fixture.
   private val manifestJson: String =
     """{"version":1,"packages":[{"name":"std.identity.package","semver":"1.0.0","strict":false,"metadata":{},""" +
-    """"schemaShape":{"stateMessage":{"typeName":"ottochain.apps.identity.v1.Identity",""" +
+    """"machineShape":{"stateMessage":{"typeName":"ottochain.apps.identity.v1.Identity",""" +
     """"fields":[{"name":"id","number":1,"typeName":"string","repeated":false,"optional":false}]},"commands":{}},""" +
     """"definition":{"states":{"locked":{"id":"locked","isFinal":false},"unlocked":{"id":"unlocked","isFinal":true}},""" +
     """"initialState":"locked","transitions":[{"from":"locked","to":"unlocked","eventName":"unlock",""" +
@@ -38,7 +38,10 @@ object GenesisManifestLoaderSuite extends SimpleIOSuite {
         .get(idName)
         .exists(_.target match {
           case RegistryTarget.SchemaPackage(lineage) =>
-            lineage.head.exists(_.schemaShape.stateMessage.typeName == "ottochain.apps.identity.v1.Identity")
+            lineage.head.exists(_.shape match {
+              case RegistryShape.Machine(ms) => ms.stateMessage.typeName == "ottochain.apps.identity.v1.Identity"
+              case _                         => false
+            })
           case _ => false
         })
     )
@@ -50,7 +53,7 @@ object GenesisManifestLoaderSuite extends SimpleIOSuite {
       genesis  <- GenesisManifestLoader.fromManifest[IO](manifest)
       pkg = manifest.packages.head
       expectedLogic  <- pkg.definition.computeDigest
-      expectedSchema <- pkg.schemaShape.computeDigest
+      expectedSchema <- pkg.machineShape.computeDigest
       registered = genesis.calculated.registry
         .get(idName)
         .flatMap(_.target match {

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/GuardEdgeCasesSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/GuardEdgeCasesSuite.scala
@@ -44,8 +44,8 @@ object GuardEdgeCasesSuite extends SimpleIOSuite {
         // Guard references a field that doesn't exist in state
         definition = StateMachineDefinition(
           states = Map(
-            StateId("start") -> State(StateId("start")),
-            StateId("end")   -> State(StateId("end"))
+            StateId("start") -> State(StateId("start"), isFinal = false),
+            StateId("end")   -> State(StateId("end"), isFinal = false)
           ),
           initialState = StateId("start"),
           transitions = List(
@@ -59,7 +59,8 @@ object GuardEdgeCasesSuite extends SimpleIOSuite {
                 EqOp,
                 List(VarExpression(Left("state.missingField")), ConstExpression(BoolValue(true)))
               ),
-              effect = ConstExpression(MapValue(Map("path" -> StrValue("first"))))
+              effect = ConstExpression(MapValue(Map("path" -> StrValue("first")))),
+              dependencies = Set.empty
             ),
             // Fallback guard that always passes
             Transition(
@@ -67,7 +68,8 @@ object GuardEdgeCasesSuite extends SimpleIOSuite {
               to = StateId("end"),
               eventName = "check",
               guard = ConstExpression(BoolValue(true)),
-              effect = ConstExpression(MapValue(Map("path" -> StrValue("fallback"))))
+              effect = ConstExpression(MapValue(Map("path" -> StrValue("fallback")))),
+              dependencies = Set.empty
             )
           )
         )
@@ -145,8 +147,8 @@ object GuardEdgeCasesSuite extends SimpleIOSuite {
 
         definition = StateMachineDefinition(
           states = Map(
-            StateId("start") -> State(StateId("start")),
-            StateId("end")   -> State(StateId("end"))
+            StateId("start") -> State(StateId("start"), isFinal = false),
+            StateId("end")   -> State(StateId("end"), isFinal = false)
           ),
           initialState = StateId("start"),
           transitions = List(
@@ -155,7 +157,8 @@ object GuardEdgeCasesSuite extends SimpleIOSuite {
               to = StateId("end"),
               eventName = "process",
               guard = deepGuard,
-              effect = ConstExpression(MapValue(Map("processed" -> BoolValue(true))))
+              effect = ConstExpression(MapValue(Map("processed" -> BoolValue(true)))),
+              dependencies = Set.empty
             )
           )
         )
@@ -228,8 +231,8 @@ object GuardEdgeCasesSuite extends SimpleIOSuite {
 
         definition = StateMachineDefinition(
           states = Map(
-            StateId("start") -> State(StateId("start")),
-            StateId("end")   -> State(StateId("end"))
+            StateId("start") -> State(StateId("start"), isFinal = false),
+            StateId("end")   -> State(StateId("end"), isFinal = false)
           ),
           initialState = StateId("start"),
           transitions = List(
@@ -238,7 +241,8 @@ object GuardEdgeCasesSuite extends SimpleIOSuite {
               to = StateId("end"),
               eventName = "divide",
               guard = divByZeroGuard,
-              effect = ConstExpression(MapValue(Map("divided" -> BoolValue(true))))
+              effect = ConstExpression(MapValue(Map("divided" -> BoolValue(true)))),
+              dependencies = Set.empty
             ),
             // Fallback
             Transition(
@@ -246,7 +250,8 @@ object GuardEdgeCasesSuite extends SimpleIOSuite {
               to = StateId("end"),
               eventName = "divide",
               guard = ConstExpression(BoolValue(true)),
-              effect = ConstExpression(MapValue(Map("fallback" -> BoolValue(true))))
+              effect = ConstExpression(MapValue(Map("fallback" -> BoolValue(true)))),
+              dependencies = Set.empty
             )
           )
         )
@@ -304,8 +309,8 @@ object GuardEdgeCasesSuite extends SimpleIOSuite {
         // Three transitions - first two guards check specific conditions
         definition = StateMachineDefinition(
           states = Map(
-            StateId("start") -> State(StateId("start")),
-            StateId("end")   -> State(StateId("end"))
+            StateId("start") -> State(StateId("start"), isFinal = false),
+            StateId("end")   -> State(StateId("end"), isFinal = false)
           ),
           initialState = StateId("start"),
           transitions = List(
@@ -318,7 +323,8 @@ object GuardEdgeCasesSuite extends SimpleIOSuite {
                 Gt,
                 List(VarExpression(Left("state.value")), ConstExpression(IntValue(100)))
               ),
-              effect = ConstExpression(MapValue(Map("path" -> StrValue("high"))))
+              effect = ConstExpression(MapValue(Map("path" -> StrValue("high")))),
+              dependencies = Set.empty
             ),
             // Second: requires value > 50
             Transition(
@@ -329,7 +335,8 @@ object GuardEdgeCasesSuite extends SimpleIOSuite {
                 Gt,
                 List(VarExpression(Left("state.value")), ConstExpression(IntValue(50)))
               ),
-              effect = ConstExpression(MapValue(Map("path" -> StrValue("medium"))))
+              effect = ConstExpression(MapValue(Map("path" -> StrValue("medium")))),
+              dependencies = Set.empty
             ),
             // Third: always passes
             Transition(
@@ -337,7 +344,8 @@ object GuardEdgeCasesSuite extends SimpleIOSuite {
               to = StateId("end"),
               eventName = "process",
               guard = ConstExpression(BoolValue(true)),
-              effect = ConstExpression(MapValue(Map("path" -> StrValue("low"))))
+              effect = ConstExpression(MapValue(Map("path" -> StrValue("low")))),
+              dependencies = Set.empty
             )
           )
         )
@@ -401,8 +409,8 @@ object GuardEdgeCasesSuite extends SimpleIOSuite {
 
         definition = StateMachineDefinition(
           states = Map(
-            StateId("start") -> State(StateId("start")),
-            StateId("end")   -> State(StateId("end"))
+            StateId("start") -> State(StateId("start"), isFinal = false),
+            StateId("end")   -> State(StateId("end"), isFinal = false)
           ),
           initialState = StateId("start"),
           transitions = List(
@@ -411,7 +419,8 @@ object GuardEdgeCasesSuite extends SimpleIOSuite {
               to = StateId("end"),
               eventName = "go",
               guard = nonBooleanGuard,
-              effect = ConstExpression(MapValue(Map("done" -> BoolValue(true))))
+              effect = ConstExpression(MapValue(Map("done" -> BoolValue(true)))),
+              dependencies = Set.empty
             )
           )
         )
@@ -469,8 +478,8 @@ object GuardEdgeCasesSuite extends SimpleIOSuite {
 
         definition = StateMachineDefinition(
           states = Map(
-            StateId("start") -> State(StateId("start")),
-            StateId("end")   -> State(StateId("end"))
+            StateId("start") -> State(StateId("start"), isFinal = false),
+            StateId("end")   -> State(StateId("end"), isFinal = false)
           ),
           initialState = StateId("start"),
           transitions = List(
@@ -479,7 +488,8 @@ object GuardEdgeCasesSuite extends SimpleIOSuite {
               to = StateId("end"),
               eventName = "go",
               guard = ConstExpression(BoolValue(true)),
-              effect = ConstExpression(MapValue(Map("done" -> BoolValue(true))))
+              effect = ConstExpression(MapValue(Map("done" -> BoolValue(true)))),
+              dependencies = Set.empty
             )
           )
         )

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/PublishVersionSigningCanonicalSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/PublishVersionSigningCanonicalSuite.scala
@@ -27,11 +27,11 @@ import weaver.SimpleIOSuite
 object PublishVersionSigningCanonicalSuite extends SimpleIOSuite {
 
   private val harnessJson: String =
-    """{"PublishVersion":{
+    """{"PublishMachineVersion":{
       |  "name":"order.package",
       |  "version":"1.0.0",
       |  "schemaB64":"ZGVzY3JpcHRvcjpvcmRlci5wYWNrYWdlOjEuMC4w",
-      |  "schemaShape":{
+      |  "machineShape":{
       |    "stateMessage":{"typeName":"Order","fields":[
       |      {"name":"orderId","number":1,"typeName":"string","repeated":false,"optional":false},
       |      {"name":"customer","number":2,"typeName":"string","repeated":false,"optional":false},
@@ -92,8 +92,8 @@ object PublishVersionSigningCanonicalSuite extends SimpleIOSuite {
 
   test("harness PublishVersion passes DL1 (L1) stateless validation") {
     decode[OttochainMessage](harnessJson) match {
-      case Right(pv: Updates.PublishVersion) =>
-        new RegistryValidator.L1Validator[IO].publish(pv).map {
+      case Right(pv: Updates.PublishMachineVersion) =>
+        new RegistryValidator.L1Validator[IO].publishMachineVersion(pv).map {
           case Valid(_)      => success
           case Invalid(errs) => failure(s"L1 REJECTED: ${errs.toNonEmptyList.toList.map(_.toString).mkString(" | ")}")
         }

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/RegistryCodecSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/RegistryCodecSuite.scala
@@ -17,8 +17,8 @@ import weaver.SimpleIOSuite
 
 object RegistryCodecSuite extends SimpleIOSuite {
 
-  private val shape: SchemaShape =
-    SchemaShape(
+  private val shape: MachineShape =
+    MachineShape(
       stateMessage =
         MessageShape("App.State", List(FieldShape("balance", 1, "int64", repeated = false, optional = false))),
       commands = SortedMap(

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/RegistryCodecSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/RegistryCodecSuite.scala
@@ -36,9 +36,10 @@ object RegistryCodecSuite extends SimpleIOSuite {
             version = SemVer(1, 0, 0),
             schemaHash = Hash("schema"),
             logicHash = Hash("logic"),
-            schemaShape = shape,
+            shape = RegistryShape.Machine(shape),
             status = RegistryStatus.Active,
-            registeredAt = SnapshotOrdinal.MinValue
+            registeredAt = SnapshotOrdinal.MinValue,
+            strict = false
           )
         )
       )

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/RegistryCombinerSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/RegistryCombinerSuite.scala
@@ -49,8 +49,8 @@ object RegistryCombinerSuite extends SimpleIOSuite {
   // Package names now carry the `.package` TLD (Option B): a name is `<labels>.<tld>`.
   private def pkg(n: String): RegistryName = RegistryName.unsafe(s"$n.package")
 
-  private val shape: SchemaShape =
-    SchemaShape(
+  private val shape: MachineShape =
+    MachineShape(
       stateMessage =
         MessageShape("App.State", List(FieldShape("balance", 1, "int64", repeated = false, optional = false))),
       commands = SortedMap(

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/RegistryCombinerSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/RegistryCombinerSuite.scala
@@ -12,7 +12,13 @@ import io.constellationnetwork.metagraph_sdk.json_logic.{IntValue, JsonLogicValu
 import io.constellationnetwork.security.SecurityProvider
 import io.constellationnetwork.security.signature.Signed
 
-import xyz.kd5ujc.schema.Updates.{CreateStateMachine, PublishVersion, RegisterAlias, SetVersionStatus, UpgradeFiber}
+import xyz.kd5ujc.schema.Updates.{
+  CreateStateMachine,
+  PublishMachineVersion,
+  RegisterAlias,
+  SetVersionStatus,
+  UpgradeFiber
+}
 import xyz.kd5ujc.schema.fiber.{FiberLogEntry, FiberOrdinal, State, StateId, StateMachineDefinition}
 import xyz.kd5ujc.schema.registry._
 import xyz.kd5ujc.schema.{CalculatedState, OnChain, Records}
@@ -68,12 +74,12 @@ object RegistryCombinerSuite extends SimpleIOSuite {
   private val emptyData: JsonLogicValue = MapValue(Map.empty[String, JsonLogicValue])
   private val fiberA = UUID.fromString("11111111-1111-4111-8111-111111111111")
 
-  private def publish(name: String, v: SemVer): PublishVersion =
-    PublishVersion(
+  private def publish(name: String, v: SemVer): PublishMachineVersion =
+    PublishMachineVersion(
       name = pkg(name),
       version = v,
       schemaB64 = b64(s"schema-$name-${v.render}"),
-      schemaShape = shape,
+      machineShape = shape,
       definition = minimalDef,
       strict = false
     )
@@ -90,8 +96,8 @@ object RegistryCombinerSuite extends SimpleIOSuite {
     )
   }
 
-  private def publishWith(name: String, v: SemVer, definition: StateMachineDefinition): PublishVersion =
-    PublishVersion(pkg(name), v, b64(s"schema-$name-${v.render}"), shape, definition, strict = false)
+  private def publishWith(name: String, v: SemVer, definition: StateMachineDefinition): PublishMachineVersion =
+    PublishMachineVersion(pkg(name), v, b64(s"schema-$name-${v.render}"), shape, definition, strict = false)
 
   private val genesis = DataState(OnChain.genesis, CalculatedState.genesis)
 
@@ -236,11 +242,14 @@ object RegistryCombinerSuite extends SimpleIOSuite {
         prC           <- fixture.registry.generateProofs(create, Set(Alice))
         valid         <- validator.validateSignedUpdate(s1, Signed(create, prC))
         combineFailed <- combiner.insert(s1, Signed(create, prC)).map(wasRejected)
-      } yield expect(valid.isInvalid) and expect(combineFailed)
+        // validator passes (structural only — registry lineage is combine-only per TOCTOU rule)
+      } yield expect(valid.isValid) and expect(combineFailed)
     }
   }
 
-  test("creating a fiber with a schemaRef to an unknown name is rejected (validator invalid + combiner aborts)") {
+  test(
+    "creating a fiber with a schemaRef to an unknown name is rejected (combiner aborts; validator passes structural)"
+  ) {
     TestFixture.resource(Set(Alice)).use { fixture =>
       implicit val sp: SecurityProvider[IO] = fixture.securityProvider
       implicit val l0: L0NodeContext[IO] = fixture.l0Context
@@ -256,7 +265,8 @@ object RegistryCombinerSuite extends SimpleIOSuite {
         prC           <- fixture.registry.generateProofs(create, Set(Alice))
         valid         <- validator.validateSignedUpdate(genesis, Signed(create, prC))
         combineFailed <- combiner.insert(genesis, Signed(create, prC)).map(wasRejected)
-      } yield expect(valid.isInvalid) and expect(combineFailed)
+        // validator passes (structural only — registry lineage is combine-only per TOCTOU rule)
+      } yield expect(valid.isValid) and expect(combineFailed)
     }
   }
 
@@ -327,7 +337,9 @@ object RegistryCombinerSuite extends SimpleIOSuite {
     }
   }
 
-  test("upgrading with a definition that does not match the target version's logicHash is rejected") {
+  test(
+    "upgrading with a definition that does not match the target version's logicHash is rejected (combiner; validator structural-only)"
+  ) {
     TestFixture.resource(Set(Alice)).use { fixture =>
       implicit val sp: SecurityProvider[IO] = fixture.securityProvider
       implicit val l0: L0NodeContext[IO] = fixture.l0Context
@@ -356,7 +368,8 @@ object RegistryCombinerSuite extends SimpleIOSuite {
         prU           <- fixture.registry.generateProofs(badUpgrade, Set(Alice))
         valid         <- validator.validateSignedUpdate(s2, Signed(badUpgrade, prU))
         combineFailed <- combiner.insert(s2, Signed(badUpgrade, prU)).map(wasRejected)
-      } yield expect(valid.isInvalid) and expect(combineFailed)
+        // validator passes (structural only — registry hash check is combine-only per TOCTOU rule)
+      } yield expect(valid.isValid) and expect(combineFailed)
     }
   }
 
@@ -428,7 +441,7 @@ object RegistryCombinerSuite extends SimpleIOSuite {
       val combiner = Combiner.make[IO]()
       // strict v1; `shape` declares state field "balance: int64"
       val pStrict =
-        PublishVersion(
+        PublishMachineVersion(
           pkg("escrow"),
           SemVer(1, 0, 0),
           b64("schema-escrow-1.0.0"),
@@ -459,7 +472,7 @@ object RegistryCombinerSuite extends SimpleIOSuite {
       val combiner = Combiner.make[IO]()
       val p1 = publish("escrow", SemVer(1, 0, 0)) // NON-strict v1 -> create with an extra field is allowed
       val p2strict =
-        PublishVersion(
+        PublishMachineVersion(
           pkg("escrow"),
           SemVer(2, 0, 0),
           b64("schema-escrow-2.0.0"),
@@ -615,7 +628,7 @@ object RegistryCombinerSuite extends SimpleIOSuite {
       val combiner = Combiner.make[IO]()
       val meta = SortedMap("repo" -> "https://github.com/acme/escrow", "license" -> "MIT")
       val good =
-        PublishVersion(
+        PublishMachineVersion(
           pkg("escrow"),
           SemVer(1, 0, 0),
           b64("schema"),
@@ -624,7 +637,7 @@ object RegistryCombinerSuite extends SimpleIOSuite {
           strict = false,
           metadata = Some(meta)
         )
-      val bad = PublishVersion(
+      val bad = PublishMachineVersion(
         pkg("widget"),
         SemVer(1, 0, 0),
         b64("schema"),

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/RegistryLineageSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/RegistryLineageSuite.scala
@@ -35,9 +35,10 @@ object RegistryLineageSuite extends SimpleIOSuite {
       version = SemVer(major, minor, patch),
       schemaHash = Hash(s"schema-$major.$minor.$patch"),
       logicHash = Hash(s"logic-$major.$minor.$patch"),
-      schemaShape = shape,
+      shape = RegistryShape.Machine(shape),
       status = status,
-      registeredAt = ord
+      registeredAt = ord,
+      strict = false
     )
 
   private def lineage(vs: RegisteredVersion*): VersionLineage =
@@ -132,9 +133,9 @@ object RegistryLineageSuite extends SimpleIOSuite {
     )
   }
 
-  // ── schemaShapeWellFormed: structural proto validation of the typed domain projection ─────────
+  // ── machineShapeWellFormed: structural proto validation of the typed domain projection ─────────
 
-  test("schemaShapeWellFormed accepts a valid shape and rejects each malformed kind") {
+  test("machineShapeWellFormed accepts a valid shape and rejects each malformed kind") {
     val outOfRange = shape.copy(stateMessage =
       MessageShape("App.State", List(FieldShape("x", 0, "int64", repeated = false, optional = false)))
     )
@@ -161,14 +162,14 @@ object RegistryLineageSuite extends SimpleIOSuite {
     )
     val emptyCmdName = shape.copy(commands = SortedMap(" " -> MessageShape("App.Start", Nil)))
     for {
-      ok  <- RegistryRules.L1.schemaShapeWellFormed[IO](shape)
-      oor <- RegistryRules.L1.schemaShapeWellFormed[IO](outOfRange)
-      big <- RegistryRules.L1.schemaShapeWellFormed[IO](tooBig)
-      res <- RegistryRules.L1.schemaShapeWellFormed[IO](reserved)
-      dpl <- RegistryRules.L1.schemaShapeWellFormed[IO](dup)
-      efn <- RegistryRules.L1.schemaShapeWellFormed[IO](emptyFieldName)
-      etn <- RegistryRules.L1.schemaShapeWellFormed[IO](emptyTypeName)
-      ecn <- RegistryRules.L1.schemaShapeWellFormed[IO](emptyCmdName)
+      ok  <- RegistryRules.L1.machineShapeWellFormed[IO](shape)
+      oor <- RegistryRules.L1.machineShapeWellFormed[IO](outOfRange)
+      big <- RegistryRules.L1.machineShapeWellFormed[IO](tooBig)
+      res <- RegistryRules.L1.machineShapeWellFormed[IO](reserved)
+      dpl <- RegistryRules.L1.machineShapeWellFormed[IO](dup)
+      efn <- RegistryRules.L1.machineShapeWellFormed[IO](emptyFieldName)
+      etn <- RegistryRules.L1.machineShapeWellFormed[IO](emptyTypeName)
+      ecn <- RegistryRules.L1.machineShapeWellFormed[IO](emptyCmdName)
     } yield expect(ok.isValid) and
     expect(oor.isInvalid) and
     expect(big.isInvalid) and

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/RegistryLineageSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/RegistryLineageSuite.scala
@@ -16,8 +16,8 @@ object RegistryLineageSuite extends SimpleIOSuite {
 
   private val ord = SnapshotOrdinal.MinValue
 
-  private val shape: SchemaShape =
-    SchemaShape(
+  private val shape: MachineShape =
+    MachineShape(
       stateMessage =
         MessageShape("App.State", List(FieldShape("balance", 1, "int64", repeated = false, optional = false))),
       commands = SortedMap(

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/RollbackCompensationSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/RollbackCompensationSuite.scala
@@ -44,8 +44,8 @@ object RollbackCompensationSuite extends SimpleIOSuite {
         // Machine A triggers B
         defA = StateMachineDefinition(
           states = Map(
-            StateId("idle")      -> State(StateId("idle")),
-            StateId("triggered") -> State(StateId("triggered"))
+            StateId("idle")      -> State(StateId("idle"), isFinal = false),
+            StateId("triggered") -> State(StateId("triggered"), isFinal = false)
           ),
           initialState = StateId("idle"),
           transitions = List(
@@ -71,7 +71,8 @@ object RollbackCompensationSuite extends SimpleIOSuite {
                     )
                   )
                 )
-              )
+              ),
+              dependencies = Set.empty
             )
           )
         )
@@ -79,8 +80,8 @@ object RollbackCompensationSuite extends SimpleIOSuite {
         // Machine B triggers C
         defB = StateMachineDefinition(
           states = Map(
-            StateId("waiting")   -> State(StateId("waiting")),
-            StateId("continued") -> State(StateId("continued"))
+            StateId("waiting")   -> State(StateId("waiting"), isFinal = false),
+            StateId("continued") -> State(StateId("continued"), isFinal = false)
           ),
           initialState = StateId("waiting"),
           transitions = List(
@@ -106,7 +107,8 @@ object RollbackCompensationSuite extends SimpleIOSuite {
                     )
                   )
                 )
-              )
+              ),
+              dependencies = Set.empty
             )
           )
         )
@@ -114,8 +116,8 @@ object RollbackCompensationSuite extends SimpleIOSuite {
         // Machine C fails (guard always false, no valid transition)
         defC = StateMachineDefinition(
           states = Map(
-            StateId("PENDING")  -> State(StateId("PENDING")),
-            StateId("finished") -> State(StateId("finished"))
+            StateId("PENDING")  -> State(StateId("PENDING"), isFinal = false),
+            StateId("finished") -> State(StateId("finished"), isFinal = false)
           ),
           initialState = StateId("PENDING"),
           transitions = List(
@@ -125,7 +127,8 @@ object RollbackCompensationSuite extends SimpleIOSuite {
               eventName = "finish",
               // Guard that always fails
               guard = ConstExpression(BoolValue(false)),
-              effect = ConstExpression(MapValue(Map("step" -> IntValue(3))))
+              effect = ConstExpression(MapValue(Map("step" -> IntValue(3)))),
+              dependencies = Set.empty
             )
           )
         )
@@ -229,8 +232,8 @@ object RollbackCompensationSuite extends SimpleIOSuite {
         // by trying to access non-existent nested property in complex way
         definition = StateMachineDefinition(
           states = Map(
-            StateId("start") -> State(StateId("start")),
-            StateId("end")   -> State(StateId("end"))
+            StateId("start") -> State(StateId("start"), isFinal = false),
+            StateId("end")   -> State(StateId("end"), isFinal = false)
           ),
           initialState = StateId("start"),
           transitions = List(
@@ -248,7 +251,8 @@ object RollbackCompensationSuite extends SimpleIOSuite {
                   // Accessing a deeply nested non-existent path
                   VarExpression(Left("event.payload.deeply.nested.missing.path"))
                 )
-              )
+              ),
+              dependencies = Set.empty
             )
           )
         )
@@ -337,8 +341,8 @@ object RollbackCompensationSuite extends SimpleIOSuite {
 
         parentDefinition = StateMachineDefinition(
           states = Map(
-            StateId("ready")   -> State(StateId("ready")),
-            StateId("spawned") -> State(StateId("spawned"))
+            StateId("ready")   -> State(StateId("ready"), isFinal = false),
+            StateId("spawned") -> State(StateId("spawned"), isFinal = false)
           ),
           initialState = StateId("ready"),
           transitions = List(
@@ -376,7 +380,8 @@ object RollbackCompensationSuite extends SimpleIOSuite {
                     )
                   )
                 )
-              )
+              ),
+              dependencies = Set.empty
             )
           )
         )
@@ -438,7 +443,7 @@ object RollbackCompensationSuite extends SimpleIOSuite {
         // State machine with no valid transitions for the event
         definition = StateMachineDefinition(
           states = Map(
-            StateId("locked") -> State(StateId("locked"))
+            StateId("locked") -> State(StateId("locked"), isFinal = false)
           ),
           initialState = StateId("locked"),
           transitions = List.empty // No transitions at all

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/SequencedOrderingE2ESuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/SequencedOrderingE2ESuite.scala
@@ -58,7 +58,8 @@ object SequencedOrderingE2ESuite extends SimpleIOSuite {
                 )
               )
             )
-          )
+          ),
+          dependencies = Set.empty
         )
       )
     )

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/SpawnMachinesSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/SpawnMachinesSuite.scala
@@ -1607,8 +1607,8 @@ object SpawnMachinesSuite extends SimpleIOSuite {
         // Parent that spawns with an invalid UUID
         parentDefinition = StateMachineDefinition(
           states = Map(
-            StateId("init")    -> State(StateId("init")),
-            StateId("spawned") -> State(StateId("spawned"))
+            StateId("init")    -> State(StateId("init"), isFinal = false),
+            StateId("spawned") -> State(StateId("spawned"), isFinal = false)
           ),
           initialState = StateId("init"),
           transitions = List(
@@ -1649,7 +1649,8 @@ object SpawnMachinesSuite extends SimpleIOSuite {
                     )
                   )
                 )
-              )
+              ),
+              dependencies = Set.empty
             )
           )
         )
@@ -1713,8 +1714,8 @@ object SpawnMachinesSuite extends SimpleIOSuite {
         // Parent that spawns with childId as an integer instead of string
         parentDefinition = StateMachineDefinition(
           states = Map(
-            StateId("init")    -> State(StateId("init")),
-            StateId("spawned") -> State(StateId("spawned"))
+            StateId("init")    -> State(StateId("init"), isFinal = false),
+            StateId("spawned") -> State(StateId("spawned"), isFinal = false)
           ),
           initialState = StateId("init"),
           transitions = List(
@@ -1755,7 +1756,8 @@ object SpawnMachinesSuite extends SimpleIOSuite {
                     )
                   )
                 )
-              )
+              ),
+              dependencies = Set.empty
             )
           )
         )
@@ -1816,8 +1818,8 @@ object SpawnMachinesSuite extends SimpleIOSuite {
         // Parent that spawns with owners as a string instead of array
         parentDefinition = StateMachineDefinition(
           states = Map(
-            StateId("init")    -> State(StateId("init")),
-            StateId("spawned") -> State(StateId("spawned"))
+            StateId("init")    -> State(StateId("init"), isFinal = false),
+            StateId("spawned") -> State(StateId("spawned"), isFinal = false)
           ),
           initialState = StateId("init"),
           transitions = List(
@@ -1859,7 +1861,8 @@ object SpawnMachinesSuite extends SimpleIOSuite {
                     )
                   )
                 )
-              )
+              ),
+              dependencies = Set.empty
             )
           )
         )
@@ -1920,8 +1923,8 @@ object SpawnMachinesSuite extends SimpleIOSuite {
         // Parent that spawns with an invalid owner address
         parentDefinition = StateMachineDefinition(
           states = Map(
-            StateId("init")    -> State(StateId("init")),
-            StateId("spawned") -> State(StateId("spawned"))
+            StateId("init")    -> State(StateId("init"), isFinal = false),
+            StateId("spawned") -> State(StateId("spawned"), isFinal = false)
           ),
           initialState = StateId("init"),
           transitions = List(
@@ -1963,7 +1966,8 @@ object SpawnMachinesSuite extends SimpleIOSuite {
                     )
                   )
                 )
-              )
+              ),
+              dependencies = Set.empty
             )
           )
         )

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/StandardAppsConformanceSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/StandardAppsConformanceSuite.scala
@@ -6,7 +6,7 @@ import scala.collection.immutable.SortedMap
 
 import io.constellationnetwork.metagraph_sdk.json_logic._
 
-import xyz.kd5ujc.schema.registry.{FieldShape, MessageShape, SchemaShape}
+import xyz.kd5ujc.schema.registry.{FieldShape, MachineShape, MessageShape}
 import xyz.kd5ujc.shared_data.fiber.ConformanceChecker
 import xyz.kd5ujc.shared_data.lifecycle.validate.rules.RegistryRules
 
@@ -21,12 +21,12 @@ import weaver.SimpleIOSuite
  *
  * SCOPE: this is the on-chain MACHINERY check. The full integration — real FileDescriptorSet descriptors,
  * buf compatibility/evolution checks, the Bridge registration ceremony, and cross-version classification —
- * is the SDK lib's job (#34). Here we model each app's state message as the SchemaShape the Bridge would
+ * is the SDK lib's job (#34). Here we model each app's state message as the MachineShape the Bridge would
  * derive, and exercise it on-chain.
  */
 object StandardAppsConformanceSuite extends SimpleIOSuite {
 
-  // ── Faithful SchemaShape projections of the SDK app state messages ────────────────────────────
+  // ── Faithful MachineShape projections of the SDK app state messages ────────────────────────────
 
   // ottochain.apps.identity.v1.Identity
   val identity: MessageShape = MessageShape(
@@ -86,9 +86,9 @@ object StandardAppsConformanceSuite extends SimpleIOSuite {
     )
   )
 
-  private def shapeOf(state: MessageShape): SchemaShape = SchemaShape(state, SortedMap.empty)
+  private def shapeOf(state: MessageShape): MachineShape = MachineShape(state, SortedMap.empty)
 
-  test("every standard-app SchemaShape is well-formed (valid + unique proto field numbers, named)") {
+  test("every standard-app MachineShape is well-formed (valid + unique proto field numbers, named)") {
     for {
       i <- RegistryRules.L1.machineShapeWellFormed[IO](shapeOf(identity))
       g <- RegistryRules.L1.machineShapeWellFormed[IO](shapeOf(proposal))

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/StandardAppsConformanceSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/StandardAppsConformanceSuite.scala
@@ -90,9 +90,9 @@ object StandardAppsConformanceSuite extends SimpleIOSuite {
 
   test("every standard-app SchemaShape is well-formed (valid + unique proto field numbers, named)") {
     for {
-      i <- RegistryRules.L1.schemaShapeWellFormed[IO](shapeOf(identity))
-      g <- RegistryRules.L1.schemaShapeWellFormed[IO](shapeOf(proposal))
-      m <- RegistryRules.L1.schemaShapeWellFormed[IO](shapeOf(market))
+      i <- RegistryRules.L1.machineShapeWellFormed[IO](shapeOf(identity))
+      g <- RegistryRules.L1.machineShapeWellFormed[IO](shapeOf(proposal))
+      m <- RegistryRules.L1.machineShapeWellFormed[IO](shapeOf(market))
     } yield expect(i.isValid) and expect(g.isValid) and expect(m.isValid)
   }
 

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/StdManifestContractSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/StdManifestContractSuite.scala
@@ -5,7 +5,7 @@ import cats.effect.IO
 import scala.io.Source
 
 import xyz.kd5ujc.schema.GenesisManifest
-import xyz.kd5ujc.schema.registry.{RegistryName, RegistryTarget}
+import xyz.kd5ujc.schema.registry.{RegistryName, RegistryShape, RegistryTarget}
 import xyz.kd5ujc.shared_data.genesis.GenesisManifestLoader
 
 import io.circe.parser.decode
@@ -40,8 +40,12 @@ object StdManifestContractSuite extends SimpleIOSuite {
       genesis.calculated.registry.contains(name) && genesis.onChain.registryCommits.contains(name)
     }) and
     expect(genesis.calculated.registry.values.forall(_.target match {
-      case RegistryTarget.SchemaPackage(lineage) => lineage.head.exists(_.schemaShape.stateMessage.fields.nonEmpty)
-      case _                                     => false
+      case RegistryTarget.SchemaPackage(lineage) =>
+        lineage.head.exists(_.shape match {
+          case RegistryShape.Machine(ms) => ms.stateMessage.fields.nonEmpty
+          case _                         => false
+        })
+      case _ => false
     }))
   }
 }

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/ValidatorSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/ValidatorSuite.scala
@@ -27,7 +27,7 @@ object ValidatorSuite extends SimpleIOSuite {
     def minimalDefinition(): StateMachineDefinition = {
       val initial = StateId("initial")
       StateMachineDefinition(
-        states = Map(initial -> State(initial)),
+        states = Map(initial -> State(initial, isFinal = false)),
         initialState = initial,
         transitions = List.empty
       )
@@ -38,8 +38,8 @@ object ValidatorSuite extends SimpleIOSuite {
       val stateB = StateId("stateB")
       StateMachineDefinition(
         states = Map(
-          stateA -> State(stateA),
-          stateB -> State(stateB)
+          stateA -> State(stateA, isFinal = false),
+          stateB -> State(stateB, isFinal = false)
         ),
         initialState = stateA,
         transitions = List(
@@ -48,7 +48,8 @@ object ValidatorSuite extends SimpleIOSuite {
             to = stateB,
             eventName = "advance",
             guard = ConstExpression(BoolValue(true)),
-            effect = ConstExpression(MapValue(Map("moved" -> BoolValue(true))))
+            effect = ConstExpression(MapValue(Map("moved" -> BoolValue(true)))),
+            dependencies = Set.empty
           )
         )
       )
@@ -56,7 +57,7 @@ object ValidatorSuite extends SimpleIOSuite {
 
     def definitionWithStates(count: Int): StateMachineDefinition = {
       val states = (1 to count).map(i => StateId(s"state$i"))
-      val stateMap = states.map(s => s -> State(s)).toMap
+      val stateMap = states.map(s => s -> State(s, isFinal = false)).toMap
       StateMachineDefinition(
         states = stateMap,
         initialState = states.head,
@@ -69,7 +70,7 @@ object ValidatorSuite extends SimpleIOSuite {
       val maxPerState = 20
       val numStates = Math.max(2, (count / maxPerState) + 2)
       val states = (1 to numStates).map(i => StateId(s"state$i"))
-      val stateMap = states.map(s => s -> State(s)).toMap
+      val stateMap = states.map(s => s -> State(s, isFinal = false)).toMap
 
       val transitions = (1 to count).map { i =>
         val fromIdx = ((i - 1) / maxPerState) % (numStates - 1)
@@ -79,7 +80,8 @@ object ValidatorSuite extends SimpleIOSuite {
           to = states(toIdx),
           eventName = s"event$i",
           guard = ConstExpression(BoolValue(true)),
-          effect = ConstExpression(MapValue(Map.empty))
+          effect = ConstExpression(MapValue(Map.empty)),
+          dependencies = Set.empty
         )
       }.toList
 
@@ -99,11 +101,12 @@ object ValidatorSuite extends SimpleIOSuite {
           to = state2,
           eventName = s"event$i",
           guard = ConstExpression(BoolValue(true)),
-          effect = ConstExpression(MapValue(Map.empty))
+          effect = ConstExpression(MapValue(Map.empty)),
+          dependencies = Set.empty
         )
       }.toList
       StateMachineDefinition(
-        states = Map(state1 -> State(state1), state2 -> State(state2)),
+        states = Map(state1 -> State(state1, isFinal = false), state2 -> State(state2, isFinal = false)),
         initialState = state1,
         transitions = transitions
       )
@@ -119,7 +122,7 @@ object ValidatorSuite extends SimpleIOSuite {
     def invalidInitialStateDefinition(): StateMachineDefinition = {
       val existing = StateId("existing")
       StateMachineDefinition(
-        states = Map(existing -> State(existing)),
+        states = Map(existing -> State(existing, isFinal = false)),
         initialState = StateId("nonexistent"),
         transitions = List.empty
       )
@@ -128,7 +131,7 @@ object ValidatorSuite extends SimpleIOSuite {
     def invalidTransitionFromDefinition(): StateMachineDefinition = {
       val stateA = StateId("stateA")
       StateMachineDefinition(
-        states = Map(stateA -> State(stateA)),
+        states = Map(stateA -> State(stateA, isFinal = false)),
         initialState = stateA,
         transitions = List(
           Transition(
@@ -136,7 +139,8 @@ object ValidatorSuite extends SimpleIOSuite {
             to = stateA,
             eventName = "test",
             guard = ConstExpression(BoolValue(true)),
-            effect = ConstExpression(MapValue(Map.empty))
+            effect = ConstExpression(MapValue(Map.empty)),
+            dependencies = Set.empty
           )
         )
       )
@@ -145,7 +149,7 @@ object ValidatorSuite extends SimpleIOSuite {
     def invalidTransitionToDefinition(): StateMachineDefinition = {
       val stateA = StateId("stateA")
       StateMachineDefinition(
-        states = Map(stateA -> State(stateA)),
+        states = Map(stateA -> State(stateA, isFinal = false)),
         initialState = stateA,
         transitions = List(
           Transition(
@@ -153,7 +157,8 @@ object ValidatorSuite extends SimpleIOSuite {
             to = StateId("nonexistent"),
             eventName = "test",
             guard = ConstExpression(BoolValue(true)),
-            effect = ConstExpression(MapValue(Map.empty))
+            effect = ConstExpression(MapValue(Map.empty)),
+            dependencies = Set.empty
           )
         )
       )
@@ -167,10 +172,11 @@ object ValidatorSuite extends SimpleIOSuite {
         to = stateB,
         eventName = "test",
         guard = ConstExpression(BoolValue(true)),
-        effect = ConstExpression(MapValue(Map.empty))
+        effect = ConstExpression(MapValue(Map.empty)),
+        dependencies = Set.empty
       )
       StateMachineDefinition(
-        states = Map(stateA -> State(stateA), stateB -> State(stateB)),
+        states = Map(stateA -> State(stateA, isFinal = false), stateB -> State(stateB, isFinal = false)),
         initialState = stateA,
         transitions = List(transition, transition)
       )
@@ -182,9 +188,9 @@ object ValidatorSuite extends SimpleIOSuite {
       val stateC = StateId("stateC")
       StateMachineDefinition(
         states = Map(
-          stateA -> State(stateA),
-          stateB -> State(stateB),
-          stateC -> State(stateC)
+          stateA -> State(stateA, isFinal = false),
+          stateB -> State(stateB, isFinal = false),
+          stateC -> State(stateC, isFinal = false)
         ),
         initialState = stateA,
         transitions = List(
@@ -193,14 +199,16 @@ object ValidatorSuite extends SimpleIOSuite {
             to = stateB,
             eventName = "test",
             guard = ConstExpression(BoolValue(true)),
-            effect = ConstExpression(MapValue(Map.empty))
+            effect = ConstExpression(MapValue(Map.empty)),
+            dependencies = Set.empty
           ),
           Transition(
             from = stateA,
             to = stateC,
             eventName = "test",
             guard = ConstExpression(BoolValue(true)),
-            effect = ConstExpression(MapValue(Map.empty))
+            effect = ConstExpression(MapValue(Map.empty)),
+            dependencies = Set.empty
           )
         )
       )
@@ -215,8 +223,8 @@ object ValidatorSuite extends SimpleIOSuite {
       val stateB = StateId("stateB")
       StateMachineDefinition(
         states = Map(
-          stateA -> State(stateA),
-          stateB -> State(stateB)
+          stateA -> State(stateA, isFinal = false),
+          stateB -> State(stateB, isFinal = false)
         ),
         initialState = stateA,
         transitions = List(
@@ -232,7 +240,8 @@ object ValidatorSuite extends SimpleIOSuite {
                 ConstExpression(IntValue(2))
               )
             ),
-            effect = ConstExpression(MapValue(Map.empty))
+            effect = ConstExpression(MapValue(Map.empty)),
+            dependencies = Set.empty
           )
         )
       )
@@ -244,8 +253,8 @@ object ValidatorSuite extends SimpleIOSuite {
       val stateB = StateId("stateB")
       StateMachineDefinition(
         states = Map(
-          stateA -> State(stateA),
-          stateB -> State(stateB)
+          stateA -> State(stateA, isFinal = false),
+          stateB -> State(stateB, isFinal = false)
         ),
         initialState = stateA,
         transitions = List(
@@ -255,7 +264,8 @@ object ValidatorSuite extends SimpleIOSuite {
             eventName = "test",
             guard = ConstExpression(BoolValue(true)),
             // Using "merge" as a field name - this collides with the merge operator
-            effect = MapExpression(Map("merge" -> VarExpression(Left("data"))))
+            effect = MapExpression(Map("merge" -> VarExpression(Left("data")))),
+            dependencies = Set.empty
           )
         )
       )


### PR DESCRIPTION
## Summary

- **Versionable script fibers**: `PublishScriptVersion`, `UpgradeScript`, `ScriptShape` ADT (`MethodDispatch`), and `ScriptCombiner.upgradeScript` bring scripts to full parity with state machines — same monotonic re-bind, metered migration, verified `logicHash` check
- **Machine/script symmetry**: `PublishVersion` → `PublishMachineVersion`, `schemaShape` → `machineShape`, `RegistryShape` ADT (`Machine` | `Script`), symmetric validator and combiner method names
- **Signing invariant fixes**: `State.isFinal`, `Transition.dependencies`, `RegisteredVersion.strict` had non-`Option` defaults — silently produced `InvalidSignature` when clients omitted them; all three promoted to required fields (220+ call sites updated)
- **TOCTOU block-poisoning fix**: `FiberValidator.L0.upgrade` and `createFiber` were reading `CalculatedState.registry` lineage inside `validateSignedUpdate` — a race on concurrent publish/yank returns `Invalid` and drops the entire block; removed, registry lineage is now combiner-only
- **CLAUDE.md rule 3**: codifies the TOCTOU gate for future reviewers

## Test plan

- [ ] `sbt sharedData/test` — 344/344 passing
- [ ] `PublishVersionSigningCanonicalSuite` — covers `PublishMachineVersion`, `PublishScriptVersion`, `UpgradeScript` canonical round-trips (no injected defaults)
- [ ] `RegistryCodecSuite` — covers `RegistryShape.Script` / `ScriptShape.MethodDispatch` JSON round-trips
- [ ] `RegistryCombinerSuite` — updated 3 tests to reflect combiner-only registry gate (validator structural-only, combiner is the authoritative rejection point)
- [ ] e2e harness updated: `publishVersion.ts` + `runner.ts` + `example.ts` emit `PublishMachineVersion` / `machineShape` wire keys

## Notable decisions

- `ScriptShape` is a sealed trait with a single `MethodDispatch` variant (the only form observed in practice); wire format unchanged from prior case class (`{"methods":{...}}`)
- Registry lineage checks (`refResolvesAndMatches`) intentionally absent from `validateSignedUpdate` — they belong only in the combiner per the TOCTOU invariant documented in CLAUDE.md
- `State.isFinal`/`Transition.dependencies`/`RegisteredVersion.strict` are now required (no default), not `Option[T]` — both satisfy the signing invariant; required is cleaner when the intent is always-provide

🤖 Generated with [Claude Code](https://claude.com/claude-code)