### PR TITLE
refactor: migrate oracle terminology to script (api, engine, docs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CI](https://github.com/scasplte2/ottochain/actions/workflows/ci.yml/badge.svg)](https://github.com/scasplte2/ottochain/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/scasplte2/ottochain/branch/main/graph/badge.svg)](https://codecov.io/gh/scasplte2/ottochain)
 
-A metagraph on [Constellation Network](https://constellationnetwork.io/) for creating automated workflow contracts using JSON-encoded state machines and script oracles.
+A metagraph on [Constellation Network](https://constellationnetwork.io/) for creating automated workflow contracts using JSON-encoded state machines and scripts.
 
 **[📖 Read the Introduction →](docs/introduction.md)**
 
@@ -16,13 +16,13 @@ graph LR
     A["📋 JSON Definition"] -->|deploy| B["🔗 On-Chain Fiber"]
     B -->|events| C["⚙️ Guard → Effect → Transition"]
     C -->|triggers| D["📋 Other Fibers"]
-    C -->|oracle calls| E["🔮 Script Oracles"]
+    C -->|script calls| E["🔮 Scripts"]
 ```
 
 ### Key Capabilities
 
 - **JSON-Encoded State Machines** — Define workflows as states, transitions, guards, and effects in JSON
-- **Script Oracles** — Stateful computation units callable by state machines
+- **Scripts** — Stateful computation units callable by state machines
 - **Cross-Machine Triggers** — One machine's transition fires events on other machines
 - **Parent-Child Spawning** — Dynamically create child machines at runtime
 - **Broadcast Triggers** — Fan out events to many machines simultaneously
@@ -33,7 +33,7 @@ graph LR
 
 | Example | Machines | What It Demonstrates |
 |---------|----------|---------------------|
-| [Tic-Tac-Toe](docs/examples/tictactoe.md) | 1 + oracle | Oracle-centric architecture pattern |
+| [Tic-Tac-Toe](docs/examples/tictactoe.md) | 1 + script | Script-centric architecture pattern |
 | [Fuel Logistics](docs/examples/fuel-logistics.md) | 4 | Cross-machine triggers, GPS tracking |
 | [Clinical Trial](docs/examples/clinical-trial.md) | 6 | Multiple guards, bi-directional transitions |
 | [Real Estate](docs/examples/real-estate.md) | 8 | Self-transitions, lifecycle management |
@@ -54,7 +54,7 @@ OttoChain runs three layers on each node, built on Constellation's Tessellation 
 
 | Layer | Port | Purpose |
 |-------|------|---------|
-| Data L1 | 9300 | Fiber processing — events, oracle calls, validation |
+| Data L1 | 9300 | Fiber processing — events, script calls, validation |
 | Currency L1 | 9200 | Token transfers and balances |
 | Metagraph L0 | 9100 | Consensus, snapshots, state management |
 
@@ -64,7 +64,7 @@ See [Architecture Details](docs/reference/architecture.md) for the full technica
 
 - **Scala 2.13** with cats-effect, fs2, circe
 - **Tessellation** metagraph SDK
-- **JSON Logic** with OttoChain extensions (_oracleCall, _trigger, _spawn, _emit)
+- **JSON Logic** with OttoChain extensions (_scriptCall, _trigger, _spawn, _emit)
 - **sbt** multi-module build
 
 ## License

--- a/docs/API-REFERENCE.md
+++ b/docs/API-REFERENCE.md
@@ -210,14 +210,14 @@ All custom routes are prefixed with `/v1/`.
 | `GET` | `/v1/state-machines/{fiberId}` | Get specific state machine by UUID |
 | `GET` | `/v1/state-machines/{fiberId}/events` | Event receipts for a fiber |
 
-#### Oracles (Scripts)
+#### Scripts
 
 | Method | Path | Description |
 |--------|------|-------------|
-| `GET` | `/v1/oracles` | List all script oracles |
-| `GET` | `/v1/oracles?status={status}` | Filter by status |
-| `GET` | `/v1/oracles/{oracleId}` | Get specific oracle by UUID |
-| `GET` | `/v1/oracles/{oracleId}/invocations` | Invocation history for oracle |
+| `GET` | `/v1/scripts` | List all scripts |
+| `GET` | `/v1/scripts?status={status}` | Filter by status |
+| `GET` | `/v1/scripts/{scriptId}` | Get specific script by UUID |
+| `GET` | `/v1/scripts/{scriptId}/invocations` | Invocation history for script |
 
 #### State
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,7 +12,7 @@ Step-by-step guides for using OttoChain:
 | Guide | Description |
 |-------|-------------|
 | [State Machine Design](guides/state-machine-design.md) | How to design and write JSON-encoded state machines |
-| [Terminal Usage](guides/terminal-usage.md) | Interactive CLI for testing state machines and oracles |
+| [Terminal Usage](guides/terminal-usage.md) | Interactive CLI for testing state machines and scripts |
 | [Deployment](guides/deployment.md) | Deploy an OttoChain metagraph to Digital Ocean |
 
 ## 💡 Examples
@@ -21,7 +21,7 @@ Real-world examples demonstrating state machine capabilities, from simple to com
 
 | Example | Complexity | Key Patterns |
 |---------|-----------|--------------|
-| [Tic-Tac-Toe](examples/tictactoe.md) | ⭐ | Oracle-centric architecture, self-transitions |
+| [Tic-Tac-Toe](examples/tictactoe.md) | ⭐ | Script-centric architecture, self-transitions |
 | [Fuel Logistics](examples/fuel-logistics.md) | ⭐⭐ | Cross-machine triggers, GPS tracking |
 | [Clinical Trial](examples/clinical-trial.md) | ⭐⭐⭐ | Multiple guards, bi-directional transitions |
 | [Real Estate](examples/real-estate.md) | ⭐⭐⭐ | Self-transitions, lifecycle management |

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -183,9 +183,9 @@ Raw Materials → Manufacturer → Retailer → Consumer
 **Participants**: 2
 **Total States**: 4
 
-A two-player game demonstrating the **oracle-centric architecture** pattern where the script acts as the game engine and the state machine orchestrates the game lifecycle.
+A two-player game demonstrating the **script-centric architecture** pattern where the script acts as the game engine and the state machine orchestrates the game lifecycle.
 
-#### Architecture: Oracle-Centric Pattern
+#### Architecture: Script-Centric Pattern
 
 **Script** (Game Engine):
 - Holds complete game state (board, moves, players)
@@ -196,12 +196,12 @@ A two-player game demonstrating the **oracle-centric architecture** pattern wher
 
 **State Machine** (Lifecycle Orchestrator):
 - Manages game phases: setup → playing → finished/cancelled
-- Calls oracle methods via `_oracleCall`
-- Guards check oracle state for transitions
+- Calls script methods via `_scriptCall`
+- Guards check script state for transitions
 - Self-transitions during gameplay
-- Minimal state - delegates game logic to oracle
+- Minimal state - delegates game logic to script
 
-This separation demonstrates a key architectural pattern: **oracle holds state and logic, state machine orchestrates lifecycle**.
+This separation demonstrates a key architectural pattern: **script holds state and logic, state machine orchestrates lifecycle**.
 
 #### State Machine States
 
@@ -213,12 +213,12 @@ This separation demonstrates a key architectural pattern: **oracle holds state a
 
 #### Key Features
 
-- **Oracle-Centric Pattern** - Oracle is the single source of truth for game state
-- **Oracle Method Dispatch** - Single script with 6 methods handling all game logic
-- **Validation in Oracle** - Move validation happens in oracle, not state machine
+- **Script-Centric Pattern** - Script is the single source of truth for game state
+- **Script Method Dispatch** - Single script with 6 methods handling all game logic
+- **Validation in Script** - Move validation happens in script, not state machine
 - **Self-Transitions** - State machine stays in `playing` during move sequences
-- **Multiple Guards** - Same event (`make_move`) transitions to different states based on oracle status
-- **Win Detection** - Oracle checks all 8 winning patterns deterministically
+- **Multiple Guards** - Same event (`make_move`) transitions to different states based on script status
+- **Win Detection** - Script checks all 8 winning patterns deterministically
 - **Reset Support** - Clear board for new round without recreating machines
 - **Structured Outputs** - Emit `game_completed` output on finish
 
@@ -229,8 +229,8 @@ setup → playing (self-transitions) → finished/cancelled
          │  ↑
          │  └── make_move events ───────┘
          │
-         └──→ _oracleCall(makeMove)
-              - Oracle validates move
+         └──→ _scriptCall(makeMove)
+              - Script validates move
               - Updates board state
               - Checks win/draw
               - Returns result
@@ -238,11 +238,11 @@ setup → playing (self-transitions) → finished/cancelled
 
 #### Why Start Here?
 
-- **Foundational pattern** - Oracle-centric architecture scales to complex logic
+- **Foundational pattern** - Script-centric architecture scales to complex logic
 - **Familiar domain** - Everyone understands tic-tac-toe rules
 - **Clean separation** - State vs. lifecycle management clearly delineated
-- **Core concepts** - Oracle calls, guards, self-transitions, validation patterns
-- **Complete example** - Shows oracle creation, invocation, and state updates
+- **Core concepts** - Script calls, guards, self-transitions, validation patterns
+- **Complete example** - Shows script creation, invocation, and state updates
 - **Well tested** - Full test suite demonstrating all scenarios
 
 **[View Detailed Documentation →](./tictactoe.md)**

--- a/docs/examples/tictactoe.md
+++ b/docs/examples/tictactoe.md
@@ -1,13 +1,13 @@
 # Tic-Tac-Toe Game
 
-Complete tic-tac-toe implementation using OttoChain script + state machine, demonstrating the **oracle-centric architecture** pattern.
+Complete tic-tac-toe implementation using OttoChain script + state machine, demonstrating the **script-centric architecture** pattern.
 
 ## Table of Contents
 
 1. [Overview](#overview)
 2. [Key Features Demonstrated](#key-features-demonstrated)
 3. [Architecture](#architecture)
-4. [Script Design](#script-oracle-design)
+4. [Script Design](#script-design)
 5. [State Machine Design](#state-machine-design)
 6. [Test Location](#test-location)
 7. [Cell Numbering](#cell-numbering)
@@ -20,20 +20,20 @@ Complete tic-tac-toe implementation using OttoChain script + state machine, demo
 
 ![Tic-Tac-Toe Sequence Diagram](../../diagrams/tictactoe-sequence.png)
 
-This example demonstrates the **oracle-centric architecture** where:
+This example demonstrates the **script-centric architecture** where:
 - **Script** = Game engine (holds board, enforces rules, detects wins)
 - **State Machine** = Lifecycle orchestrator (setup → playing → finished/cancelled)
 
 The game provides a simple but complete example of:
 - Stateful scripts maintaining game state
-- State machines calling oracle methods via `_oracleCall`
-- Guards checking oracle state for transitions
+- State machines calling script methods via `_scriptCall`
+- Guards checking script state for transitions
 - Self-transitions for ongoing gameplay
 - Multiple final states (finished vs cancelled)
 
-### Why Oracle Holds State?
+### Why Script Holds State?
 
-- ✅ **Deterministic rules**: Oracle enforces valid moves, win detection
+- ✅ **Deterministic rules**: Script enforces valid moves, win detection
 - ✅ **Single source of truth**: Board state in one place
 - ✅ **Atomic operations**: makeMove updates board + checks winner in one call
 - ✅ **Simple state machine**: Just lifecycle, no game logic
@@ -44,13 +44,13 @@ The game provides a simple but complete example of:
 
 | Feature | Description |
 |---------|-------------|
-| **Script Pattern** | Oracle holds all game state (board, players, history) |
-| **Oracle Method Dispatch** | Single script with 6 methods: initialize, makeMove, checkWinner, getBoard, resetGame, cancelGame |
-| **Validation Logic** | Oracle validates moves (turn, cell bounds, occupied check) |
+| **Script Pattern** | Script holds all game state (board, players, history) |
+| **Script Method Dispatch** | Single script with 6 methods: initialize, makeMove, checkWinner, getBoard, resetGame, cancelGame |
+| **Validation Logic** | Script validates moves (turn, cell bounds, occupied check) |
 | **Win Detection** | Deterministic check of all 8 winning patterns |
 | **Self-Transitions** | State machine stays in `playing` during moves |
-| **Multiple Guards** | Same event type (make_move) transitions to different states based on oracle status |
-| **Reset Support** | Clear board without recreating oracle/machine |
+| **Multiple Guards** | Same event type (make_move) transitions to different states based on script status |
+| **Reset Support** | Clear board without recreating script/machine |
 | **Structured Outputs** | Emit `game_completed` output on win/draw |
 
 ---
@@ -66,7 +66,7 @@ The game provides a simple but complete example of:
 │          ↓   ↑           │
 │      finished/cancelled  │
 └──────────┬───────────────┘
-           │ _oracleCall
+           │ _scriptCall
            ▼
 ┌──────────────────────────┐
 │   Script          │
@@ -109,7 +109,7 @@ The game provides a simple but complete example of:
 
 ## Script Design
 
-### Oracle State Structure
+### Script State Structure
 
 ```json
 {
@@ -131,7 +131,7 @@ The game provides a simple but complete example of:
 }
 ```
 
-### Oracle Methods
+### Script Methods
 
 #### 1. `initialize(playerX, playerO, gameId)`
 Sets up new game with two players.
@@ -176,7 +176,7 @@ Validates and applies move, checks for win/draw.
   }
 }
 ```
-Note: Returns `_result` only (no `_state`), so oracle state unchanged.
+Note: Returns `_result` only (no `_state`), so script state unchanged.
 
 #### 3. `checkWinner()`
 Returns current game status and winner (read-only).
@@ -217,13 +217,13 @@ Rows:        Columns:     Diagonals:
 
 ### Design Philosophy
 
-**Lifecycle Orchestrator**: The state machine manages setup → playing → finished/cancelled transitions, while the oracle enforces game rules.
+**Lifecycle Orchestrator**: The state machine manages setup → playing → finished/cancelled transitions, while the script enforces game rules.
 
 **Why State Machine is Minimal:**
-- ✅ Oracle holds game state (board, moves, winner)
+- ✅ Script holds game state (board, moves, winner)
 - ✅ State machine only tracks lifecycle phase
-- ✅ Guards check oracle state for transitions
-- ✅ Effects invoke oracle methods via `_oracleCall`
+- ✅ Guards check script state for transitions
+- ✅ Effects invoke script methods via `_scriptCall`
 
 ### State Definitions
 
@@ -233,7 +233,7 @@ Rows:        Columns:     Diagonals:
 
 #### `playing`
 - Game is active, moves being made
-- References oracle for querying game state
+- References script for querying game state
 - **Next States**: `playing` (self), `finished`, `cancelled`
 - **Special**: Self-transitions on both `make_move` and `reset_board`
 
@@ -263,7 +263,7 @@ Rows:        Columns:     Diagonals:
 }
 ```
 
-**Effect:** Calls oracle `initialize` method with player info.
+**Effect:** Calls script `initialize` method with player info.
 
 #### 2. `playing → playing` on `make_move` (game continues)
 
@@ -278,18 +278,18 @@ Rows:        Columns:     Diagonals:
 }
 ```
 
-**Guard:** Oracle status is "InProgress"
+**Guard:** Script status is "InProgress"
 
-**Effect:** Calls oracle `makeMove` method, stays in `playing` state.
+**Effect:** Calls script `makeMove` method, stays in `playing` state.
 
 #### 3. `playing → finished` on `make_move` (win/draw)
 
 **Same Event Type** as transition #2, but different guard!
 
-**Guard:** Oracle status is "Won" OR "Draw"
+**Guard:** Script status is "Won" OR "Draw"
 
 **Effect:**
-- Captures final status, winner, and board from oracle state
+- Captures final status, winner, and board from script state
 - Emits structured output:
 ```json
 {
@@ -306,20 +306,20 @@ Rows:        Columns:     Diagonals:
 
 #### 4. `playing → playing` on `reset_board`
 
-**Guard:** Oracle status is "Won" OR "Draw"
+**Guard:** Script status is "Won" OR "Draw"
 
 **Effect:**
 - Increments state machine's `roundCount`
-- Calls oracle `resetGame` method
+- Calls script `resetGame` method
 - Stays in `playing` state for new round
 
 #### 5. `playing → cancelled` on `cancel_game`
 
-**Effect:** Calls oracle `cancelGame` method with reason.
+**Effect:** Calls script `cancelGame` method with reason.
 
 ### Dependencies
 
-Every transition that reads oracle state must include the oracle CID in its `dependencies` array:
+Every transition that reads script state must include the script CID in its `dependencies` array:
 
 ```json
 {
@@ -330,7 +330,7 @@ Every transition that reads oracle state must include the oracle CID in its `dep
 }
 ```
 
-This ensures the DeterministicEventProcessor loads oracle state before evaluating guards/effects.
+This ensures the DeterministicEventProcessor loads script state before evaluating guards/effects.
 
 ---
 
@@ -353,9 +353,9 @@ The tic-tac-toe example is fully implemented and tested in the Scala test suite:
 4. **Reset and play another round**: Complete game, reset board, play again
 
 The test suite demonstrates:
-- Creating oracle and state machine
+- Creating script and state machine
 - Starting game and making moves
-- Oracle state updates and win detection
+- Script state updates and win detection
 - Invalid move handling (event fails, state unchanged)
 - Multi-round gameplay with reset
 
@@ -383,7 +383,7 @@ Possible extensions to explore:
 - **Undo move**: Add `undoLastMove()` method using moveHistory
 - **Timed moves**: Add turn time limits with auto-forfeit
 - **Tournament mode**: Chain multiple games with bracket progression
-- **AI opponent**: Oracle method for computer player move selection
+- **AI opponent**: Script method for computer player move selection
 
 ---
 

--- a/docs/fiber-engine/README.md
+++ b/docs/fiber-engine/README.md
@@ -1,6 +1,6 @@
 # JLVM Fiber Engine
 
-The fiber engine orchestrates deterministic execution of state machines and oracles on the metagraph. This document covers the internal architecture for engine maintainers.
+The fiber engine orchestrates deterministic execution of state machines and scripts on the metagraph. This document covers the internal architecture for engine maintainers.
 
 ## Table of Contents
 
@@ -61,7 +61,7 @@ A fiber is an independently addressable execution unit. Two types exist:
 | Type | Record | Input | Purpose |
 |------|--------|-------|---------|
 | State Machine | `StateMachineFiberRecord` | `Transition` | Guarded state transitions with effects |
-| Oracle | `ScriptFiberRecord` | `MethodCall` | Stateless computations with access control |
+| Script | `ScriptFiberRecord` | `MethodCall` | Stateless computations with access control |
 
 ### FiberInput
 
@@ -102,7 +102,7 @@ Result of a complete transaction (including cascades):
 sealed trait TransactionOutcome
 case class Committed(
   updatedStateMachines: Map[UUID, Records.StateMachineFiberRecord],
-  updatedOracles: Map[UUID, Records.ScriptFiberRecord],
+  updatedScripts: Map[UUID, Records.ScriptFiberRecord],
   statuses: List[(UUID, Records.EventProcessingStatus)],
   totalGasUsed: Long,
   maxDepth: Int = 0,
@@ -161,9 +161,9 @@ Evaluates a single fiber without cascading. Dispatches based on fiber/input comb
 | Fiber Type | Input Type | Action |
 |------------|------------|--------|
 | StateMachine | Transition | Guard evaluation → Effect execution |
-| Oracle | MethodCall | Access control → Script evaluation |
+| Script | MethodCall | Access control → Script evaluation |
 | StateMachine | MethodCall | Error: invalid combination |
-| Oracle | Transition | Error: invalid combination |
+| Script | Transition | Error: invalid combination |
 
 **State Machine Evaluation:**
 1. Validate event against limits
@@ -173,7 +173,7 @@ Evaluates a single fiber without cascading. Dispatches based on fiber/input comb
 5. Extract triggers, spawns, outputs from effect result
 6. Merge effect into current state
 
-**Oracle Evaluation:**
+**Script Evaluation:**
 1. Validate caller against access control policy
 2. Build input data: `{ _method, _args, _state }`
 3. Evaluate script program
@@ -198,9 +198,9 @@ def processStateMachineTrigger(
 ): FiberT[F, Either[FailureReason, TriggerResult]]
 ```
 
-**Trigger processing for oracles:**
+**Trigger processing for scripts:**
 - Converts `Transition` input to `MethodCall` with caller address from source fiber
-- Increments depth (prevents unbounded oracle chains)
+- Increments depth (prevents unbounded script chains)
 
 **Target not found:**
 - Returns `TriggerTargetNotFound` failure
@@ -344,7 +344,7 @@ sealed trait FailureReason
 // Transition failures
 case class NoTransitionFound(fromState, eventType)
 case class NoGuardMatched(fromState, eventType, attemptedGuards)
-case class EvaluationError(phase, message)  // phase: Guard | Effect | Oracle
+case class EvaluationError(phase, message)  // phase: Guard | Effect | Script
 
 // Execution limit failures
 case class CycleDetected(fiberId, eventType)
@@ -360,9 +360,9 @@ case class TriggerTargetNotFound(targetFiberId, sourceFiberId)
 // Spawn failures
 case class SpawnValidationFailed(parentId, errors: List[String])
 
-// Oracle failures
-case class OracleInvocationFailed(oracleId, method, errorMsg)
-case class CallerResolutionFailed(oracleId, sourceId)
+// Script failures
+case class ScriptInvocationFailed(scriptId, method, errorMsg)
+case class CallerResolutionFailed(scriptId, sourceId)
 case class AccessDenied(caller, resourceId, policyType, details)
 case class MissingProof(fiberId, operation)
 
@@ -374,7 +374,7 @@ sealed trait GasExhaustionPhase
 object GasExhaustionPhase {
   case object Guard   // During guard evaluation
   case object Effect  // During effect evaluation
-  case object Oracle  // During oracle script evaluation
+  case object Script  // During script evaluation
   case object Trigger // During trigger dispatch
   case object Spawn   // During spawn processing
 }
@@ -445,17 +445,17 @@ Available via `var` expressions in guards/effects:
 | `machines` | `Map` | Dependent machine states |
 | `parent` | `MapValue?` | Parent fiber state (if exists) |
 | `children` | `Map` | Child fiber states |
-| `scripts` | `Map` | Available oracle states |
+| `scripts` | `Map` | Available script states |
 
-### Context Input Keys (Oracle)
+### Context Input Keys (Script)
 
-Available via `var` expressions in oracle scripts:
+Available via `var` expressions in scripts:
 
 | Key | Type | Description |
 |-----|------|-------------|
 | `method` | `String` | Method being invoked |
 | `args` | `JsonLogicValue` | Method arguments |
-| `state` | `JsonLogicValue?` | Current oracle state (if exists) |
+| `state` | `JsonLogicValue?` | Current script state (if exists) |
 
 ### Output Side-Effect Keys (State Machine)
 
@@ -464,17 +464,17 @@ Extracted from effect results, not merged into state:
 | Key | Type | Purpose |
 |-----|------|---------|
 | `_triggers` | `Array[TriggerSpec]` | Trigger events on other fibers |
-| `_oracleCall` | `OracleCallSpec` | Invoke an oracle |
+| `_scriptCall` | `ScriptCallSpec` | Invoke a script |
 | `_spawn` | `Array[SpawnSpec]` | Spawn child state machines |
 | `_outputs` | `Array[OutputSpec]` | Emit output values |
 
-### Output Return Convention Keys (Oracle)
+### Output Return Convention Keys (Script)
 
-Oracle scripts return results using these keys:
+Scripts return results using these keys:
 
 | Key | Type | Purpose |
 |-----|------|---------|
-| `_state` | `JsonLogicValue?` | New oracle state (optional) |
+| `_state` | `JsonLogicValue?` | New script state (optional) |
 | `_result` | `JsonLogicValue` | Return value to caller |
 
 If neither `_state` nor `_result` is present, the entire output is used as both.
@@ -489,11 +489,11 @@ If neither `_state` nor `_result` is present, the entire output is used as both.
 }
 ```
 
-### OracleCallSpec
+### ScriptCallSpec
 
 ```json
 {
-  "oracleId": "uuid-string",
+  "scriptId": "uuid-string",
   "method": "method_name",
   "args": { /* any JsonLogicValue */ }
 }
@@ -574,7 +574,7 @@ modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/
 │       ├── ExpressionParser.scala    # Expression parsing utilities
 │       ├── FiberEvaluator.scala      # Single fiber evaluation
 │       ├── FiberOrchestrator.scala   # Transaction coordinator
-│       ├── OracleProcessor.scala     # Oracle CRUD helpers
+│       ├── ScriptProcessor.scala     # Script CRUD helpers
 │       ├── SpawnProcessor.scala      # Child fiber creation
 │       ├── StateMerger.scala         # State composition
 │       ├── TriggerDispatcher.scala   # Cascade processing

--- a/docs/guides/adding-new-app.md
+++ b/docs/guides/adding-new-app.md
@@ -583,7 +583,7 @@ pnpm update @ottochain/sdk --force
 |----------|-------------------------------|--------------------------|----------------------------------|
 | Contract | `src/apps/contracts/`          | `routes/contract.ts`      | PROPOSED → ACTIVE → COMPLETED    |
 | Market   | `src/apps/markets/`            | `routes/market.ts`        | PROPOSED → OPEN → SETTLED        |
-| Oracle   | `src/apps/oracles/`            | `routes/oracle.ts`        | REGISTERED → ACTIVE → FINALIZED  |
+| Script   | `src/apps/scripts/`            | `routes/script.ts`        | REGISTERED → ACTIVE → FINALIZED  |
 | Agent    | `src/apps/identity/`           | `routes/agent.ts`         | REGISTERED → ACTIVE              |
 | DAO      | `src/apps/governance/`         | `routes/governance.ts`    | PROPOSED → ACTIVE → DISSOLVED    |
 | Corporate| `src/apps/corporate/`          | `routes/corporate.ts`     | FORMATION → ACTIVE → DISSOLVED   |

--- a/docs/guides/json-logic-primer.md
+++ b/docs/guides/json-logic-primer.md
@@ -192,28 +192,28 @@ Use dot-notation paths:
 {"var": "scripts.11111111-1111-1111-1111-111111111111.state.board"}
 ```
 
-### Oracle Context (for Script fibers)
+### Script Context (for Script fibers)
 
-Script oracles receive a different context:
+Scripts receive a different context:
 
 | Key | Type | Description |
 |-----|------|-------------|
 | `_method` | String | Method name being called |
 | `_args` | Object | Method arguments |
-| `_state` | Object/null | Current oracle state |
+| `_state` | Object/null | Current script state |
 
 ## OttoChain Extensions (Reserved Keys)
 
 Effect results can include special keys (prefixed with `_`) that trigger side effects. These are extracted by the engine and **not** merged into state.
 
-### `_oracleCall` — Invoke a Script
+### `_scriptCall` — Invoke a Script
 
 Calls a method on a script fiber:
 
 ```json
 "effect": {
-  "_oracleCall": {
-    "cid": {"var": "state.oracleCid"},
+  "_scriptCall": {
+    "cid": {"var": "state.scriptCid"},
     "method": "makeMove",
     "args": {
       "player": {"var": "event.player"},
@@ -228,11 +228,11 @@ Calls a method on a script fiber:
 ```
 
 Fields:
-- `cid` — UUID of the target oracle (can be a `var` reference)
+- `cid` — UUID of the target script (can be a `var` reference)
 - `method` — Method name string
 - `args` — Arguments object (values are evaluated as expressions)
 
-The oracle processes the call and its return value can influence subsequent evaluation.
+The script processes the call and its return value can influence subsequent evaluation.
 
 ### `_triggers` — Cross-Machine Events
 
@@ -338,7 +338,7 @@ Check that multiple fields exist:
 }
 ```
 
-### Check Dependent Oracle State
+### Check Dependent Script State
 
 Read state from a script via the `scripts` context:
 
@@ -400,14 +400,14 @@ Use `if` within an effect to compute values conditionally:
 }
 ```
 
-### Combined: Oracle Call + State Update + Emit
+### Combined: Script Call + State Update + Emit
 
 A real-world effect combining multiple side effects with state changes:
 
 ```json
 "effect": {
-  "_oracleCall": {
-    "cid": {"var": "state.oracleCid"},
+  "_scriptCall": {
+    "cid": {"var": "state.scriptCid"},
     "method": "makeMove",
     "args": {
       "player": {"var": "event.player"},
@@ -431,7 +431,7 @@ A real-world effect combining multiple side effects with state changes:
 
 The engine processes this by:
 1. Evaluating the entire expression against the context
-2. Extracting `_oracleCall` → invokes the oracle
+2. Extracting `_scriptCall` → invokes the script
 3. Extracting `_emit` → queues emitted events
 4. Remaining keys (`finalStatus`, `winner`, `finalBoard`) → become new state
 
@@ -441,7 +441,7 @@ All JSON Logic evaluation in OttoChain is gas-metered. Each operation (compariso
 
 Gas is configured at two levels:
 - **JLVM Gas** — Per-expression evaluation costs
-- **Fiber Gas** — Per-orchestration operation costs (triggers, spawns, oracle calls)
+- **Fiber Gas** — Per-orchestration operation costs (triggers, spawns, script calls)
 
 ## Further Reading
 

--- a/docs/guides/state-machine-design.md
+++ b/docs/guides/state-machine-design.md
@@ -37,7 +37,7 @@ When your guards and effects execute, they have access to a context object with 
   },
   "parent": {...},            // Parent machine context (if any)
   "children": {...},          // Child machines (if any)
-  "scripts": {...}      // Dependent oracles (if any)
+  "scripts": {...}      // Dependent scripts (if any)
 }
 ```
 
@@ -302,7 +302,7 @@ Effects can include special keys for side effects:
 }
 ```
 
-**Call oracles:**
+**Call scripts:**
 ```json
 {
   "effect": {
@@ -310,8 +310,8 @@ Effects can include special keys for side effects:
       { "var": "state" },
       { "calculationRequested": true }
     ],
-    "_oracleCall": {
-      "cid": "oracle-uuid",
+    "_scriptCall": {
+      "cid": "script-uuid",
       "method": "calculate",
       "args": { "value": { "var": "state.amount" } }
     }

--- a/docs/guides/terminal-usage.md
+++ b/docs/guides/terminal-usage.md
@@ -9,7 +9,7 @@ Interactive CLI for testing Ottochain state machines and scripts. This terminal 
 - [Quick Start](#quick-start)
 - [Commands](#commands)
   - [State Machine Commands](#state-machine-commands)
-  - [Oracle Commands](#oracle-commands)
+  - [Script Commands](#script-commands)
   - [Helper Commands](#helper-commands)
 - [Global Options](#global-options)
 - [Examples](#examples)
@@ -57,20 +57,20 @@ npm run terminal -- state-machine process-event \
   --expectedState confirmed
 ```
 
-### Create an Oracle
+### Create a Script
 
 ```bash
-npm run terminal -- oracle create \
-  --oracle resources/oracles/calculator-oracle.json
+npm run terminal -- script create \
+  --script resources/scripts/calculator-script.json
 ```
 
-### Invoke an Oracle
+### Invoke a Script
 
 ```bash
-npm run terminal -- oracle invoke \
+npm run terminal -- script invoke \
   --address <CID-from-create-step> \
   --method add \
-  --args resources/oracles/invoke-args-add.json \
+  --args resources/scripts/invoke-args-add.json \
   --expectedResult '15'
 ```
 
@@ -124,22 +124,22 @@ node terminal.js sm archive \
   --address 7065df56-2eba-49bd-8d55-69c3ead89e05
 ```
 
-### Oracle Commands
+### Script Commands
 
-#### `oracle create` (alias: `or create`)
+#### `script create` (alias: `or create`)
 
 Create a new script.
 
 **Required Options:**
-- `--oracle <path>`: Path to oracle definition JSON file
+- `--script <path>`: Path to script definition JSON file
 
 **Example:**
 ```bash
-node terminal.js oracle create \
-  --oracle resources/oracles/counter-oracle.json
+node terminal.js script create \
+  --script resources/scripts/counter-script.json
 ```
 
-#### `oracle invoke` (alias: `or invoke`)
+#### `script invoke` (alias: `or invoke`)
 
 Invoke a method on an existing script.
 
@@ -165,12 +165,12 @@ node terminal.js or invoke \
 List available example resources.
 
 **Optional:**
-- `--type <type>`: Filter by type: `state-machines`, `oracles`, or `events`
+- `--type <type>`: Filter by type: `state-machines`, `scripts`, or `events`
 
 **Examples:**
 ```bash
 node terminal.js list
-node terminal.js list --type oracles
+node terminal.js list --type scripts
 ```
 
 ## Global Options
@@ -227,8 +227,8 @@ node terminal.js sm event \
 ### Multi-Signer Transaction
 
 ```bash
-node terminal.js oracle create \
-  --oracle resources/oracles/calculator-oracle.json \
+node terminal.js script create \
+  --script resources/scripts/calculator-script.json \
   --wallets alice,bob,charlie
 ```
 
@@ -245,10 +245,10 @@ node terminal.js sm create \
 ### Validation Only (Post-Deployment Check)
 
 ```bash
-node terminal.js oracle invoke \
+node terminal.js script invoke \
   --address abc123... \
   --method add \
-  --args resources/oracles/invoke-args-add.json \
+  --args resources/scripts/invoke-args-add.json \
   --mode validate
 ```
 
@@ -296,7 +296,7 @@ node terminal.js oracle invoke \
 }
 ```
 
-### Oracle Definition Structure
+### Script Definition Structure
 
 ```json
 {
@@ -368,13 +368,13 @@ For verbose output, examine the console logs which show:
 
 1. **State Machines**: Add to `resources/state-machines/`
 2. **Events**: Add to `resources/state-machines/events/`
-3. **Oracles**: Add to `resources/oracles/`
+3. **Scripts**: Add to `resources/scripts/`
 
 ### Extending Operations
 
 To add new operations:
 
-1. Create generator/validator in `lib/state-machine/` or `lib/oracle/`
+1. Create generator/validator in `lib/state-machine/` or `lib/script/`
 2. Add command to `terminal.js`
 3. Update this README
 
@@ -386,9 +386,9 @@ terminal.js (main CLI)
 │   ├── createFiber.js (generator + validator)
 │   ├── processEvent.js (generator + validator)
 │   └── archiveFiber.js (generator + validator)
-├── lib/oracle/
-│   ├── createOracle.js (generator + validator)
-│   └── invokeOracle.js (generator + validator)
+├── lib/script/
+│   ├── createScript.js (generator + validator)
+│   └── invokeScript.js (generator + validator)
 ├── lib/ (shared utilities)
 │   ├── generateProof.js
 │   ├── generateWallet.js
@@ -396,7 +396,7 @@ terminal.js (main CLI)
 │   └── metagraphEnv.js
 └── resources/
     ├── state-machines/
-    ├── oracles/
+    ├── scripts/
     └── state-machines/events/
 ```
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -63,13 +63,13 @@ Everything — states, transitions, guards, effects — is defined in JSON:
 
 ### Scripts
 
-Script oracles are stateful computation units. Where state machines orchestrate *lifecycle* (which state am I in?), oracles handle *logic* (what's the answer?). An oracle exposes named **methods** that other fibers can call.
+Scripts are stateful computation units. Where state machines orchestrate *lifecycle* (which state am I in?), scripts handle *logic* (what's the answer?). A script exposes named **methods** that other fibers can call.
 
 Think of them as on-chain microservices:
 
 ```
 State Machine                    Script
-┌───────────┐    _oracleCall     ┌─────────────┐
+┌───────────┐    _scriptCall     ┌─────────────┐
 │  playing  │───────────────────▶│  Game Logic  │
 │           │    makeMove(x,y)   │             │
 │           │◀───────────────────│  - board    │
@@ -78,7 +78,7 @@ State Machine                    Script
                                  └─────────────┘
 ```
 
-The tic-tac-toe example demonstrates this pattern: the oracle holds the board state and enforces game rules, while the state machine manages the game lifecycle (setup → playing → finished).
+The tic-tac-toe example demonstrates this pattern: the script holds the board state and enforces game rules, while the state machine manages the game lifecycle (setup → playing → finished).
 
 ### Fibers Working Together
 
@@ -88,7 +88,7 @@ The real power emerges when fibers interact:
 - **Dependencies** — A transition can read state from other machines before deciding
 - **Parent-child spawning** — Machines can dynamically create child machines
 - **Broadcast triggers** — One event fans out to many machines simultaneously
-- **Oracle calls** — State machines invoke oracle methods during transitions
+- **Script calls** — State machines invoke script methods during transitions
 
 This composability lets you model complex multi-party systems. The Riverdale Economy example uses 17 machine instances across 6 types to simulate an entire economic ecosystem with manufacturing, retail, banking, consumers, monetary policy, and governance — all in JSON.
 
@@ -102,7 +102,7 @@ OttoChain runs as a metagraph on Constellation's Tessellation framework. Each no
 ┌─────────────────────────────────────────────┐
 │           Data L1 (Port 9300)               │
 │  Fiber processing: state machine events,    │
-│  oracle invocations, validation             │
+│  script invocations, validation             │
 ├─────────────────────────────────────────────┤
 │         Currency L1 (Port 9200)             │
 │  Token transfers and balance tracking       │
@@ -115,7 +115,7 @@ OttoChain runs as a metagraph on Constellation's Tessellation framework. Each no
 └─────────────────────────────────────────────┘
 ```
 
-**Data L1** is where the action happens. When you send an event to a state machine or invoke an oracle method, the Data L1 layer:
+**Data L1** is where the action happens. When you send an event to a state machine or invoke a script method, the Data L1 layer:
 
 1. **Validates** the input (signature proofs, fiber exists, fiber is active)
 2. **Evaluates** the fiber (checks guards, applies effects, runs scripts)
@@ -197,7 +197,7 @@ OttoChain's examples demonstrate the range of what's possible:
 
 | Example | Machines | Complexity | Key Patterns |
 |---------|----------|-----------|--------------|
-| [Tic-Tac-Toe](examples/tictactoe.md) | 1 SM + 1 Oracle | ⭐ | Oracle-centric architecture, self-transitions |
+| [Tic-Tac-Toe](examples/tictactoe.md) | 1 SM + 1 Script | ⭐ | Script-centric architecture, self-transitions |
 | [Fuel Logistics](examples/fuel-logistics.md) | 4 SMs | ⭐⭐ | Cross-machine triggers, GPS tracking |
 | [Clinical Trial](examples/clinical-trial.md) | 6 SMs | ⭐⭐⭐ | Multiple guards, bi-directional transitions |
 | [Real Estate](examples/real-estate.md) | 8 SMs | ⭐⭐⭐ | Self-transitions, lifecycle management |
@@ -211,11 +211,11 @@ The choice to encode everything in JSON is deliberate:
 
 1. **Zero-code deployment** — Define a workflow, submit it as JSON, it's running. No compilation, no deployment pipelines, no smart contract audits.
 
-2. **AI-native** — LLMs understand JSON natively. An AI agent can read a state machine definition, understand the workflow, generate events, and even create new machines. This isn't theoretical — the [OttoBot project](projects/ottobot/ARCHITECTURE.md) demonstrates an AI agent autonomously playing tic-tac-toe through oracle interactions.
+2. **AI-native** — LLMs understand JSON natively. An AI agent can read a state machine definition, understand the workflow, generate events, and even create new machines. This isn't theoretical — the [OttoBot project](projects/ottobot/ARCHITECTURE.md) demonstrates an AI agent autonomously playing tic-tac-toe through script interactions.
 
 3. **Portable and auditable** — A JSON definition is the same everywhere. You can diff two versions, validate schemas at startup, and inspect the complete logic of any workflow without reading source code.
 
-4. **Composable** — JSON Logic expressions can be nested, combined, and extended. OttoChain adds constructs like `_oracleCall`, `_trigger`, `_spawn`, and `_emit` on top of standard JSON Logic to enable cross-fiber coordination.
+4. **Composable** — JSON Logic expressions can be nested, combined, and extended. OttoChain adds constructs like `_scriptCall`, `_trigger`, `_spawn`, and `_emit` on top of standard JSON Logic to enable cross-fiber coordination.
 
 5. **Deterministic** — JSON Logic evaluation is pure and deterministic. Given the same context, the same expression always produces the same result. This is essential for distributed consensus — every node must agree on the outcome.
 

--- a/docs/reference/jlvm-semantics.md
+++ b/docs/reference/jlvm-semantics.md
@@ -464,7 +464,7 @@ Only the keys you include in an effect's result become the new state. If you wan
 
 ### 5. Reserved keys in effects
 Keys prefixed with `_` are extracted by OttoChain's engine as side effects and NOT included in the new state:
-- `_oracleCall` → invokes an oracle
+- `_scriptCall` → invokes a script
 - `_triggers` → fires cross-machine events
 - `_spawn` → creates child fibers
 - `_emit` → emits observable events

--- a/e2e-test/examples/README.md
+++ b/e2e-test/examples/README.md
@@ -5,10 +5,10 @@ This directory contains example-based test resources for the Ottochain e2e test 
 ## Directory Structure
 
 Each example directory contains:
-- `definition.json` - The state machine or oracle definition
+- `definition.json` - The state machine or script definition
 - `initial-data.json` - Initial data for state machines
 - `event-*.json` - Event files for state machine transitions
-- `args-*.json` - Argument files for oracle method invocations
+- `args-*.json` - Argument files for script method invocations
 - `example.json` - Metadata describing the example and its test flows
 
 ## Available Examples
@@ -57,18 +57,18 @@ node terminal.js sm process-event --address <CID> --event examples/simple-order/
 node terminal.js sm process-event --address <CID> --event examples/simple-order/event-deliver.json --expectedState delivered
 ```
 
-### Oracle Examples
+### Script Examples
 
-#### counter-oracle
-A stateful script oracle that maintains a counter with increment, decrement, and reset operations.
+#### counter-script
+A stateful script that maintains a counter with increment, decrement, and reset operations.
 
 **Files:**
-- `definition.json` - Oracle definition
+- `definition.json` - Script definition
 
 **Usage:**
 ```bash
-# Create oracle
-node terminal.js or create --oracle examples/counter-oracle/definition.json
+# Create script
+node terminal.js or create --script examples/counter-script/definition.json
 
 # Invoke methods (use the CID from previous command)
 node terminal.js or invoke --address <CID> --method increment
@@ -77,11 +77,11 @@ node terminal.js or invoke --address <CID> --method decrement
 node terminal.js or invoke --address <CID> --method reset
 ```
 
-#### calculator-oracle
-A stateless script oracle for basic arithmetic operations.
+#### calculator-script
+A stateless script for basic arithmetic operations.
 
 **Files:**
-- `definition.json` - Oracle definition
+- `definition.json` - Script definition
 - `args-add.json` - Arguments for add method
 - `args-subtract.json` - Arguments for subtract method
 - `args-multiply.json` - Arguments for multiply method
@@ -89,41 +89,41 @@ A stateless script oracle for basic arithmetic operations.
 
 **Usage:**
 ```bash
-# Create oracle
-node terminal.js or create --oracle examples/calculator-oracle/definition.json
+# Create script
+node terminal.js or create --script examples/calculator-script/definition.json
 
 # Invoke methods with arguments (use the CID from previous command)
-node terminal.js or invoke --address <CID> --method add --args examples/calculator-oracle/args-add.json
-node terminal.js or invoke --address <CID> --method subtract --args examples/calculator-oracle/args-subtract.json
-node terminal.js or invoke --address <CID> --method multiply --args examples/calculator-oracle/args-multiply.json
-node terminal.js or invoke --address <CID> --method divide --args examples/calculator-oracle/args-divide.json
+node terminal.js or invoke --address <CID> --method add --args examples/calculator-script/args-add.json
+node terminal.js or invoke --address <CID> --method subtract --args examples/calculator-script/args-subtract.json
+node terminal.js or invoke --address <CID> --method multiply --args examples/calculator-script/args-multiply.json
+node terminal.js or invoke --address <CID> --method divide --args examples/calculator-script/args-divide.json
 ```
 
-### Combined Examples (Oracle + State Machine)
+### Combined Examples (Script + State Machine)
 
 #### tictactoe
-A complete tic-tac-toe implementation demonstrating the **oracle-centric architecture** where:
-- **Oracle** = Game engine (holds board state, enforces rules, detects wins)
+A complete tic-tac-toe implementation demonstrating the **script-centric architecture** where:
+- **Script** = Game engine (holds board state, enforces rules, detects wins)
 - **State Machine** = Lifecycle orchestrator (setup → playing → finished)
 
 **Files:**
-- `oracle-definition.json` - Game engine oracle with methods: initialize, makeMove, checkWinner, getBoard, resetGame, cancelGame
+- `script-definition.json` - Game engine script with methods: initialize, makeMove, checkWinner, getBoard, resetGame, cancelGame
 - `sm-definition.json` - Lifecycle state machine with states: setup, playing, finished, cancelled
-- `sm-initial-data.json` - Initial data template (oracleCid injected at runtime)
+- `sm-initial-data.json` - Initial data template (scriptCid injected at runtime)
 - `event-start-game.json` - Start game event template
 - `event-move.json` - Make move event template
 - `event-reset.json` - Reset board event
 
 **Usage:**
 ```bash
-# Run autonomous simulation (creates oracle + state machine automatically)
+# Run autonomous simulation (creates script + state machine automatically)
 node terminal.js simulate tictactoe --games 1
 
 # Or run the predefined test flow
 node terminal.js run --example tictactoe
 
 # Query the results
-node terminal.js query oracles --oracleId <ORACLE_CID>
+node terminal.js query scripts --scriptId <SCRIPT_CID>
 node terminal.js query state-machines --fiberId <FIBER_ID>
 ```
 
@@ -146,7 +146,7 @@ node terminal.js run --example simple-order --target remote
 ```
 
 Test flows automate multi-step operations like:
-1. Creating oracles and state machines
+1. Creating scripts and state machines
 2. Processing events in sequence
 3. Validating state after each step
 4. Tracking CIDs between steps automatically
@@ -173,8 +173,8 @@ node terminal.js list
 # List only state machine examples
 node terminal.js list --type state-machines
 
-# List only oracle examples
-node terminal.js list --type oracles
+# List only script examples
+node terminal.js list --type scripts
 
 # Get detailed info about a specific example
 node terminal.js list --example approval-workflow
@@ -187,14 +187,14 @@ To create a new example:
 1. Create a directory: `examples/my-example/`
 2. Add the required files based on the type:
    - State machines: `definition.json`, `initial-data.json`, `event-*.json`
-   - Oracles: `definition.json`, `args-*.json` (if methods take arguments)
+   - Scripts: `definition.json`, `args-*.json` (if methods take arguments)
 3. Create an `example.json` manifest:
 
 ```json
 {
   "name": "My Example",
   "description": "Description of what this example demonstrates",
-  "type": "state-machine",  // or "oracle"
+  "type": "state-machine",  // or "script"
   "definition": "definition.json",
   "initialData": "initial-data.json",  // for state machines
   "events": [  // for state machines
@@ -206,7 +206,7 @@ To create a new example:
       "to": "target-state"
     }
   ],
-  "methods": [  // for oracles
+  "methods": [  // for scripts
     {
       "name": "method-name",
       "description": "What this method does",

--- a/e2e-test/examples/calculator-script/example.json
+++ b/e2e-test/examples/calculator-script/example.json
@@ -1,7 +1,7 @@
 {
-  "name": "Calculator Oracle",
-  "description": "A stateless script oracle that performs basic arithmetic operations",
-  "type": "oracle",
+  "name": "Calculator Script",
+  "description": "A stateless script script that performs basic arithmetic operations",
+  "type": "script",
   "definition": "definition.json",
   "methods": [
     {
@@ -32,7 +32,7 @@
   "testFlows": [
     {
       "name": "All arithmetic operations",
-      "description": "Create oracle and test all arithmetic methods",
+      "description": "Create script and test all arithmetic methods",
       "steps": [
         { "action": "createScript", "definition": "definition.json" },
         { "action": "invoke", "method": "add", "args": "args-add.json" },

--- a/e2e-test/examples/counter-script/example.json
+++ b/e2e-test/examples/counter-script/example.json
@@ -1,7 +1,7 @@
 {
-  "name": "Counter Oracle",
-  "description": "A stateful script oracle that maintains a counter and supports increment, decrement, and reset operations",
-  "type": "oracle",
+  "name": "Counter Script",
+  "description": "A stateful script script that maintains a counter and supports increment, decrement, and reset operations",
+  "type": "script",
   "definition": "definition.json",
   "methods": [
     {
@@ -26,7 +26,7 @@
   "testFlows": [
     {
       "name": "Basic counter operations",
-      "description": "Create oracle, increment twice, decrement once, reset",
+      "description": "Create script, increment twice, decrement once, reset",
       "steps": [
         { "action": "createScript", "definition": "definition.json" },
         { "action": "invoke", "method": "increment" },

--- a/e2e-test/examples/tictactoe/archive/example.json
+++ b/e2e-test/examples/tictactoe/archive/example.json
@@ -1,8 +1,8 @@
 {
   "name": "Tic-Tac-Toe Game",
-  "description": "Complete tic-tac-toe implementation demonstrating the oracle-centric architecture pattern where the oracle holds game state and the state machine orchestrates the lifecycle",
+  "description": "Complete tic-tac-toe implementation demonstrating the script-centric architecture pattern where the script holds game state and the state machine orchestrates the lifecycle",
   "type": "combined",
-  "oracle": {
+  "script": {
     "definition": "script-definition.json",
     "methods": [
       {

--- a/e2e-test/examples/tictactoe/archive/sm-definition.json
+++ b/e2e-test/examples/tictactoe/archive/sm-definition.json
@@ -55,9 +55,9 @@
         ]
       },
       "effect": {
-        "_oracleCall": {
+        "_scriptCall": {
           "fiberId": {
-            "var": "state.oracleFiberId"
+            "var": "state.scriptFiberId"
           },
           "method": "initialize",
           "args": {
@@ -94,15 +94,15 @@
       "guard": {
         "===": [
           {
-            "var": "scriptOracles.11111111-1111-1111-1111-111111111111.state.status"
+            "var": "scriptScripts.11111111-1111-1111-1111-111111111111.state.status"
           },
           "InProgress"
         ]
       },
       "effect": {
-        "_oracleCall": {
+        "_scriptCall": {
           "fiberId": {
-            "var": "state.oracleFiberId"
+            "var": "state.scriptFiberId"
           },
           "method": "makeMove",
           "args": {
@@ -138,7 +138,7 @@
           {
             "===": [
               {
-                "var": "scriptOracles.11111111-1111-1111-1111-111111111111.state.status"
+                "var": "scriptScripts.11111111-1111-1111-1111-111111111111.state.status"
               },
               "Won"
             ]
@@ -146,7 +146,7 @@
           {
             "===": [
               {
-                "var": "scriptOracles.11111111-1111-1111-1111-111111111111.state.status"
+                "var": "scriptScripts.11111111-1111-1111-1111-111111111111.state.status"
               },
               "Draw"
             ]
@@ -154,9 +154,9 @@
         ]
       },
       "effect": {
-        "_oracleCall": {
+        "_scriptCall": {
           "fiberId": {
-            "var": "state.oracleFiberId"
+            "var": "state.scriptFiberId"
           },
           "method": "makeMove",
           "args": {
@@ -169,13 +169,13 @@
           }
         },
         "finalStatus": {
-          "var": "scriptOracles.11111111-1111-1111-1111-111111111111.state.status"
+          "var": "scriptScripts.11111111-1111-1111-1111-111111111111.state.status"
         },
         "winner": {
-          "var": "scriptOracles.11111111-1111-1111-1111-111111111111.state.winner"
+          "var": "scriptScripts.11111111-1111-1111-1111-111111111111.state.winner"
         },
         "finalBoard": {
-          "var": "scriptOracles.11111111-1111-1111-1111-111111111111.state.board"
+          "var": "scriptScripts.11111111-1111-1111-1111-111111111111.state.board"
         },
         "_outputs": [
           {
@@ -185,13 +185,13 @@
                 "var": "state.gameId"
               },
               "winner": {
-                "var": "scriptOracles.11111111-1111-1111-1111-111111111111.state.winner"
+                "var": "scriptScripts.11111111-1111-1111-1111-111111111111.state.winner"
               },
               "status": {
-                "var": "scriptOracles.11111111-1111-1111-1111-111111111111.state.status"
+                "var": "scriptScripts.11111111-1111-1111-1111-111111111111.state.status"
               },
               "moveCount": {
-                "var": "scriptOracles.11111111-1111-1111-1111-111111111111.state.moveCount"
+                "var": "scriptScripts.11111111-1111-1111-1111-111111111111.state.moveCount"
               }
             }
           }
@@ -212,7 +212,7 @@
           {
             "===": [
               {
-                "var": "scriptOracles.11111111-1111-1111-1111-111111111111.state.status"
+                "var": "scriptScripts.11111111-1111-1111-1111-111111111111.state.status"
               },
               "Won"
             ]
@@ -220,7 +220,7 @@
           {
             "===": [
               {
-                "var": "scriptOracles.11111111-1111-1111-1111-111111111111.state.status"
+                "var": "scriptScripts.11111111-1111-1111-1111-111111111111.state.status"
               },
               "Draw"
             ]
@@ -228,9 +228,9 @@
         ]
       },
       "effect": {
-        "_oracleCall": {
+        "_scriptCall": {
           "fiberId": {
-            "var": "state.oracleFiberId"
+            "var": "state.scriptFiberId"
           },
           "method": "resetGame",
           "args": {}
@@ -261,9 +261,9 @@
         ]
       },
       "effect": {
-        "_oracleCall": {
+        "_scriptCall": {
           "fiberId": {
-            "var": "state.oracleFiberId"
+            "var": "state.scriptFiberId"
           },
           "method": "cancelGame",
           "args": {

--- a/e2e-test/examples/tictactoe/archive/sm-initial-data.json
+++ b/e2e-test/examples/tictactoe/archive/sm-initial-data.json
@@ -1,4 +1,4 @@
 {
-  "oracleFiberId": null,
+  "scriptFiberId": null,
   "roundCount": 0
 }

--- a/e2e-test/examples/tictactoe/example.json
+++ b/e2e-test/examples/tictactoe/example.json
@@ -1,9 +1,9 @@
 {
   "name": "Tic-Tac-Toe Game",
-  "description": "Complete tic-tac-toe implementation demonstrating the oracle-centric architecture pattern where the oracle holds game state and the state machine orchestrates the lifecycle",
+  "description": "Complete tic-tac-toe implementation demonstrating the script-centric architecture pattern where the script holds game state and the state machine orchestrates the lifecycle",
   "type": "combined",
 
-  "oracle": {
+  "script": {
     "definition": "script-definition.json",
     "methods": [
       { "name": "initialize", "description": "Initialize game with two players" },

--- a/e2e-test/examples/tictactoe/sm-definition.ts
+++ b/e2e-test/examples/tictactoe/sm-definition.ts
@@ -4,14 +4,14 @@ import crypto from 'crypto';
  * Tic-Tac-Toe State Machine Definition
  *
  * Orchestrates the game lifecycle: setup -> playing -> finished/cancelled
- * Coordinates with the oracle via _oracleCall effects.
+ * Coordinates with the script via _scriptCall effects.
  *
- * The oracle fiberId is injected dynamically from context.session.oracleFiberId
- * so each test run uses a fresh oracle.
+ * The script fiberId is injected dynamically from context.session.scriptFiberId
+ * so each test run uses a fresh script.
  */
 export default (context: Record<string, unknown>) => {
-  const session = context?.session as { oracleFiberId?: string } | undefined;
-  const oracleFiberId = session?.oracleFiberId || crypto.randomUUID();
+  const session = context?.session as { scriptFiberId?: string } | undefined;
+  const scriptFiberId = session?.scriptFiberId || crypto.randomUUID();
 
   return {
     states: {
@@ -51,8 +51,8 @@ export default (context: Record<string, unknown>) => {
           ],
         },
         effect: {
-          _oracleCall: {
-            fiberId: { var: 'state.oracleFiberId' },
+          _scriptCall: {
+            fiberId: { var: 'state.scriptFiberId' },
             method: 'initialize',
             args: {
               playerX: { var: 'event.playerX' },
@@ -74,11 +74,11 @@ export default (context: Record<string, unknown>) => {
         to: 'playing',
         eventName: 'make_move',
         guard: {
-          '===': [{ var: `scripts.${oracleFiberId}.state.status` }, 'InProgress'],
+          '===': [{ var: `scripts.${scriptFiberId}.state.status` }, 'InProgress'],
         },
         effect: {
-          _oracleCall: {
-            fiberId: { var: 'state.oracleFiberId' },
+          _scriptCall: {
+            fiberId: { var: 'state.scriptFiberId' },
             method: 'makeMove',
             args: {
               player: { var: 'event.player' },
@@ -90,7 +90,7 @@ export default (context: Record<string, unknown>) => {
             cell: { var: 'event.cell' },
           },
         },
-        dependencies: [oracleFiberId],
+        dependencies: [scriptFiberId],
       },
 
       // playing -> finished (make_move, game ends with win/draw)
@@ -100,35 +100,35 @@ export default (context: Record<string, unknown>) => {
         eventName: 'make_move',
         guard: {
           or: [
-            { '===': [{ var: `scripts.${oracleFiberId}.state.status` }, 'Won'] },
-            { '===': [{ var: `scripts.${oracleFiberId}.state.status` }, 'Draw'] },
+            { '===': [{ var: `scripts.${scriptFiberId}.state.status` }, 'Won'] },
+            { '===': [{ var: `scripts.${scriptFiberId}.state.status` }, 'Draw'] },
           ],
         },
         effect: {
-          _oracleCall: {
-            fiberId: { var: 'state.oracleFiberId' },
+          _scriptCall: {
+            fiberId: { var: 'state.scriptFiberId' },
             method: 'makeMove',
             args: {
               player: { var: 'event.player' },
               cell: { var: 'event.cell' },
             },
           },
-          finalStatus: { var: `scripts.${oracleFiberId}.state.status` },
-          winner: { var: `scripts.${oracleFiberId}.state.winner` },
-          finalBoard: { var: `scripts.${oracleFiberId}.state.board` },
+          finalStatus: { var: `scripts.${scriptFiberId}.state.status` },
+          winner: { var: `scripts.${scriptFiberId}.state.winner` },
+          finalBoard: { var: `scripts.${scriptFiberId}.state.board` },
           _emit: [
             {
               name: 'game_completed',
               data: {
                 gameId: { var: 'state.gameId' },
-                winner: { var: `scripts.${oracleFiberId}.state.winner` },
-                status: { var: `scripts.${oracleFiberId}.state.status` },
-                moveCount: { var: `scripts.${oracleFiberId}.state.moveCount` },
+                winner: { var: `scripts.${scriptFiberId}.state.winner` },
+                status: { var: `scripts.${scriptFiberId}.state.status` },
+                moveCount: { var: `scripts.${scriptFiberId}.state.moveCount` },
               },
             },
           ],
         },
-        dependencies: [oracleFiberId],
+        dependencies: [scriptFiberId],
       },
 
       // playing -> playing (reset_board, start new round)
@@ -138,19 +138,19 @@ export default (context: Record<string, unknown>) => {
         eventName: 'reset_board',
         guard: {
           or: [
-            { '===': [{ var: `scripts.${oracleFiberId}.state.status` }, 'Won'] },
-            { '===': [{ var: `scripts.${oracleFiberId}.state.status` }, 'Draw'] },
+            { '===': [{ var: `scripts.${scriptFiberId}.state.status` }, 'Won'] },
+            { '===': [{ var: `scripts.${scriptFiberId}.state.status` }, 'Draw'] },
           ],
         },
         effect: {
-          _oracleCall: {
-            fiberId: { var: 'state.oracleFiberId' },
+          _scriptCall: {
+            fiberId: { var: 'state.scriptFiberId' },
             method: 'resetGame',
             args: {},
           },
           roundCount: { '+': [{ var: 'state.roundCount' }, 1] },
         },
-        dependencies: [oracleFiberId],
+        dependencies: [scriptFiberId],
       },
 
       // playing -> cancelled (cancel_game)
@@ -160,8 +160,8 @@ export default (context: Record<string, unknown>) => {
         eventName: 'cancel_game',
         guard: { '==': [1, 1] },
         effect: {
-          _oracleCall: {
-            fiberId: { var: 'state.oracleFiberId' },
+          _scriptCall: {
+            fiberId: { var: 'state.scriptFiberId' },
             method: 'cancelGame',
             args: {
               requestedBy: { var: 'event.requestedBy' },

--- a/e2e-test/examples/tictactoe/sm-initial-data.ts
+++ b/e2e-test/examples/tictactoe/sm-initial-data.ts
@@ -1,11 +1,11 @@
 import crypto from 'crypto';
 
 export default (context: Record<string, unknown>) => {
-  const session = context?.session as { oracleFiberId?: string } | undefined;
-  const oracleFiberId = session?.oracleFiberId || crypto.randomUUID();
+  const session = context?.session as { scriptFiberId?: string } | undefined;
+  const scriptFiberId = session?.scriptFiberId || crypto.randomUUID();
 
   return {
-    oracleFiberId,
+    scriptFiberId,
     roundCount: 0,
   };
 };

--- a/e2e-test/lib/ordinalConfirmation.ts
+++ b/e2e-test/lib/ordinalConfirmation.ts
@@ -12,7 +12,7 @@ const TAG = '\x1b[33m[ordinalConfirm]\x1b[0m';
 export interface OrdinalConfirmationOptions {
   /** ML0 base URL (e.g., http://localhost:9200) */
   ml0BaseUrl: string;
-  /** Entity path (e.g., state-machines/{id} or oracles/{id}) */
+  /** Entity path (e.g., state-machines/{id} or scripts/{id}) */
   entityPath: string;
   /** Predicate to check if the entity state is as expected */
   predicate: (data: unknown) => boolean;

--- a/e2e-test/lib/script/createScript.ts
+++ b/e2e-test/lib/script/createScript.ts
@@ -3,29 +3,29 @@ import path from 'path';
 import type { OttochainMessage } from '@ottochain/sdk/core';
 import type { StatesMap } from '../types.ts';
 
-export interface CreateOracleOptions {
-  oracle?: string;
-  oracleDefinition?: {
+export interface CreateScriptOptions {
+  script?: string;
+  scriptDefinition?: {
     scriptProgram: unknown;
     accessControl: unknown;
     initialState?: unknown;
   };
 }
 
-export const generator = ({ cid, options }: { cid: string; wallets?: unknown; options: CreateOracleOptions }): OttochainMessage => {
-  let oracleDefinition: { scriptProgram: unknown; accessControl: unknown; initialState?: unknown };
+export const generator = ({ cid, options }: { cid: string; wallets?: unknown; options: CreateScriptOptions }): OttochainMessage => {
+  let scriptDefinition: { scriptProgram: unknown; accessControl: unknown; initialState?: unknown };
 
-  if (options.oracleDefinition && typeof options.oracleDefinition === 'object') {
-    oracleDefinition = options.oracleDefinition;
-  } else if (typeof options.oracle === 'string') {
-    const oraclePath = path.resolve(options.oracle);
-    if (!fs.existsSync(oraclePath)) {
-      throw new Error(`Oracle definition file not found: ${oraclePath}`);
+  if (options.scriptDefinition && typeof options.scriptDefinition === 'object') {
+    scriptDefinition = options.scriptDefinition;
+  } else if (typeof options.script === 'string') {
+    const scriptPath = path.resolve(options.script);
+    if (!fs.existsSync(scriptPath)) {
+      throw new Error(`Script definition file not found: ${scriptPath}`);
     }
-    oracleDefinition = JSON.parse(fs.readFileSync(oraclePath, 'utf8'));
+    scriptDefinition = JSON.parse(fs.readFileSync(scriptPath, 'utf8'));
   } else {
     throw new Error(
-      'Either options.oracle (path) or options.oracleDefinition (object) must be provided'
+      'Either options.script (path) or options.scriptDefinition (object) must be provided'
     );
   }
 
@@ -37,9 +37,9 @@ export const generator = ({ cid, options }: { cid: string; wallets?: unknown; op
   // requirement.
   const createMsg: Record<string, unknown> = {
     fiberId: cid,
-    scriptProgram: oracleDefinition.scriptProgram,
-    initialState: oracleDefinition.initialState ?? null,
-    accessControl: oracleDefinition.accessControl,
+    scriptProgram: scriptDefinition.scriptProgram,
+    initialState: scriptDefinition.initialState ?? null,
+    accessControl: scriptDefinition.accessControl,
   };
 
   return { CreateScript: createMsg } as unknown as OttochainMessage;
@@ -51,25 +51,25 @@ export const validator = ({ cid, statesMap }: { cid: string; statesMap: StatesMa
 
     if (!finalRecord) {
       throw new Error(
-        `\x1b[33m[createScript.validator]\x1b[0m No script oracle found for fiberId = ${cid} in final state from ${url}.`
+        `\x1b[33m[createScript.validator]\x1b[0m No script script found for fiberId = ${cid} in final state from ${url}.`
       );
     }
 
     if (finalRecord.status !== 'ACTIVE') {
       throw new Error(
-        `\x1b[33m[createScript.validator]\x1b[0m Expected oracle status "ACTIVE" but found "${finalRecord.status}" for fiberId = ${cid} at ${url}.`
+        `\x1b[33m[createScript.validator]\x1b[0m Expected script status "ACTIVE" but found "${finalRecord.status}" for fiberId = ${cid} at ${url}.`
       );
     }
 
     // US-7: invocationCount → sequenceNumber
     if (finalRecord.sequenceNumber !== 0) {
       throw new Error(
-        `\x1b[33m[createScript.validator]\x1b[0m Expected sequenceNumber 0 for new oracle but found ${finalRecord.sequenceNumber} for fiberId = ${cid} at ${url}.`
+        `\x1b[33m[createScript.validator]\x1b[0m Expected sequenceNumber 0 for new script but found ${finalRecord.sequenceNumber} for fiberId = ${cid} at ${url}.`
       );
     }
 
     console.log(
-      `\x1b[33m[createScript.validator]\x1b[32m Oracle created successfully for fiberId = ${cid} at ${url}!\x1b[0m`
+      `\x1b[33m[createScript.validator]\x1b[32m Script created successfully for fiberId = ${cid} at ${url}!\x1b[0m`
     );
   }
 };

--- a/e2e-test/lib/script/invokeScript.ts
+++ b/e2e-test/lib/script/invokeScript.ts
@@ -2,9 +2,9 @@ import fs from 'fs';
 import path from 'path';
 import type { OttochainMessage } from '@ottochain/sdk/core';
 import type { StatesMap } from '../types.ts';
-import { validateOracleLogs } from '../validateLogs.ts';
+import { validateScriptLogs } from '../validateLogs.ts';
 
-export interface InvokeOracleOptions {
+export interface InvokeScriptOptions {
   method: string;
   args?: string | object;
   argsData?: object;
@@ -12,7 +12,7 @@ export interface InvokeOracleOptions {
   targetSequenceNumber?: number;
 }
 
-export const generator = ({ cid, options }: { cid: string; wallets?: unknown; options: InvokeOracleOptions }): OttochainMessage => {
+export const generator = ({ cid, options }: { cid: string; wallets?: unknown; options: InvokeScriptOptions }): OttochainMessage => {
   let args: unknown = {};
 
   if (options.argsData && typeof options.argsData === 'object') {
@@ -40,20 +40,20 @@ export const generator = ({ cid, options }: { cid: string; wallets?: unknown; op
   };
 };
 
-export const validator = async ({ cid, statesMap, options, ml0Urls }: { cid: string; statesMap: StatesMap; options: InvokeOracleOptions; wallets?: unknown; ml0Urls?: string[] }) => {
+export const validator = async ({ cid, statesMap, options, ml0Urls }: { cid: string; statesMap: StatesMap; options: InvokeScriptOptions; wallets?: unknown; ml0Urls?: string[] }) => {
   for (const [url, { initial, final }] of Object.entries(statesMap)) {
     const initialRecord = initial?.state?.scripts?.[cid];
     const finalRecord = final?.state?.scripts?.[cid];
 
     if (!initialRecord) {
       throw new Error(
-        `\x1b[33m[invokeScript.validator]\x1b[0m No initial script oracle found for fiberId = ${cid} from ${url}.`
+        `\x1b[33m[invokeScript.validator]\x1b[0m No initial script script found for fiberId = ${cid} from ${url}.`
       );
     }
 
     if (!finalRecord) {
       throw new Error(
-        `\x1b[33m[invokeScript.validator]\x1b[0m No final script oracle found for fiberId = ${cid} from ${url}.`
+        `\x1b[33m[invokeScript.validator]\x1b[0m No final script script found for fiberId = ${cid} from ${url}.`
       );
     }
 
@@ -68,7 +68,7 @@ export const validator = async ({ cid, statesMap, options, ml0Urls }: { cid: str
     const latestInvocation = finalRecord.lastInvocation;
     if (latestInvocation) {
       console.log(
-        `\x1b[33m[invokeScript.validator]\x1b[32m Oracle invoked successfully for fiberId = ${cid} at ${url}.`
+        `\x1b[33m[invokeScript.validator]\x1b[32m Script invoked successfully for fiberId = ${cid} at ${url}.`
       );
       console.log(
         `\x1b[33m[invokeScript.validator]\x1b[0m   Method: ${latestInvocation.method}`
@@ -95,13 +95,13 @@ export const validator = async ({ cid, statesMap, options, ml0Urls }: { cid: str
       }
     } else {
       console.log(
-        `\x1b[33m[invokeScript.validator]\x1b[33m Oracle sequenceNumber increased but no lastInvocation found for fiberId = ${cid} at ${url}.\x1b[0m`
+        `\x1b[33m[invokeScript.validator]\x1b[33m Script sequenceNumber increased but no lastInvocation found for fiberId = ${cid} at ${url}.\x1b[0m`
       );
     }
   }
 
   // US-8: Mandatory log endpoint validation
   if (ml0Urls && ml0Urls.length > 0) {
-    await validateOracleLogs({ ml0Urls, fiberId: cid }, options.method);
+    await validateScriptLogs({ ml0Urls, fiberId: cid }, options.method);
   }
 };

--- a/e2e-test/lib/validateLogs.ts
+++ b/e2e-test/lib/validateLogs.ts
@@ -57,33 +57,33 @@ export async function validateEventLogs(
 }
 
 /**
- * Validate that the latest OracleInvocation on a script oracle confirms
+ * Validate that the latest ScriptInvocation on a script script confirms
  * a successful invocation. Uses the ML0 custom route:
- *   GET /data-application/v1/oracles/{fiberId}
+ *   GET /data-application/v1/scripts/{fiberId}
  *
- * The `lastInvocation` field on the oracle record contains the most recent
+ * The `lastInvocation` field on the script record contains the most recent
  * invocation result.
  */
-export async function validateOracleLogs(
+export async function validateScriptLogs(
   ctx: LogValidationContext,
   expectedMethod?: string
 ): Promise<void> {
   for (const ml0Url of ctx.ml0Urls) {
     const client = new HttpClient(
-      `${ml0Url}/data-application/v1/oracles/${ctx.fiberId}`
+      `${ml0Url}/data-application/v1/scripts/${ctx.fiberId}`
     );
 
-    const oracle = await client.get<Record<string, unknown>>('');
-    if (!oracle) {
+    const script = await client.get<Record<string, unknown>>('');
+    if (!script) {
       throw new Error(
-        `${TAG} Oracle not found for fiberId = ${ctx.fiberId} at ${ml0Url}`
+        `${TAG} Script not found for fiberId = ${ctx.fiberId} at ${ml0Url}`
       );
     }
 
-    const lastInvocation = oracle.lastInvocation as Record<string, unknown> | null;
+    const lastInvocation = script.lastInvocation as Record<string, unknown> | null;
     if (!lastInvocation) {
       throw new Error(
-        `${TAG} No lastInvocation found on oracle for fiberId = ${ctx.fiberId} at ${ml0Url}`
+        `${TAG} No lastInvocation found on script for fiberId = ${ctx.fiberId} at ${ml0Url}`
       );
     }
 
@@ -94,7 +94,7 @@ export async function validateOracleLogs(
     }
 
     console.log(
-      `${TAG}\x1b[32m Oracle invocation verified (method: ${lastInvocation.method}, result: ${JSON.stringify(lastInvocation.result)}) for fiberId = ${ctx.fiberId} at ${ml0Url}\x1b[0m`
+      `${TAG}\x1b[32m Script invocation verified (method: ${lastInvocation.method}, result: ${JSON.stringify(lastInvocation.result)}) for fiberId = ${ctx.fiberId} at ${ml0Url}\x1b[0m`
     );
   }
 }

--- a/e2e-test/runner.ts
+++ b/e2e-test/runner.ts
@@ -216,7 +216,7 @@ async function validateWithRetries(
 
 /**
  * Poll an ML0 endpoint until a condition is met.
- * Uses the ML0 custom routes (e.g. /v1/state-machines/{id}, /v1/oracles/{id}).
+ * Uses the ML0 custom routes (e.g. /v1/state-machines/{id}, /v1/scripts/{id}).
  */
 async function waitForMl0Confirmation(
   ml0BaseUrl: string,
@@ -340,7 +340,7 @@ interface Example {
   name: string;
   description: string;
   type: string;
-  oracleFiberId?: string;
+  scriptFiberId?: string;
   testFlows: TestFlow[];
   [key: string]: unknown;
 }
@@ -393,7 +393,7 @@ async function runFlow(
   const l = log ? (...a: unknown[]) => log.log(...a) : (...a: unknown[]) => console.log(...a);
   const session = {
     cid: crypto.randomUUID(),
-    oracleFiberId: null as string | null,
+    scriptFiberId: null as string | null,
   };
 
   for (let i = 0; i < flow.steps.length; i++) {
@@ -479,9 +479,9 @@ async function runFlow(
       };
 
       // Determine which fiber this step targets and fetch its current sequence number
-      // Script actions (createScript, invokeScript, invoke) use the /oracles/ endpoint
-      const isOracleStep =
-        (step.action as string).includes('Oracle') ||
+      // Script actions (createScript, invokeScript, invoke) use the /scripts/ endpoint
+      const isScriptStep =
+        (step.action as string).includes('Script') ||
         (step.action as string).includes('Script') ||
         step.action === 'invoke';
       const isCreateStep =
@@ -489,11 +489,11 @@ async function runFlow(
         step.action === 'createStateMachine' ||
         step.action === 'createScript';
 
-      // For createScript, oracleFiberId is assigned inside the switch below,
+      // For createScript, scriptFiberId is assigned inside the switch below,
       // so we defer activeCid/entityPath until after the switch for create steps.
-      let activeCid = isOracleStep ? session.oracleFiberId! : session.cid;
-      let entityPath = isOracleStep
-        ? `oracles/${activeCid}`
+      let activeCid = isScriptStep ? session.scriptFiberId! : session.cid;
+      let entityPath = isScriptStep
+        ? `scripts/${activeCid}`
         : `state-machines/${activeCid}`;
 
       let preSendSeqNum = -1;
@@ -538,19 +538,19 @@ async function runFlow(
         }
 
         case 'createScript': {
-          session.oracleFiberId = (example.oracleFiberId as string) || crypto.randomUUID();
+          session.scriptFiberId = (example.scriptFiberId as string) || crypto.randomUUID();
           const definition = await loadFileOrModule(
             path.join(examplesDir, example.dir, step.definition!),
             loadContext
           );
 
-          stepOptions = { oracleDefinition: definition };
+          stepOptions = { scriptDefinition: definition };
 
           const libModule = await import('./lib/script/createScript.ts');
           generator = libModule.generator;
           validator = libModule.validator;
           message = generator({
-            cid: session.oracleFiberId,
+            cid: session.scriptFiberId,
             wallets,
             options: stepOptions,
           });
@@ -610,7 +610,7 @@ async function runFlow(
           generator = libModule.generator;
           validator = libModule.validator;
           message = generator({
-            cid: session.oracleFiberId!,
+            cid: session.scriptFiberId!,
             wallets,
             options: stepOptions,
           });
@@ -649,11 +649,11 @@ async function runFlow(
       }
 
       // Re-compute activeCid/entityPath after the switch — createScript assigns
-      // session.oracleFiberId inside the switch, so the pre-switch values may be stale.
+      // session.scriptFiberId inside the switch, so the pre-switch values may be stale.
       if (isCreateStep) {
-        activeCid = isOracleStep ? session.oracleFiberId! : session.cid;
-        entityPath = isOracleStep
-          ? `oracles/${activeCid}`
+        activeCid = isScriptStep ? session.scriptFiberId! : session.cid;
+        entityPath = isScriptStep
+          ? `scripts/${activeCid}`
           : `state-machines/${activeCid}`;
       }
 

--- a/e2e-test/scripts/debug-tictactoe.ts
+++ b/e2e-test/scripts/debug-tictactoe.ts
@@ -1,6 +1,6 @@
 /**
  * Debug script for tic-tac-toe test flow.
- * Runs the first few steps manually and queries oracle + SM state between each.
+ * Runs the first few steps manually and queries script + SM state between each.
  */
 import 'dotenv/config';
 import crypto from 'crypto';
@@ -28,11 +28,11 @@ const wallets: Record<string, ReturnType<typeof generateWallet>> = {
 };
 
 const smCid = crypto.randomUUID();
-const oracleFiberId = crypto.randomUUID();
-const session = { cid: smCid, oracleFiberId };
+const scriptFiberId = crypto.randomUUID();
+const session = { cid: smCid, scriptFiberId };
 
 console.log(`SM CID: ${smCid}`);
-console.log(`Oracle CID: ${oracleFiberId}`);
+console.log(`Script CID: ${scriptFiberId}`);
 
 async function loadModule(file: string, context: Record<string, unknown> = {}) {
   const fullPath = path.join(examplesDir, file);
@@ -84,19 +84,19 @@ async function send(message: unknown) {
 async function main() {
   const loadContext = { wallets, session };
 
-  // Step 1: Create Oracle
-  console.log('\n=== Step 1: Create Oracle ===');
-  const oracleDef = await loadModule('script-definition.json');
+  // Step 1: Create Script
+  console.log('\n=== Step 1: Create Script ===');
+  const scriptDef = await loadModule('script-definition.json');
   const createScriptLib = await import('../lib/script/createScript.ts');
-  const oracleMsg = createScriptLib.generator({
-    cid: oracleFiberId,
+  const scriptMsg = createScriptLib.generator({
+    cid: scriptFiberId,
     wallets,
-    options: { oracleDefinition: oracleDef },
+    options: { scriptDefinition: scriptDef },
   });
-  console.log('Oracle message (first 300 chars):', JSON.stringify(oracleMsg).substring(0, 300));
-  await send(oracleMsg);
-  const oracleAfterCreate = await waitForSequence(`oracles/${oracleFiberId}`, 0, 'oracle create');
-  console.log('Oracle after create:', JSON.stringify(oracleAfterCreate, null, 2).substring(0, 500));
+  console.log('Script message (first 300 chars):', JSON.stringify(scriptMsg).substring(0, 300));
+  await send(scriptMsg);
+  const scriptAfterCreate = await waitForSequence(`scripts/${scriptFiberId}`, 0, 'script create');
+  console.log('Script after create:', JSON.stringify(scriptAfterCreate, null, 2).substring(0, 500));
 
   // Step 2: Create State Machine
   console.log('\n=== Step 2: Create State Machine ===');
@@ -137,12 +137,12 @@ async function main() {
   console.log('  lastReceipt:', JSON.stringify(smAfterStart.lastReceipt));
   console.log('  stateData:', JSON.stringify(smAfterStart.stateData));
 
-  // Check oracle state after start_game
-  const oracleAfterStart = await queryEntity(`oracles/${oracleFiberId}`) as Record<string, unknown>;
-  console.log('Oracle after start_game:');
-  console.log('  sequenceNumber:', oracleAfterStart?.sequenceNumber);
-  console.log('  stateData:', JSON.stringify((oracleAfterStart as any)?.stateData)?.substring(0, 500));
-  console.log('  lastInvocation:', JSON.stringify((oracleAfterStart as any)?.lastInvocation)?.substring(0, 500));
+  // Check script state after start_game
+  const scriptAfterStart = await queryEntity(`scripts/${scriptFiberId}`) as Record<string, unknown>;
+  console.log('Script after start_game:');
+  console.log('  sequenceNumber:', scriptAfterStart?.sequenceNumber);
+  console.log('  stateData:', JSON.stringify((scriptAfterStart as any)?.stateData)?.substring(0, 500));
+  console.log('  lastInvocation:', JSON.stringify((scriptAfterStart as any)?.lastInvocation)?.substring(0, 500));
 
   // Step 4: make_move X:0
   console.log('\n=== Step 4: make_move (X, cell 0) ===');
@@ -175,12 +175,12 @@ async function main() {
   console.log('  lastReceipt:', JSON.stringify(smAfterMove.lastReceipt));
   console.log('  stateData:', JSON.stringify(smAfterMove.stateData));
 
-  // Check oracle state after make_move
-  const oracleAfterMove = await queryEntity(`oracles/${oracleFiberId}`) as Record<string, unknown>;
-  console.log('Oracle after make_move:');
-  console.log('  sequenceNumber:', oracleAfterMove?.sequenceNumber);
-  console.log('  stateData:', JSON.stringify((oracleAfterMove as any)?.stateData));
-  console.log('  lastInvocation:', JSON.stringify((oracleAfterMove as any)?.lastInvocation));
+  // Check script state after make_move
+  const scriptAfterMove = await queryEntity(`scripts/${scriptFiberId}`) as Record<string, unknown>;
+  console.log('Script after make_move:');
+  console.log('  sequenceNumber:', scriptAfterMove?.sequenceNumber);
+  console.log('  stateData:', JSON.stringify((scriptAfterMove as any)?.stateData));
+  console.log('  lastInvocation:', JSON.stringify((scriptAfterMove as any)?.lastInvocation));
 }
 
 main().catch((err) => {

--- a/e2e-test/terminal.ts
+++ b/e2e-test/terminal.ts
@@ -18,7 +18,7 @@ const __dirname = path.dirname(__filename);
 const program = new Command()
   .name('ottochain-terminal')
   .description(
-    'Interactive CLI for testing Ottochain state machines and script oracles'
+    'Interactive CLI for testing Ottochain state machines and script scripts'
   )
   .option(
     '--address <address>',
@@ -248,29 +248,29 @@ stateMachineCmd
   });
 
 // ---------------------------------------------------------------------------
-// Oracle Commands
+// Script Commands
 // ---------------------------------------------------------------------------
 
-const oracleCmd = new Command('oracle')
+const scriptCmd = new Command('script')
   .alias('or')
-  .description('Manage script oracles');
+  .description('Manage script scripts');
 
-oracleCmd
+scriptCmd
   .command('create')
-  .description('Create a new script oracle')
-  .requiredOption('--oracle <path>', 'Path to oracle definition JSON file')
+  .description('Create a new script script')
+  .requiredOption('--script <path>', 'Path to script definition JSON file')
   .action(async (cmdOptions) => {
-    await executeCommand('oracle', 'create', cmdOptions);
+    await executeCommand('script', 'create', cmdOptions);
   });
 
-oracleCmd
+scriptCmd
   .command('invoke')
-  .description('Invoke a method on an existing script oracle')
+  .description('Invoke a method on an existing script script')
   .requiredOption('--method <name>', 'Method name to invoke')
   .option('--args <path>', 'Path to arguments JSON file')
   .option('--expectedResult <json>', 'Expected result (for validation)')
   .action(async (cmdOptions) => {
-    await executeCommand('oracle', 'invoke', cmdOptions);
+    await executeCommand('script', 'invoke', cmdOptions);
   });
 
 // ---------------------------------------------------------------------------
@@ -310,15 +310,15 @@ queryCmd
   });
 
 queryCmd
-  .command('oracles')
+  .command('scripts')
   .alias('or')
-  .description('List all oracles')
+  .description('List all scripts')
   .option('--node <number>', 'Node number (1, 2, or 3). Default: 1', '1')
   .option('--status <status>', 'Filter by status: [Active, Archived]')
-  .option('--oracleId <uuid>', 'Get specific oracle by ID')
-  .option('--invocations', 'Get invocation log (requires --oracleId)')
+  .option('--scriptId <uuid>', 'Get specific script by ID')
+  .option('--invocations', 'Get invocation log (requires --scriptId)')
   .action(async (cmdOptions) => {
-    await executeQuery('oracles', cmdOptions);
+    await executeQuery('scripts', cmdOptions);
   });
 
 async function executeQuery(
@@ -356,13 +356,13 @@ async function executeQuery(
           if (options.status) apiPath += `?status=${options.status}`;
         }
         break;
-      case 'oracles':
-        if (options.oracleId && options.invocations) {
-          apiPath = `/data-application/v1/oracles/${options.oracleId}/invocations`;
-        } else if (options.oracleId) {
-          apiPath = `/data-application/v1/oracles/${options.oracleId}`;
+      case 'scripts':
+        if (options.scriptId && options.invocations) {
+          apiPath = `/data-application/v1/scripts/${options.scriptId}/invocations`;
+        } else if (options.scriptId) {
+          apiPath = `/data-application/v1/scripts/${options.scriptId}`;
         } else {
-          apiPath = '/data-application/v1/oracles';
+          apiPath = '/data-application/v1/scripts';
           if (options.status) apiPath += `?status=${options.status}`;
         }
         break;
@@ -391,7 +391,7 @@ program
   .description('List available examples')
   .option(
     '--type <type>',
-    'Filter by type: [state-machines, oracles, all]',
+    'Filter by type: [state-machines, scripts, all]',
     'all'
   )
   .option('--example <name>', 'Show detailed info for a specific example')
@@ -467,7 +467,7 @@ program
     ).filter((e): e is Record<string, unknown> & { dir: string } => e !== null);
 
     const stateMachines = examples.filter((e) => e.type === 'state-machine');
-    const oracles = examples.filter((e) => e.type === 'oracle');
+    const scripts = examples.filter((e) => e.type === 'script');
     const combined = examples.filter((e) => e.type === 'combined');
 
     if (cmdOptions.type === 'all' || cmdOptions.type === 'state-machines') {
@@ -479,9 +479,9 @@ program
       console.log('');
     }
 
-    if (cmdOptions.type === 'all' || cmdOptions.type === 'oracles') {
-      console.log('\x1b[33mOracle Examples:\x1b[0m');
-      oracles.forEach((e) => {
+    if (cmdOptions.type === 'all' || cmdOptions.type === 'scripts') {
+      console.log('\x1b[33mScript Examples:\x1b[0m');
+      scripts.forEach((e) => {
         console.log(`  \x1b[36m${e.dir}\x1b[0m - ${e.name}`);
         console.log(`    ${e.description}`);
       });
@@ -489,7 +489,7 @@ program
     }
 
     if (cmdOptions.type === 'all' && combined.length > 0) {
-      console.log('\x1b[33mCombined Examples (Oracle + State Machine):\x1b[0m');
+      console.log('\x1b[33mCombined Examples (Script + State Machine):\x1b[0m');
       combined.forEach((e) => {
         console.log(`  \x1b[36m${e.dir}\x1b[0m - ${e.name}`);
         console.log(`    ${e.description}`);
@@ -535,7 +535,7 @@ async function executeCommand(
         processEvent: 'processEvent',
         archive: 'archiveFiber',
       },
-      oracle: {
+      script: {
         create: 'createScript',
         invoke: 'invokeScript',
       },
@@ -654,12 +654,12 @@ program
       console.log('\x1b[36m\n=== Ottochain Interactive Terminal ===\x1b[0m\n');
 
       const action = await question(
-        'What would you like to do?\n  1) Create state machine\n  2) Process event on state machine\n  3) Archive state machine\n  4) Create oracle\n  5) Invoke oracle\n  6) Query state\n\nChoice (1-6): '
+        'What would you like to do?\n  1) Create state machine\n  2) Process event on state machine\n  3) Archive state machine\n  4) Create script\n  5) Invoke script\n  6) Query state\n\nChoice (1-6): '
       );
 
       if (action === '6') {
         const queryType = await question(
-          '\nWhat would you like to query?\n  1) Checkpoint\n  2) Onchain state\n  3) All state machines\n  4) Specific state machine\n  5) All oracles\n  6) Specific oracle\n\nChoice (1-6): '
+          '\nWhat would you like to query?\n  1) Checkpoint\n  2) Onchain state\n  3) All state machines\n  4) Specific state machine\n  5) All scripts\n  6) Specific script\n\nChoice (1-6): '
         );
 
         const node =
@@ -698,15 +698,15 @@ program
             'Filter by status? (Active/Archived) [press enter for all]: '
           );
           cmdOptions.status = status || undefined;
-          await executeQuery('oracles', cmdOptions);
+          await executeQuery('scripts', cmdOptions);
         } else if (queryType === '6') {
-          const oracleId = await question('Enter oracle ID: ');
+          const scriptId = await question('Enter script ID: ');
           const showInvocations = await question(
             'Show invocation log? (y/n) [default: n]: '
           );
-          cmdOptions.oracleId = oracleId;
+          cmdOptions.scriptId = scriptId;
           cmdOptions.invocations = showInvocations.toLowerCase() === 'y';
-          await executeQuery('oracles', cmdOptions);
+          await executeQuery('scripts', cmdOptions);
         }
         return;
       }
@@ -829,10 +829,10 @@ program
         const fiberId = await question('\nEnter fiber ID to archive: ');
         cmdOptions.address = fiberId;
       } else if (action === '4') {
-        category = 'oracle';
+        category = 'script';
         operation = 'create';
 
-        const oracleExamples = fs
+        const scriptExamples = fs
           .readdirSync(examplesDir)
           .filter((dir) => {
             try {
@@ -841,14 +841,14 @@ program
               const example = JSON.parse(
                 fs.readFileSync(examplePath, 'utf8')
               );
-              return example.type === 'oracle';
+              return example.type === 'script';
             } catch {
               return false;
             }
           });
 
-        console.log('\n\x1b[33mAvailable oracle examples:\x1b[0m');
-        oracleExamples.forEach((dir, i) => {
+        console.log('\n\x1b[33mAvailable script examples:\x1b[0m');
+        scriptExamples.forEach((dir, i) => {
           const example = JSON.parse(
             fs.readFileSync(
               path.join(examplesDir, dir, 'example.json'),
@@ -863,16 +863,16 @@ program
         );
         const exampleDir = isNaN(Number(exampleChoice))
           ? exampleChoice
-          : oracleExamples[parseInt(exampleChoice) - 1];
-        cmdOptions.oracle = `examples/${exampleDir}/definition.json`;
+          : scriptExamples[parseInt(exampleChoice) - 1];
+        cmdOptions.script = `examples/${exampleDir}/definition.json`;
       } else if (action === '5') {
-        category = 'oracle';
+        category = 'script';
         operation = 'invoke';
 
-        const oracleId = await question('\nEnter oracle ID (CID): ');
-        cmdOptions.address = oracleId;
+        const scriptId = await question('\nEnter script ID (CID): ');
+        cmdOptions.address = scriptId;
 
-        const oracleExamples = fs
+        const scriptExamples = fs
           .readdirSync(examplesDir)
           .filter((dir) => {
             try {
@@ -881,14 +881,14 @@ program
               const example = JSON.parse(
                 fs.readFileSync(examplePath, 'utf8')
               );
-              return example.type === 'oracle';
+              return example.type === 'script';
             } catch {
               return false;
             }
           });
 
-        console.log('\n\x1b[33mSelect oracle example:\x1b[0m');
-        oracleExamples.forEach((dir, i) => {
+        console.log('\n\x1b[33mSelect script example:\x1b[0m');
+        scriptExamples.forEach((dir, i) => {
           const example = JSON.parse(
             fs.readFileSync(
               path.join(examplesDir, dir, 'example.json'),
@@ -903,7 +903,7 @@ program
         );
         const exampleDir = isNaN(Number(exampleChoice))
           ? exampleChoice
-          : oracleExamples[parseInt(exampleChoice) - 1];
+          : scriptExamples[parseInt(exampleChoice) - 1];
 
         const example = JSON.parse(
           fs.readFileSync(
@@ -1143,7 +1143,7 @@ Examples:
       // Session state to track CIDs between steps
       const session = {
         cid: (globalOpts.address as string) || crypto.randomUUID(),
-        oracleFiberId: null as string | null,
+        scriptFiberId: null as string | null,
       };
 
       for (let i = 0; i < flow.steps.length; i++) {
@@ -1199,8 +1199,8 @@ Examples:
           }
 
           case 'createScript': {
-            session.oracleFiberId =
-              (example.oracleFiberId as string) || crypto.randomUUID();
+            session.scriptFiberId =
+              (example.scriptFiberId as string) || crypto.randomUUID();
             const definition = await loadFileOrModule(
               path.join(
                 examplesDir,
@@ -1210,17 +1210,17 @@ Examples:
               loadContext
             );
 
-            stepOptions = { oracleDefinition: definition };
+            stepOptions = { scriptDefinition: definition };
 
             const libModule = await import('./lib/script/createScript.ts');
             generator = libModule.generator;
             validator = libModule.validator;
             message = generator({
-              cid: session.oracleFiberId,
+              cid: session.scriptFiberId,
               wallets,
               options: stepOptions,
             });
-            console.log(`   Oracle CID: ${session.oracleFiberId}`);
+            console.log(`   Script CID: ${session.scriptFiberId}`);
             break;
           }
 
@@ -1285,7 +1285,7 @@ Examples:
             generator = libModule.generator;
             validator = libModule.validator;
             message = generator({
-              cid: session.oracleFiberId,
+              cid: session.scriptFiberId,
               wallets,
               options: stepOptions,
             });
@@ -1305,12 +1305,12 @@ Examples:
           ...stepOptions!,
           expectedState: step.expectedState,
         };
-        const useOracleCid =
-          (step.action as string).includes('Oracle') ||
+        const useScriptCid =
+          (step.action as string).includes('Script') ||
           step.action === 'invoke';
         await validate(
           validator!,
-          useOracleCid ? session.oracleFiberId! : session.cid,
+          useScriptCid ? session.scriptFiberId! : session.cid,
           initialStates,
           validationOptions,
           wallets,
@@ -1324,8 +1324,8 @@ Examples:
 
       console.log('\x1b[32m\n✓ Flow completed successfully!\x1b[0m');
       console.log(`  State Machine CID: ${session.cid}`);
-      if (session.oracleFiberId) {
-        console.log(`  Oracle CID: ${session.oracleFiberId}`);
+      if (session.scriptFiberId) {
+        console.log(`  Script CID: ${session.scriptFiberId}`);
       }
       console.log('');
       process.exit(0);
@@ -1335,7 +1335,7 @@ Examples:
   });
 
 program.addCommand(stateMachineCmd);
-program.addCommand(oracleCmd);
+program.addCommand(scriptCmd);
 program.addCommand(queryCmd);
 program.addCommand(runCmd);
 

--- a/modules/l0/src/main/scala/xyz/kd5ujc/metagraph_l0/ML0Routes.scala
+++ b/modules/l0/src/main/scala/xyz/kd5ujc/metagraph_l0/ML0Routes.scala
@@ -58,10 +58,10 @@ class ML0Routes[F[_]: Async](
     case GET -> Root / "state-machines" / UUIDVar(id) / "state-proof" :? FieldQueryParam(field) =>
       stateProof.stateMachine(id, field)
 
-    // --- scripts (the legacy /oracles surface is retained) ---
-    case GET -> Root / "oracles" :? StatusQueryParam(status)    => script.list(status).toResponse
-    case GET -> Root / "oracles" / UUIDVar(id)                  => script.get(id).toResponse
-    case GET -> Root / "oracles" / UUIDVar(id) / "invocations"  => script.invocations(id).toResponse
+    // --- scripts ---
+    case GET -> Root / "scripts" :? StatusQueryParam(status)    => script.list(status).toResponse
+    case GET -> Root / "scripts" / UUIDVar(id)                  => script.get(id).toResponse
+    case GET -> Root / "scripts" / UUIDVar(id) / "invocations"  => script.invocations(id).toResponse
     case GET -> Root / "scripts" / UUIDVar(id) / "estimate-fee" => estimate.script(id).toResponse
     case GET -> Root / "scripts" / UUIDVar(id) / "state-proof" :? FieldQueryParam(field) =>
       stateProof.script(id, field)

--- a/modules/l0/src/main/scala/xyz/kd5ujc/metagraph_l0/handlers/ScriptHandler.scala
+++ b/modules/l0/src/main/scala/xyz/kd5ujc/metagraph_l0/handlers/ScriptHandler.scala
@@ -12,12 +12,12 @@ import io.constellationnetwork.metagraph_sdk.lifecycle.CheckpointService
 import io.constellationnetwork.metagraph_sdk.std.Checkpoint
 import io.constellationnetwork.metagraph_sdk.syntax.all.L0ContextOps
 
-import xyz.kd5ujc.schema.fiber.FiberLogEntry.OracleInvocation
+import xyz.kd5ujc.schema.fiber.FiberLogEntry.ScriptInvocation
 import xyz.kd5ujc.schema.fiber.FiberStatus
 import xyz.kd5ujc.schema.{CalculatedState, OnChain, Records}
 
 /**
- * Script-fiber logic (the legacy `/oracles` API surface is retained; "script" is the current term):
+ * Script-fiber logic backing the `/scripts` API surface:
  * list (optionally by status), single record, invocation log.
  */
 class ScriptHandler[F[_]: Async](
@@ -42,10 +42,10 @@ class ScriptHandler[F[_]: Async](
       state.scripts.get(scriptId).asRight[DataApplicationValidationError]
     }
 
-  def invocations(scriptId: UUID): F[Either[DataApplicationValidationError, List[OracleInvocation]]] =
+  def invocations(scriptId: UUID): F[Either[DataApplicationValidationError, List[ScriptInvocation]]] =
     context
       .getOnChainState[OnChain]
       .map(_.map { onChain =>
-        onChain.latestLogs.getOrElse(scriptId, List.empty).collect { case i: OracleInvocation => i }
+        onChain.latestLogs.getOrElse(scriptId, List.empty).collect { case i: ScriptInvocation => i }
       })
 }

--- a/modules/models/src/main/scala/xyz/kd5ujc/schema/Records.scala
+++ b/modules/models/src/main/scala/xyz/kd5ujc/schema/Records.scala
@@ -8,7 +8,7 @@ import io.constellationnetwork.schema.address.Address
 import io.constellationnetwork.security.hash.Hash
 
 import xyz.kd5ujc.schema.CodecConfiguration._
-import xyz.kd5ujc.schema.fiber.FiberLogEntry.{EventReceipt, OracleInvocation}
+import xyz.kd5ujc.schema.fiber.FiberLogEntry.{EventReceipt, ScriptInvocation}
 import xyz.kd5ujc.schema.fiber._
 import xyz.kd5ujc.schema.registry.SchemaBinding
 
@@ -58,7 +58,7 @@ object Records {
     sequenceNumber:      FiberOrdinal,
     owners:              Set[Address],
     status:              FiberStatus,
-    lastInvocation:      Option[OracleInvocation] = None,
+    lastInvocation:      Option[ScriptInvocation] = None,
     schemaBinding:       Option[SchemaBinding] = None
   ) extends FiberRecord
 }

--- a/modules/models/src/main/scala/xyz/kd5ujc/schema/fiber/AuditRenderer.scala
+++ b/modules/models/src/main/scala/xyz/kd5ujc/schema/fiber/AuditRenderer.scala
@@ -42,7 +42,7 @@ object AuditRenderer {
       val triggers = if (r.triggersFired > 0) s", ${r.triggersFired} trigger(s)" else ""
       s"[ord ${ord(r.ordinal)}] ${machine(r.fiberId, reverseNames)} '${r.eventName}' $outcome (gas ${r.gasUsed}$triggers)"
 
-    case i: FiberLogEntry.OracleInvocation =>
+    case i: FiberLogEntry.ScriptInvocation =>
       s"[ord ${ord(i.invokedAt)}] ${script(i.fiberId, reverseNames)} .${i.method}() by ${i.invokedBy.show} (gas ${i.gasUsed})"
 
     case r: FiberLogEntry.RejectionReceipt =>

--- a/modules/models/src/main/scala/xyz/kd5ujc/schema/fiber/FailureReason.scala
+++ b/modules/models/src/main/scala/xyz/kd5ujc/schema/fiber/FailureReason.scala
@@ -37,10 +37,10 @@ sealed trait FailureReason {
       s"Fiber $fiberId is not active (status: $status)"
     case FailureReason.DepthExceeded(depth, maxDepth) =>
       s"Trigger cascade depth exceeded: $depth (max: $maxDepth)"
-    case FailureReason.OracleInvocationFailed(oracleId, method, errorMsg) =>
-      s"Oracle $oracleId method '$method' failed${errorMsg.fold("")(e => s": $e")}"
-    case FailureReason.CallerResolutionFailed(oracleId, sourceId) =>
-      s"Unable to determine caller for oracle $oracleId${sourceId.fold("")(s => s" (source fiber: $s)")}"
+    case FailureReason.ScriptInvocationFailed(scriptId, method, errorMsg) =>
+      s"Script $scriptId method '$method' failed${errorMsg.fold("")(e => s": $e")}"
+    case FailureReason.CallerResolutionFailed(scriptId, sourceId) =>
+      s"Unable to determine caller for script $scriptId${sourceId.fold("")(s => s" (source fiber: $s)")}"
     case FailureReason.MissingProof(fiberId, operation) =>
       s"No signature proof provided for $operation on fiber $fiberId"
     case FailureReason.StateSizeTooLarge(actualBytes, maxBytes) =>
@@ -78,8 +78,8 @@ object FailureReason {
   case class FiberNotActive(fiberId: UUID, currentStatus: String) extends FailureReason
   case class DepthExceeded(depth: Int, maxDepth: Int) extends FailureReason
 
-  case class OracleInvocationFailed(oracleId: UUID, method: String, errorMessage: Option[String]) extends FailureReason
-  case class CallerResolutionFailed(targetOracleId: UUID, sourceFiberId: Option[UUID]) extends FailureReason
+  case class ScriptInvocationFailed(scriptId: UUID, method: String, errorMessage: Option[String]) extends FailureReason
+  case class CallerResolutionFailed(targetScriptId: UUID, sourceFiberId: Option[UUID]) extends FailureReason
   case class MissingProof(fiberId: UUID, operation: String) extends FailureReason
   case class StateSizeTooLarge(actualBytes: Int, maxBytes: Int) extends FailureReason
   case class InvalidChildIdFormat(expression: String, error: String) extends FailureReason

--- a/modules/models/src/main/scala/xyz/kd5ujc/schema/fiber/FiberEffect.scala
+++ b/modules/models/src/main/scala/xyz/kd5ujc/schema/fiber/FiberEffect.scala
@@ -3,7 +3,7 @@ package xyz.kd5ujc.schema.fiber
 /**
  * A side effect produced by evaluating a state-machine transition effect, represented as data.
  *
- * The fiber engine extracts these from an effect result's reserved keys (`_triggers`, `_oracleCall`,
+ * The fiber engine extracts these from an effect result's reserved keys (`_triggers`, `_scriptCall`,
  * `_spawn`, `_emit`) into a single ordered `List[FiberEffect]` rather than scraping each key into a
  * separate field. Representing effects as data is what lets the engine route them uniformly — e.g. a
  * `Triggered` whose target fiber lives in another shard can become a cross-shard message instead of an
@@ -13,7 +13,7 @@ sealed trait FiberEffect
 
 object FiberEffect {
 
-  /** A cross-fiber trigger. Covers both `_triggers` and `_oracleCall` (both target a fiber by id). */
+  /** A cross-fiber trigger. Covers both `_triggers` and `_scriptCall` (both target a fiber by id). */
   final case class Triggered(trigger: FiberTrigger) extends FiberEffect
 
   /** A child state machine to spawn (`_spawn`). */

--- a/modules/models/src/main/scala/xyz/kd5ujc/schema/fiber/FiberInput.scala
+++ b/modules/models/src/main/scala/xyz/kd5ujc/schema/fiber/FiberInput.scala
@@ -5,7 +5,7 @@ import io.constellationnetwork.schema.address.Address
 
 /**
  * Unified input for fiber processing.
- * Supports both state machine transitions and oracle method calls.
+ * Supports both state machine transitions and script method calls.
  */
 sealed trait FiberInput {
   val key: String
@@ -29,7 +29,7 @@ object FiberInput {
   }
 
   /**
-   * Oracle method call input.
+   * Script method call input.
    *
    * @param method Method name to invoke
    * @param args Arguments for the method

--- a/modules/models/src/main/scala/xyz/kd5ujc/schema/fiber/FiberLogEntry.scala
+++ b/modules/models/src/main/scala/xyz/kd5ujc/schema/fiber/FiberLogEntry.scala
@@ -18,7 +18,7 @@ import derevo.derive
  * Supertype for log entries emitted by fibers.
  *
  * State machines emit EventReceipt entries.
- * Script oracles emit OracleInvocation entries.
+ * Scripts emit ScriptInvocation entries.
  *
  * These are collected per-ordinal in OnChain.latestLogs for external signaling.
  */
@@ -91,7 +91,7 @@ object FiberLogEntry {
   }
 
   @derive(customizableEncoder, customizableDecoder)
-  final case class OracleInvocation(
+  final case class ScriptInvocation(
     fiberId:   UUID,
     method:    String,
     args:      JsonLogicValue,

--- a/modules/models/src/main/scala/xyz/kd5ujc/schema/fiber/FiberResult.scala
+++ b/modules/models/src/main/scala/xyz/kd5ujc/schema/fiber/FiberResult.scala
@@ -19,10 +19,10 @@ object FiberResult {
    * Gas is tracked via StateT (ExecutionState) — not carried in this result.
    *
    * @param newStateData Updated state data
-   * @param newStateId New state ID (Some for state machines, None for oracles)
+   * @param newStateId New state ID (Some for state machines, None for scripts)
    * @param triggers Triggered events for other fibers
    * @param spawns Child fibers to create (state machines only)
-   * @param returnValue Return value (Some for oracles, None for state machines)
+   * @param returnValue Return value (Some for scripts, None for state machines)
    */
   final case class Success(
     newStateData:  JsonLogicValue,

--- a/modules/models/src/main/scala/xyz/kd5ujc/schema/fiber/FiberTrigger.scala
+++ b/modules/models/src/main/scala/xyz/kd5ujc/schema/fiber/FiberTrigger.scala
@@ -7,7 +7,7 @@ import java.util.UUID
  *
  * @param targetFiberId The fiber to trigger
  * @param input The input to send to the fiber
- * @param sourceFiberId The fiber that initiated this trigger (for oracle access control)
+ * @param sourceFiberId The fiber that initiated this trigger (for script access control)
  */
 final case class FiberTrigger(
   targetFiberId: UUID,

--- a/modules/models/src/main/scala/xyz/kd5ujc/schema/fiber/GasExhaustionPhase.scala
+++ b/modules/models/src/main/scala/xyz/kd5ujc/schema/fiber/GasExhaustionPhase.scala
@@ -11,7 +11,7 @@ object GasExhaustionPhase extends Enum[GasExhaustionPhase] with CirceEnum[GasExh
 
   case object Guard extends GasExhaustionPhase
   case object Effect extends GasExhaustionPhase
-  case object Oracle extends GasExhaustionPhase
+  case object Script extends GasExhaustionPhase
   case object Trigger extends GasExhaustionPhase
   case object Spawn extends GasExhaustionPhase
   case object Migration extends GasExhaustionPhase

--- a/modules/models/src/main/scala/xyz/kd5ujc/schema/fiber/ReservedKeys.scala
+++ b/modules/models/src/main/scala/xyz/kd5ujc/schema/fiber/ReservedKeys.scala
@@ -11,19 +11,19 @@ object ReservedKeys {
   // Effect Result Keys - Used in extracting side effects from transition results
   val TRIGGERS = "_triggers"
   val SPAWN = "_spawn"
-  val ORACLE_CALL = "_oracleCall"
+  val SCRIPT_CALL = "_scriptCall"
   val EMIT = "_emit"
 
-  // Oracle Return Convention Keys - Used in extractStateAndResult for oracle results
-  val ORACLE_STATE = "_state"
-  val ORACLE_RESULT = "_result"
+  // Script Return Convention Keys - Used in extractStateAndResult for script results
+  val SCRIPT_STATE = "_state"
+  val SCRIPT_RESULT = "_result"
 
   // Trigger Event Keys - Used in extractTriggerEvents for cross-machine event firing
   val TARGET_MACHINE_ID = "targetMachineId"
   val EVENT_NAME = "eventName"
   val PAYLOAD = "payload"
 
-  // Oracle Call Keys - Used in extractOracleCall for oracle invocation
+  // Script Call Keys - Used in extractScriptCall for script invocation
   val FIBER_ID = "fiberId"
   val METHOD = "method"
   val ARGS = "args"
@@ -68,14 +68,14 @@ object ReservedKeys {
   val MACHINES = "machines"
   val PARENT = "parent"
   val CHILDREN = "children"
-  val SCRIPT_ORACLES = "scripts"
+  val SCRIPTS = "scripts"
 
   // Emitted Event Keys - Used in parseEmittedEvent for user-defined event emission
   val NAME = "name"
   val DATA = "data"
   val DESTINATION = "destination"
 
-  // Oracle Invocation Log Keys
+  // Script Invocation Log Keys
   val RESULT = "result"
   val GAS_USED = "gasUsed"
   val INVOKED_AT = "invokedAt"

--- a/modules/models/src/main/scala/xyz/kd5ujc/schema/fiber/TransactionResult.scala
+++ b/modules/models/src/main/scala/xyz/kd5ujc/schema/fiber/TransactionResult.scala
@@ -16,7 +16,7 @@ object TransactionResult {
    * All state changes should be persisted.
    *
    * @param updatedStateMachines State machines modified during transaction
-   * @param updatedOracles Oracles modified during transaction
+   * @param updatedScripts Scripts modified during transaction
    * @param logEntries Log entries (receipts + invocations) for each fiber touched during transaction
    * @param totalGasUsed Total gas consumed by all operations
    * @param maxDepth Maximum trigger chain depth reached
@@ -24,7 +24,7 @@ object TransactionResult {
    */
   final case class Committed(
     updatedStateMachines: Map[UUID, Records.StateMachineFiberRecord],
-    updatedOracles:       Map[UUID, Records.ScriptFiberRecord],
+    updatedScripts:       Map[UUID, Records.ScriptFiberRecord],
     logEntries:           List[FiberLogEntry],
     totalGasUsed:         Long,
     maxDepth:             Int = 0,

--- a/modules/models/src/main/scala/xyz/kd5ujc/schema/registry/NameTld.scala
+++ b/modules/models/src/main/scala/xyz/kd5ujc/schema/registry/NameTld.scala
@@ -9,7 +9,7 @@ import enumeratum.{CirceEnum, Enum, EnumEntry}
  *
  *  - `.package` — a versioned schema/program package (its [[VersionLineage]]).
  *  - `.machine` — an alias (nickname) for a state-machine fiber.
- *  - `.script`  — an alias (nickname) for a script/oracle fiber.
+ *  - `.script`  — an alias (nickname) for a script fiber.
  *
  * Putting the TLD in the key lets a package and a fiber alias share label text under different TLDs
  * (`escrow.package` vs `escrow.machine`). See docs/proposals/naming-and-fingerprints.md §3.

--- a/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/fiber/FiberEngine.scala
+++ b/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/fiber/FiberEngine.scala
@@ -17,7 +17,7 @@ import io.constellationnetwork.security.SecurityProvider
 import io.constellationnetwork.security.hash.Hash
 import io.constellationnetwork.security.signature.signature.SignatureProof
 
-import xyz.kd5ujc.schema.fiber.FiberLogEntry.{EventReceipt, OracleInvocation, UpgradeReceipt}
+import xyz.kd5ujc.schema.fiber.FiberLogEntry.{EventReceipt, ScriptInvocation, UpgradeReceipt}
 import xyz.kd5ujc.schema.fiber._
 import xyz.kd5ujc.schema.registry.SchemaBinding
 import xyz.kd5ujc.schema.{CalculatedState, Records}
@@ -37,7 +37,7 @@ import xyz.kd5ujc.shared_data.syntax.calculatedState._
  * Processing flow:
  * 1. Create FiberContext with ordinal, limits, gas config
  * 2. Lookup fiber by ID and validate it's active
- * 3. Evaluate fiber (guards/effects for SM, script for Oracle)
+ * 3. Evaluate fiber (guards/effects for SM, script for Script)
  * 4. On success:
  *    a. Validate and process spawns (creates child fibers)
  *    b. Build effective state with spawns visible to triggers
@@ -208,7 +208,7 @@ object FiberEngine {
               logs <- ExecutionOps.getLogs[FiberT[F, *]]
             } yield TransactionResult.Committed(
               updatedStateMachines = Map.empty,
-              updatedOracles = Map(script.fiberId -> updated),
+              updatedScripts = Map(script.fiberId -> updated),
               logEntries = logs.toList,
               totalGasUsed = gasUsed
             ): TransactionResult
@@ -236,7 +236,7 @@ object FiberEngine {
               logs <- ExecutionOps.getLogs[FiberT[F, *]]
             } yield TransactionResult.Committed(
               updatedStateMachines = Map.empty,
-              updatedOracles = Map(script.fiberId -> updated),
+              updatedScripts = Map(script.fiberId -> updated),
               logEntries = logs.toList,
               totalGasUsed = gasUsed
             ): TransactionResult
@@ -291,7 +291,7 @@ object FiberEngine {
                   logs <- ExecutionOps.getLogs[FiberT[F, *]]
                 } yield TransactionResult.Committed(
                   updatedStateMachines = Map(sm.fiberId -> updated),
-                  updatedOracles = Map.empty,
+                  updatedScripts = Map.empty,
                   logEntries = logs.toList,
                   totalGasUsed = gasUsed
                 ): TransactionResult
@@ -351,8 +351,8 @@ object FiberEngine {
                 case sm: Records.StateMachineFiberRecord =>
                   processStateMachineSuccess(sm, input, newStateData, newStateId, fiberTriggers, spawns, emittedEvents)
 
-                case oracle: Records.ScriptFiberRecord =>
-                  processOracleSuccess(oracle, input, newStateData, returnValue)
+                case script: Records.ScriptFiberRecord =>
+                  processScriptSuccess(script, input, newStateData, returnValue)
               }
 
             case FiberResult.GuardFailed(attemptedCount) =>
@@ -522,7 +522,7 @@ object FiberEngine {
           val allMachines = Map(primaryFiberId -> updatedFiber) ++ spawnedFibers.map(f => f.fiberId -> f).toMap
           TransactionResult.Committed(
             updatedStateMachines = allMachines,
-            updatedOracles = Map.empty,
+            updatedScripts = Map.empty,
             logEntries = logEntries.toList,
             totalGasUsed = gasUsed,
             maxDepth = depth
@@ -539,12 +539,12 @@ object FiberEngine {
           .make[F, FiberT[F, *]]
           .dispatch(triggers, stateWithSpawns)
           .flatMap {
-            case TransactionResult.Committed(machines, oracles, _, totalGas, maxDepth, opCount) =>
+            case TransactionResult.Committed(machines, scripts, _, totalGas, maxDepth, opCount) =>
               ExecutionOps.getLogs[FiberT[F, *]].map { logs =>
                 val allMachines = spawnedFibers.map(f => f.fiberId -> f).toMap ++ machines
                 TransactionResult.Committed(
                   updatedStateMachines = allMachines,
-                  updatedOracles = oracles,
+                  updatedScripts = scripts,
                   logEntries = logs.toList,
                   totalGasUsed = totalGas,
                   maxDepth = maxDepth,
@@ -556,8 +556,8 @@ object FiberEngine {
               (aborted: TransactionResult).pureFiber[F]
           }
 
-      private def processOracleSuccess(
-        oracle:       Records.ScriptFiberRecord,
+      private def processScriptSuccess(
+        script:       Records.ScriptFiberRecord,
         input:        FiberInput,
         newStateData: JsonLogicValue,
         returnValue:  Option[JsonLogicValue]
@@ -575,14 +575,14 @@ object FiberEngine {
               Async[F]
                 .raiseError[(String, JsonLogicValue, Address)](
                   new RuntimeException(
-                    s"Oracle ${oracle.fiberId} received Transition input (event: ${et}). Oracles only support MethodCall input."
+                    s"Script ${script.fiberId} received Transition input (event: ${et}). Scripts only support MethodCall input."
                   )
                 )
                 .liftFiber
           }
 
-          invocation = OracleInvocation(
-            fiberId = oracle.fiberId,
+          invocation = ScriptInvocation(
+            fiberId = script.fiberId,
             method = method,
             args = args,
             result = returnValue.getOrElse(NullValue),
@@ -594,16 +594,16 @@ object FiberEngine {
           _          <- ExecutionOps.appendLog[FiberT[F, *]](invocation)
           logEntries <- ExecutionOps.getLogs[FiberT[F, *]]
 
-          updatedOracle = oracle.copy(
+          updatedScript = script.copy(
             stateData = Some(newStateData),
             stateDataHash = newHash,
             latestUpdateOrdinal = ordinal,
-            sequenceNumber = oracle.sequenceNumber.next,
+            sequenceNumber = script.sequenceNumber.next,
             lastInvocation = Some(invocation)
           )
         } yield TransactionResult.Committed(
           updatedStateMachines = Map.empty,
-          updatedOracles = Map(oracle.fiberId -> updatedOracle),
+          updatedScripts = Map(script.fiberId -> updatedScript),
           logEntries = logEntries.toList,
           totalGasUsed = gasUsed,
           maxDepth = depth

--- a/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/fiber/core/ContextProvider.scala
+++ b/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/fiber/core/ContextProvider.scala
@@ -13,7 +13,7 @@ import io.constellationnetwork.security.SecurityProvider
 import io.constellationnetwork.security.hash.Hash
 import io.constellationnetwork.security.signature.signature.SignatureProof
 
-import xyz.kd5ujc.schema.fiber.FiberLogEntry.OracleInvocation
+import xyz.kd5ujc.schema.fiber.FiberLogEntry.ScriptInvocation
 import xyz.kd5ujc.schema.fiber.{FiberInput, ReservedKeys}
 import xyz.kd5ujc.schema.{CalculatedState, Records}
 
@@ -31,12 +31,12 @@ import xyz.kd5ujc.schema.{CalculatedState, Records}
  * - parent: parent fiber data (if any)
  * - children: child fiber data
  * - machines: dependent machine states
- * - scripts: dependent oracle states
+ * - scripts: dependent script states
  *
- * For oracles, context includes:
+ * For scripts, context includes:
  * - _method: method name
  * - _args: method arguments
- * - _state: current oracle state
+ * - _state: current script state
  */
 trait ContextProvider[F[_]] {
 
@@ -94,10 +94,10 @@ object ContextProvider {
               Async[F].raiseError(new RuntimeException("Cannot use MethodCall input with StateMachineFiberRecord"))
           }
 
-        case oracle: Records.ScriptFiberRecord =>
+        case script: Records.ScriptFiberRecord =>
           input match {
             case _: FiberInput.MethodCall =>
-              buildOracleContext(oracle, input.key, input.content)
+              buildScriptContext(script, input.key, input.content)
             case _: FiberInput.Transition =>
               Async[F].raiseError(new RuntimeException("Cannot use Transition input with ScriptFiberRecord"))
           }
@@ -117,7 +117,7 @@ object ContextProvider {
           machinesData <- buildMachinesContext(dependencies)
           parentData   <- buildParentContext(fiber)
           childrenData <- buildChildrenContext(fiber)
-          oraclesData  <- buildOraclesContext(dependencies)
+          scriptsData  <- buildScriptsContext(dependencies)
         } yield MapValue(
           Map(
             ReservedKeys.STATE              -> fiber.stateData,
@@ -133,14 +133,14 @@ object ContextProvider {
             ReservedKeys.MACHINES           -> machinesData,
             ReservedKeys.PARENT             -> parentData,
             ReservedKeys.CHILDREN           -> childrenData,
-            ReservedKeys.SCRIPT_ORACLES     -> oraclesData
+            ReservedKeys.SCRIPTS            -> scriptsData
           )
         )
 
-      // === Oracle Context ===
+      // === Script Context ===
 
-      private def buildOracleContext(
-        oracle: Records.ScriptFiberRecord,
+      private def buildScriptContext(
+        script: Records.ScriptFiberRecord,
         method: String,
         args:   JsonLogicValue
       ): F[JsonLogicValue] =
@@ -148,7 +148,7 @@ object ContextProvider {
           Map(
             ReservedKeys.METHOD -> StrValue(method),
             ReservedKeys.ARGS   -> args,
-            ReservedKeys.STATE  -> oracle.stateData.getOrElse(NullValue)
+            ReservedKeys.STATE  -> script.stateData.getOrElse(NullValue)
           )
         ).pure[F]
 
@@ -235,8 +235,8 @@ object ContextProvider {
           (f: Records.StateMachineFiberRecord) => buildFiberSummary(f)
         )
 
-      private def buildOraclesContext(dependencies: Set[UUID]): F[MapValue] =
-        resolveFibers(dependencies, calculatedState.scripts.get, buildOracleSummary)
+      private def buildScriptsContext(dependencies: Set[UUID]): F[MapValue] =
+        resolveFibers(dependencies, calculatedState.scripts.get, buildScriptSummary)
 
       // === Summary Builders (reused across contexts) ===
 
@@ -255,17 +255,17 @@ object ContextProvider {
         MapValue(fullMap)
       }
 
-      private def buildOracleSummary(oracle: Records.ScriptFiberRecord): MapValue =
+      private def buildScriptSummary(script: Records.ScriptFiberRecord): MapValue =
         MapValue(
           Map(
-            ReservedKeys.STATE           -> oracle.stateData.getOrElse(NullValue),
-            ReservedKeys.STATUS          -> StrValue(oracle.status.toString),
-            ReservedKeys.SEQUENCE_NUMBER -> IntValue(oracle.sequenceNumber.value.value),
-            ReservedKeys.LAST_INVOCATION -> oracle.lastInvocation.map(buildInvocationSummary).getOrElse(NullValue)
+            ReservedKeys.STATE           -> script.stateData.getOrElse(NullValue),
+            ReservedKeys.STATUS          -> StrValue(script.status.toString),
+            ReservedKeys.SEQUENCE_NUMBER -> IntValue(script.sequenceNumber.value.value),
+            ReservedKeys.LAST_INVOCATION -> script.lastInvocation.map(buildInvocationSummary).getOrElse(NullValue)
           )
         )
 
-      private def buildInvocationSummary(inv: OracleInvocation): MapValue =
+      private def buildInvocationSummary(inv: ScriptInvocation): MapValue =
         MapValue(
           Map(
             ReservedKeys.METHOD     -> StrValue(inv.method),

--- a/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/fiber/core/MeteredEvaluator.scala
+++ b/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/fiber/core/MeteredEvaluator.scala
@@ -34,7 +34,7 @@ object MeteredEvaluator {
   /**
    * Evaluate `expr` against `context`, charging consumed gas on success.
    *
-   * @param phase the gas-exhaustion phase to attribute a failure to (Guard | Effect | Oracle | Trigger | Spawn)
+   * @param phase the gas-exhaustion phase to attribute a failure to (Guard | Effect | Script | Trigger | Spawn)
    * @return Right(value) with gas already charged, or Left(reason) on evaluation failure (no gas charged)
    */
   def eval[F[_]: Async, G[_]: Monad](

--- a/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/fiber/evaluation/EffectExtractor.scala
+++ b/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/fiber/evaluation/EffectExtractor.scala
@@ -19,7 +19,7 @@ import xyz.kd5ujc.shared_data.fiber.core._
  *
  * Effect results can contain special keys that signal side effects:
  * - _triggers: Cross-machine event triggers
- * - _oracleCall: Oracle invocation
+ * - _scriptCall: Script invocation
  * - _outputs: External system outputs
  * - _spawn: Child machine creation
  *
@@ -56,10 +56,10 @@ object EffectExtractor {
 
   /**
    * Extract ALL side effects from a transition's effect result + expression as a single ordered list
-   * of typed [[FiberEffect]]s. `_triggers` and `_oracleCall` become `Triggered`; `_spawn` directives
+   * of typed [[FiberEffect]]s. `_triggers` and `_scriptCall` become `Triggered`; `_spawn` directives
    * become `Spawned`; `_emit` events become `Emitted`.
    *
-   * Order matches the prior per-key extraction (triggers, then oracle call, then spawns, then emitted),
+   * Order matches the prior per-key extraction (triggers, then script call, then spawns, then emitted),
    * and gas for payload/args evaluation is charged in that order via [[MeteredEvaluator]].
    */
   def extractEffects[F[_]: Async, G[_]: Monad](
@@ -70,11 +70,11 @@ object EffectExtractor {
   )(implicit S: Stateful[G, ExecutionState], A: Ask[G, FiberContext], lift: F ~> G): G[List[FiberEffect]] =
     for {
       triggers   <- extractTriggerEvents[F, G](effectResult, contextData, sourceFiberId)
-      oracleCall <- extractOracleCall[F, G](effectResult, contextData, sourceFiberId)
+      scriptCall <- extractScriptCall[F, G](effectResult, contextData, sourceFiberId)
     } yield {
       val spawns = extractSpawnDirectivesFromExpression(effectExpr)
       val emitted = extractEmittedEvents(effectResult)
-      (triggers ++ oracleCall.toList).map(FiberEffect.Triggered) ++
+      (triggers ++ scriptCall.toList).map(FiberEffect.Triggered) ++
       spawns.map(FiberEffect.Spawned) ++
       emitted.map(FiberEffect.Emitted)
     }
@@ -130,28 +130,28 @@ object EffectExtractor {
     }
 
   /**
-   * Extract oracle call with gas metering via StateT.
+   * Extract script call with gas metering via StateT.
    *
    * Gas is charged to the execution state automatically via Stateful.
    * Gas limit and config are read from FiberContext via Ask.
    *
-   * @param effectResult  The result from effect evaluation containing oracle call definition
+   * @param effectResult  The result from effect evaluation containing script call definition
    * @param contextData   Context data for evaluating args expressions
-   * @param sourceFiberId The fiber that is making this oracle call
-   * @return Optional oracle trigger (gas charged via state)
+   * @param sourceFiberId The fiber that is making this script call
+   * @return Optional script trigger (gas charged via state)
    */
-  def extractOracleCall[F[_]: Async, G[_]: Monad](
+  def extractScriptCall[F[_]: Async, G[_]: Monad](
     effectResult:  JsonLogicValue,
     contextData:   JsonLogicValue,
     sourceFiberId: UUID
   )(implicit S: Stateful[G, ExecutionState], A: Ask[G, FiberContext], lift: F ~> G): G[Option[FiberTrigger]] =
-    extractByKey(effectResult, ReservedKeys.ORACLE_CALL) match {
-      case Some(MapValue(oracleCallMap)) =>
+    extractByKey(effectResult, ReservedKeys.SCRIPT_CALL) match {
+      case Some(MapValue(scriptCallMap)) =>
         (for {
-          cidStr <- OptionT.fromOption[G](oracleCallMap.get(ReservedKeys.FIBER_ID).collect { case StrValue(id) => id })
+          cidStr <- OptionT.fromOption[G](scriptCallMap.get(ReservedKeys.FIBER_ID).collect { case StrValue(id) => id })
           targetId  <- OptionT.fromOption[G](scala.util.Try(UUID.fromString(cidStr)).toOption)
-          method    <- OptionT.fromOption[G](oracleCallMap.get(ReservedKeys.METHOD).collect { case StrValue(m) => m })
-          argsValue <- OptionT.fromOption[G](oracleCallMap.get(ReservedKeys.ARGS))
+          method    <- OptionT.fromOption[G](scriptCallMap.get(ReservedKeys.METHOD).collect { case StrValue(m) => m })
+          argsValue <- OptionT.fromOption[G](scriptCallMap.get(ReservedKeys.ARGS))
           argsExpr = ExpressionParser.valueToExpression(argsValue)
           evaluatedArgs <- OptionT(MeteredEvaluator.evalOpt[F, G](argsExpr, contextData, GasExhaustionPhase.Trigger))
         } yield FiberTrigger(

--- a/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/fiber/evaluation/FiberEvaluator.scala
+++ b/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/fiber/evaluation/FiberEvaluator.scala
@@ -22,7 +22,7 @@ import xyz.kd5ujc.shared_data.fiber.core._
 import xyz.kd5ujc.shared_data.syntax.all._
 
 /**
- * Unified evaluator for both state machine and oracle fibers.
+ * Unified evaluator for both state machine and script fibers.
  *
  * Operates in G[_] with Stateful[G, ExecutionState] for consistent gas tracking via StateT.
  *
@@ -30,7 +30,7 @@ import xyz.kd5ujc.shared_data.syntax.all._
  * - StateMachineFiberRecord + Transition → guard/effect evaluation
  * - ScriptFiberRecord + MethodCall → script evaluation
  *
- * Invalid combinations (SM + MethodCall, Oracle + Transition) return Failed.
+ * Invalid combinations (SM + MethodCall, Script + Transition) return Failed.
  */
 trait FiberEvaluator[G[_]] {
 
@@ -65,17 +65,17 @@ object FiberEvaluator {
         case (sm: Records.StateMachineFiberRecord, FiberInput.Transition(eventType, payload)) =>
           evaluateStateMachine(sm, eventType, payload, proofs)
 
-        case (oracle: Records.ScriptFiberRecord, FiberInput.MethodCall(method, args, caller)) =>
-          evaluateOracle(oracle, method, args, caller)
+        case (script: Records.ScriptFiberRecord, FiberInput.MethodCall(method, args, caller)) =>
+          evaluateScript(script, method, args, caller)
 
         case (sm: Records.StateMachineFiberRecord, _: FiberInput.MethodCall) =>
           FailureReason
             .FiberInputMismatch(sm.fiberId, FiberKind.StateMachine, InputKind.MethodCall)
             .pureOutcome[G]
 
-        case (oracle: Records.ScriptFiberRecord, _: FiberInput.Transition) =>
+        case (script: Records.ScriptFiberRecord, _: FiberInput.Transition) =>
           FailureReason
-            .FiberInputMismatch(oracle.fiberId, FiberKind.Script, InputKind.Transition)
+            .FiberInputMismatch(script.fiberId, FiberKind.Script, InputKind.Transition)
             .pureOutcome[G]
       }
 
@@ -275,18 +275,18 @@ object FiberEvaluator {
         } yield result
 
       // ──────────────────────────────────────────────────────────────────────────
-      // Oracle Evaluation
+      // Script Evaluation
       // ──────────────────────────────────────────────────────────────────────────
 
-      private def evaluateOracle(
-        oracle: Records.ScriptFiberRecord,
+      private def evaluateScript(
+        script: Records.ScriptFiberRecord,
         method: String,
         args:   JsonLogicValue,
         caller: io.constellationnetwork.schema.address.Address
       ): G[FiberResult] =
         for {
           result <- ScriptProcessor
-            .validateAccess[F](oracle.accessControl, caller, oracle.fiberId, calculatedState)
+            .validateAccess[F](script.accessControl, caller, script.fiberId, calculatedState)
             .liftTo[G]
             .flatMap {
               case Left(reason) => reason.pureOutcome[G]
@@ -296,17 +296,17 @@ object FiberEvaluator {
                   Map(
                     ReservedKeys.METHOD -> StrValue(method),
                     ReservedKeys.ARGS   -> args,
-                    ReservedKeys.STATE  -> oracle.stateData.getOrElse(NullValue)
+                    ReservedKeys.STATE  -> script.stateData.getOrElse(NullValue)
                   )
                 )
 
-                MeteredEvaluator.eval[F, G](oracle.scriptProgram, inputData, GasExhaustionPhase.Oracle).flatMap {
+                MeteredEvaluator.eval[F, G](script.scriptProgram, inputData, GasExhaustionPhase.Script).flatMap {
                   case Right(evaluationResult) =>
                     for {
                       stateAndResult <- ScriptProcessor.extractStateAndResult[F](evaluationResult).liftTo[G]
                       (newStateData, returnValue) = stateAndResult
                     } yield FiberResult.Success(
-                      newStateData = newStateData.getOrElse(oracle.stateData.getOrElse(NullValue)),
+                      newStateData = newStateData.getOrElse(script.stateData.getOrElse(NullValue)),
                       newStateId = None,
                       triggers = List.empty,
                       spawns = List.empty,

--- a/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/fiber/evaluation/ScriptProcessor.scala
+++ b/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/fiber/evaluation/ScriptProcessor.scala
@@ -25,16 +25,16 @@ object ScriptProcessor {
     evaluationResult: JsonLogicValue
   ): F[(Option[JsonLogicValue], JsonLogicValue)] =
     evaluationResult match {
-      case MapValue(m) if m.contains(ReservedKeys.ORACLE_STATE) && m.contains(ReservedKeys.ORACLE_RESULT) =>
-        (m.get(ReservedKeys.ORACLE_STATE), m.getOrElse(ReservedKeys.ORACLE_RESULT, NullValue)).pure[F]
+      case MapValue(m) if m.contains(ReservedKeys.SCRIPT_STATE) && m.contains(ReservedKeys.SCRIPT_RESULT) =>
+        (m.get(ReservedKeys.SCRIPT_STATE), m.getOrElse(ReservedKeys.SCRIPT_RESULT, NullValue)).pure[F]
 
-      case MapValue(m) if m.contains(ReservedKeys.ORACLE_STATE) =>
-        (m.get(ReservedKeys.ORACLE_STATE), evaluationResult).pure[F]
+      case MapValue(m) if m.contains(ReservedKeys.SCRIPT_STATE) =>
+        (m.get(ReservedKeys.SCRIPT_STATE), evaluationResult).pure[F]
 
-      case MapValue(m) if m.contains(ReservedKeys.ORACLE_RESULT) =>
+      case MapValue(m) if m.contains(ReservedKeys.SCRIPT_RESULT) =>
         (
           Option.empty[JsonLogicValue],
-          m.getOrElse(ReservedKeys.ORACLE_RESULT, NullValue)
+          m.getOrElse(ReservedKeys.SCRIPT_RESULT, NullValue)
         ).pure[F]
 
       case other =>
@@ -51,7 +51,7 @@ object ScriptProcessor {
 
     stateDataHashOpt <- update.initialState.traverse[F, Hash](_.computeDigest)
 
-    oracleRecord = Records.ScriptFiberRecord(
+    scriptRecord = Records.ScriptFiberRecord(
       fiberId = update.fiberId,
       creationOrdinal = currentOrdinal,
       latestUpdateOrdinal = currentOrdinal,
@@ -65,7 +65,7 @@ object ScriptProcessor {
       schemaBinding = binding
     )
 
-    result <- current.withRecord[F](update.fiberId, oracleRecord)
+    result <- current.withRecord[F](update.fiberId, scriptRecord)
   } yield result
 
   def validateAccess[F[_]: Async](

--- a/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/fiber/spawning/SpawnProcessor.scala
+++ b/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/fiber/spawning/SpawnProcessor.scala
@@ -20,7 +20,7 @@ import xyz.kd5ujc.shared_data.fiber.core._
 /**
  * Processes spawn directives to create child fibers.
  *
- * Only applicable to state machines (oracles don't spawn children).
+ * Only applicable to state machines (scripts don't spawn children).
  *
  * Processing flow:
  * 1. Validate all directives using SpawnValidator (collect all errors)

--- a/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/fiber/triggers/TriggerDispatcher.scala
+++ b/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/fiber/triggers/TriggerDispatcher.scala
@@ -94,7 +94,7 @@ object TriggerDispatcher {
                   logEntries <- ExecutionOps.getLogs[G]
                 } yield (TransactionResult.Committed(
                   updatedStateMachines = qs.txnState.stateMachines,
-                  updatedOracles = qs.txnState.scripts,
+                  updatedScripts = qs.txnState.scripts,
                   logEntries = logEntries.toList,
                   totalGasUsed = gasUsed,
                   maxDepth = depth

--- a/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/fiber/triggers/TriggerHandler.scala
+++ b/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/fiber/triggers/TriggerHandler.scala
@@ -14,7 +14,7 @@ import io.constellationnetwork.metagraph_sdk.json_logic.runtime.JsonLogicEvaluat
 import io.constellationnetwork.metagraph_sdk.std.JsonBinaryHasher.HasherOps
 import io.constellationnetwork.security.SecurityProvider
 
-import xyz.kd5ujc.schema.fiber.FiberLogEntry.{EventReceipt, OracleInvocation}
+import xyz.kd5ujc.schema.fiber.FiberLogEntry.{EventReceipt, ScriptInvocation}
 import xyz.kd5ujc.schema.fiber._
 import xyz.kd5ujc.schema.{CalculatedState, Records}
 import xyz.kd5ujc.shared_data.fiber.core._
@@ -52,7 +52,7 @@ object TriggerHandler {
             .handle(trigger, fiber, state)
 
         case _: Records.ScriptFiberRecord =>
-          new OracleTriggerHandler[F, G]()
+          new ScriptTriggerHandler[F, G]()
             .handle(trigger, fiber, state)
       }
 }
@@ -127,7 +127,7 @@ class StateMachineTriggerHandler[F[_]: Async: SecurityProvider, G[_]: Monad](
     } yield result
 }
 
-class OracleTriggerHandler[F[_]: Async, G[_]: Monad]()(implicit
+class ScriptTriggerHandler[F[_]: Async, G[_]: Monad]()(implicit
   S:    Stateful[G, ExecutionState],
   A:    Ask[G, FiberContext],
   lift: F ~> G
@@ -139,33 +139,33 @@ class OracleTriggerHandler[F[_]: Async, G[_]: Monad]()(implicit
     state:   CalculatedState
   ): G[TriggerHandlerResult] =
     fiber match {
-      case oracle: Records.ScriptFiberRecord =>
-        handleOracle(trigger, oracle, state)
+      case script: Records.ScriptFiberRecord =>
+        handleScript(trigger, script, state)
       case other =>
         (TriggerHandlerResult.Failed(
           FailureReason.FiberInputMismatch(other.fiberId, FiberKind.StateMachine, InputKind.MethodCall)
         ): TriggerHandlerResult).pure[G]
     }
 
-  private def handleOracle(
+  private def handleScript(
     trigger: FiberTrigger,
-    oracle:  Records.ScriptFiberRecord,
+    script:  Records.ScriptFiberRecord,
     state:   CalculatedState
   ): G[TriggerHandlerResult] = {
-    type OracleET[A] = EitherT[G, TriggerHandlerResult, A]
+    type ScriptET[A] = EitherT[G, TriggerHandlerResult, A]
 
-    val computation: OracleET[TriggerHandlerResult] = for {
+    val computation: ScriptET[TriggerHandlerResult] = for {
       callerAddress <- EitherT.fromOption[G](
         trigger.sourceFiberId.flatMap { fiberId =>
           state.getFiber(fiberId).flatMap(_.owners.headOption)
         },
         TriggerHandlerResult.Failed(
-          FailureReason.CallerResolutionFailed(oracle.fiberId, trigger.sourceFiberId)
+          FailureReason.CallerResolutionFailed(script.fiberId, trigger.sourceFiberId)
         ): TriggerHandlerResult
       )
 
       _ <- EitherT[G, TriggerHandlerResult, Unit](
-        ScriptProcessor.validateAccess(oracle.accessControl, callerAddress, oracle.fiberId, state).liftTo[G].map {
+        ScriptProcessor.validateAccess(script.accessControl, callerAddress, script.fiberId, state).liftTo[G].map {
           case Right(_)     => Right(())
           case Left(reason) => Left(TriggerHandlerResult.Failed(reason))
         }
@@ -175,7 +175,7 @@ class OracleTriggerHandler[F[_]: Async, G[_]: Monad]()(implicit
         Map(
           ReservedKeys.METHOD -> StrValue(trigger.input.key),
           ReservedKeys.ARGS   -> trigger.input.content,
-          ReservedKeys.STATE  -> oracle.stateData.getOrElse(NullValue)
+          ReservedKeys.STATE  -> script.stateData.getOrElse(NullValue)
         )
       )
 
@@ -190,14 +190,14 @@ class OracleTriggerHandler[F[_]: Async, G[_]: Monad]()(implicit
       scriptResult <- EitherT[G, TriggerHandlerResult, EvaluationResult[JsonLogicValue]](
         JsonLogicEvaluator
           .tailRecursive[F]
-          .evaluateWithGas(oracle.scriptProgram, inputData, None, GasLimit(remainingGas), gasConfig)
+          .evaluateWithGas(script.scriptProgram, inputData, None, GasLimit(remainingGas), gasConfig)
           .liftTo[G]
           .flatMap {
             case Right(result) =>
               ExecutionOps.chargeGas[G](result.gasUsed.amount).as(result.asRight[TriggerHandlerResult])
 
             case Left(ex) =>
-              ex.toFailureReason[G](GasExhaustionPhase.Oracle).map { reason =>
+              ex.toFailureReason[G](GasExhaustionPhase.Script).map { reason =>
                 (TriggerHandlerResult.Failed(reason): TriggerHandlerResult)
                   .asLeft[EvaluationResult[JsonLogicValue]]
               }
@@ -217,7 +217,7 @@ class OracleTriggerHandler[F[_]: Async, G[_]: Monad]()(implicit
           case BoolValue(false) =>
             Left(
               TriggerHandlerResult.Failed(
-                FailureReason.OracleInvocationFailed(oracle.fiberId, trigger.input.key, Some("returned false"))
+                FailureReason.ScriptInvocationFailed(script.fiberId, trigger.input.key, Some("returned false"))
               )
             )
           case MapValue(m) if m.get("valid").contains(BoolValue(false)) =>
@@ -225,7 +225,7 @@ class OracleTriggerHandler[F[_]: Async, G[_]: Monad]()(implicit
             Left(
               TriggerHandlerResult.Failed(
                 FailureReason
-                  .OracleInvocationFailed(oracle.fiberId, trigger.input.key, Some(s"validation failed: $errorMsg"))
+                  .ScriptInvocationFailed(script.fiberId, trigger.input.key, Some(s"validation failed: $errorMsg"))
               )
             )
           case _ => Right(())
@@ -241,8 +241,8 @@ class OracleTriggerHandler[F[_]: Async, G[_]: Monad]()(implicit
         ExecutionOps.askOrdinal[G]
       )
 
-      invocation = OracleInvocation(
-        fiberId = oracle.fiberId,
+      invocation = ScriptInvocation(
+        fiberId = script.fiberId,
         method = trigger.input.key,
         args = trigger.input.content,
         result = returnValue,
@@ -255,15 +255,15 @@ class OracleTriggerHandler[F[_]: Async, G[_]: Monad]()(implicit
         ExecutionOps.appendLog[G](invocation)
       )
 
-      updatedOracle = oracle.copy(
+      updatedScript = script.copy(
         stateData = newStateData,
         stateDataHash = newHash,
         latestUpdateOrdinal = ordinal,
-        sequenceNumber = oracle.sequenceNumber.next,
+        sequenceNumber = script.sequenceNumber.next,
         lastInvocation = Some(invocation)
       )
 
-      updatedState = state.updateFiber(updatedOracle)
+      updatedState = state.updateFiber(updatedScript)
 
     } yield TriggerHandlerResult.Success(
       updatedState = updatedState,

--- a/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/genesis/GenesisBuilder.scala
+++ b/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/genesis/GenesisBuilder.scala
@@ -21,7 +21,7 @@ import xyz.kd5ujc.shared_data.syntax.DataStateOps._
  * Assembles a non-empty genesis `DataState` — the chain-side core of genesis-prep (#39) and the e2e
  * edge-case genesis crafting (#40). Pre-registers packages, fiber-instance aliases (with reverse records),
  * and pre-built fiber/script records. Crucially it reuses the SAME commitment derivations the live combiner
- * uses (`DataStateOps.withAlias` / `withFibersAndOracles`, and `computeDigest` for package entries), so a
+ * uses (`DataStateOps.withAlias` / `withFibersAndScripts`, and `computeDigest` for package entries), so a
  * crafted genesis is byte-consistent with on-chain state — the node can boot from it and prove against it.
  *
  * Package/alias/fiber *content* (schemaHash, machineShape, logicHash, fiber records) comes from a pinned
@@ -69,7 +69,7 @@ object GenesisBuilder {
       withAls <- aliases.foldLeftM(withPkgs) { (st, a) =>
         st.withAlias[F](a.name, aliasEntry(a), a.targetFiberId)
       }
-      withAll <- withAls.withFibersAndOracles[F](fibers, scripts)
+      withAll <- withAls.withFibersAndScripts[F](fibers, scripts)
     } yield withAll
 
   private def aliasEntry(a: AliasSpec): RegistryEntry =

--- a/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/Combiner.scala
+++ b/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/Combiner.scala
@@ -31,11 +31,11 @@ import org.typelevel.log4cats.slf4j.Slf4jLogger
  *   - ArchiveFiber: Mark fiber as archived
  *
  * - '''ScriptCombiner''': Handles script operations
- *   - CreateScript: Initialize new oracle with script
- *   - InvokeScript: Execute oracle method
+ *   - CreateScript: Initialize new script with script
+ *   - InvokeScript: Execute script method
  *
  * @see [[combine.FiberCombiner]] for fiber operations
- * @see [[combine.ScriptCombiner]] for oracle operations
+ * @see [[combine.ScriptCombiner]] for script operations
  */
 object Combiner {
 
@@ -54,7 +54,7 @@ object Combiner {
         update:   Signed[OttochainMessage]
       )(implicit ctx: L0NodeContext[F]): F[DataState[OnChain, CalculatedState]] = {
         val fiberCombiner = FiberCombiner[F](previous, ctx, executionLimits)
-        val oracleCombiner = ScriptCombiner[F](previous, ctx, executionLimits)
+        val scriptCombiner = ScriptCombiner[F](previous, ctx, executionLimits)
         val registryCombiner = RegistryCombiner[F](previous, ctx, Limits.MaxRegistryBundleBytes)
 
         val dispatched: F[DataState[OnChain, CalculatedState]] = update.value match {
@@ -62,9 +62,9 @@ object Combiner {
           case u: Updates.TransitionStateMachine => fiberCombiner.processFiberEvent(Signed(u, update.proofs))
           case u: Updates.ArchiveStateMachine    => fiberCombiner.archiveFiber(Signed(u, update.proofs))
           case u: Updates.UpgradeFiber           => fiberCombiner.upgradeFiber(Signed(u, update.proofs))
-          case u: Updates.CreateScript           => oracleCombiner.createScript(Signed(u, update.proofs))
-          case u: Updates.InvokeScript           => oracleCombiner.invokeScript(Signed(u, update.proofs))
-          case u: Updates.UpgradeScript          => oracleCombiner.upgradeScript(Signed(u, update.proofs))
+          case u: Updates.CreateScript           => scriptCombiner.createScript(Signed(u, update.proofs))
+          case u: Updates.InvokeScript           => scriptCombiner.invokeScript(Signed(u, update.proofs))
+          case u: Updates.UpgradeScript          => scriptCombiner.upgradeScript(Signed(u, update.proofs))
           case u: Updates.PublishMachineVersion  => registryCombiner.publishMachineVersion(Signed(u, update.proofs))
           case u: Updates.PublishScriptVersion   => registryCombiner.publishScriptVersion(Signed(u, update.proofs))
           case u: Updates.SetVersionStatus       => registryCombiner.setVersionStatus(Signed(u, update.proofs))

--- a/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/Validator.scala
+++ b/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/Validator.scala
@@ -69,7 +69,7 @@ object Validator {
         )(implicit ctx: L1NodeContext[F]): F[DataApplicationValidationErrorOr[Unit]] =
           withOnChainCache(ctx) { checkpoint =>
             val fiberL1 = new FiberValidator.L1Validator[F](checkpoint.state)
-            val oracleL1 = new ScriptValidator.L1Validator[F](checkpoint.state)
+            val scriptL1 = new ScriptValidator.L1Validator[F](checkpoint.state)
             val registryL1 = new RegistryValidator.L1Validator[F]
 
             val updateName = update.getClass.getSimpleName
@@ -99,9 +99,9 @@ object Validator {
                 case u: TransitionStateMachine => fiberL1.processEvent(u)
                 case u: ArchiveStateMachine    => fiberL1.archiveFiber(u)
                 case u: UpgradeFiber           => fiberL1.upgrade(u)
-                case u: CreateScript           => oracleL1.createOracle(u)
-                case u: InvokeScript           => oracleL1.invokeOracle(u)
-                case u: UpgradeScript          => oracleL1.upgradeScript(u)
+                case u: CreateScript           => scriptL1.createScript(u)
+                case u: InvokeScript           => scriptL1.invokeScript(u)
+                case u: UpgradeScript          => scriptL1.upgradeScript(u)
                 case u: PublishMachineVersion  => registryL1.publishMachineVersion(u)
                 case u: PublishScriptVersion   => registryL1.publishScriptVersion(u)
                 case u: SetVersionStatus       => registryL1.setStatus(u)
@@ -128,7 +128,7 @@ object Validator {
           signedUpdate: Signed[OttochainMessage]
         )(implicit context: L0NodeContext[F]): F[DataApplicationValidationErrorOr[Unit]] = {
           val fiberCombined = new FiberValidator.CombinedValidator[F](current, signedUpdate.proofs)
-          val oracleCombined = new ScriptValidator.CombinedValidator[F](current, signedUpdate.proofs)
+          val scriptCombined = new ScriptValidator.CombinedValidator[F](current, signedUpdate.proofs)
 
           // Registry ops use L1 (structural) validation ONLY here, NOT the L0 contextual preview.
           // The L0 checks (ownership, monotonic version) need the CalculatedState version lineage, which the
@@ -147,9 +147,9 @@ object Validator {
             case u: TransitionStateMachine => fiberCombined.processEvent(u)
             case u: ArchiveStateMachine    => fiberCombined.archiveFiber(u)
             case u: UpgradeFiber           => fiberCombined.upgrade(u)
-            case u: CreateScript           => oracleCombined.createOracle(u)
-            case u: InvokeScript           => oracleCombined.invokeOracle(u)
-            case u: UpgradeScript          => oracleCombined.upgradeScript(u)
+            case u: CreateScript           => scriptCombined.createScript(u)
+            case u: InvokeScript           => scriptCombined.invokeScript(u)
+            case u: UpgradeScript          => scriptCombined.upgradeScript(u)
             case u: PublishMachineVersion  => registryL1.publishMachineVersion(u)
             case u: PublishScriptVersion   => registryL1.publishScriptVersion(u)
             case u: SetVersionStatus       => registryL1.setStatus(u)

--- a/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/combine/FiberCombiner.scala
+++ b/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/combine/FiberCombiner.scala
@@ -93,7 +93,7 @@ class FiberCombiner[F[_]: Async: SecurityProvider](
    * Processes a fiber event through the fiber orchestrator.
    *
    * Handles both successful transitions and failures:
-   * - Committed: Applies all fiber and oracle updates
+   * - Committed: Applies all fiber and script updates
    * - Aborted: Records failure receipt on the fiber
    */
   def processFiberEvent(
@@ -133,8 +133,8 @@ class FiberCombiner[F[_]: Async: SecurityProvider](
     outcome <- orchestrator.process(update.fiberId, input, proofsList)
 
     newState <- outcome match {
-      case TransactionResult.Committed(updatedFibers, updatedOracles, logEntries, _, _, _) =>
-        handleCommittedOutcome(updatedFibers, updatedOracles, logEntries)
+      case TransactionResult.Committed(updatedFibers, updatedScripts, logEntries, _, _, _) =>
+        handleCommittedOutcome(updatedFibers, updatedScripts, logEntries)
 
       case TransactionResult.Aborted(reason, gasUsed, _) =>
         handleAbortedOutcome(update.fiberId, update.eventName, reason, gasUsed, currentOrdinal)
@@ -254,8 +254,8 @@ class FiberCombiner[F[_]: Async: SecurityProvider](
     outcome <- orchestrator.migrate(update.fiberId, update.newDefinition, newBinding, update.migration)
 
     newState <- outcome match {
-      case TransactionResult.Committed(updatedFibers, updatedOracles, logEntries, _, _, _) =>
-        handleCommittedOutcome(updatedFibers, updatedOracles, logEntries)
+      case TransactionResult.Committed(updatedFibers, updatedScripts, logEntries, _, _, _) =>
+        handleCommittedOutcome(updatedFibers, updatedScripts, logEntries)
 
       case TransactionResult.Aborted(reason, gasUsed, _) =>
         handleAbortedOutcome(update.fiberId, "__upgrade__", reason, gasUsed, currentOrdinal)
@@ -314,14 +314,14 @@ class FiberCombiner[F[_]: Async: SecurityProvider](
   /**
    * Handles a committed transaction outcome.
    *
-   * Applies fiber/oracle record updates, then appends log entries to OnChain.latestLogs.
+   * Applies fiber/script record updates, then appends log entries to OnChain.latestLogs.
    */
   private def handleCommittedOutcome(
     updatedFibers:  Map[UUID, Records.StateMachineFiberRecord],
-    updatedOracles: Map[UUID, Records.ScriptFiberRecord],
+    updatedScripts: Map[UUID, Records.ScriptFiberRecord],
     logEntries:     List[FiberLogEntry]
   ): F[DataState[OnChain, CalculatedState]] =
-    current.withFibersAndOracles[F](updatedFibers, updatedOracles).map(_.appendLogs(logEntries))
+    current.withFibersAndScripts[F](updatedFibers, updatedScripts).map(_.appendLogs(logEntries))
 
   /**
    * Handles an aborted transaction outcome.

--- a/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/combine/ScriptCombiner.scala
+++ b/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/combine/ScriptCombiner.scala
@@ -56,12 +56,12 @@ class ScriptCombiner[F[_]: Async: SecurityProvider](
     lastSnapshotHash <- ctx.getLastSnapshotHash
     epochProgress    <- ctx.getEpochProgress
 
-    // Verify oracle exists and sequence number matches before processing
-    oracleRecord <- current.calculated.scripts
+    // Verify script exists and sequence number matches before processing
+    scriptRecord <- current.calculated.scripts
       .get(update.fiberId)
       .fold(
         Async[F].raiseError[Records.ScriptFiberRecord](
-          CombineRejected(s"Oracle ${update.fiberId} not found")
+          CombineRejected(s"Script ${update.fiberId} not found")
         )
       )(_.pure[F])
 
@@ -69,10 +69,10 @@ class ScriptCombiner[F[_]: Async: SecurityProvider](
     _ <- Async[F]
       .raiseError(
         CombineRejected(
-          s"Sequence number mismatch: target=${update.targetSequenceNumber}, actual=${oracleRecord.sequenceNumber}"
+          s"Sequence number mismatch: target=${update.targetSequenceNumber}, actual=${scriptRecord.sequenceNumber}"
         )
       )
-      .whenA(oracleRecord.sequenceNumber =!= update.targetSequenceNumber)
+      .whenA(scriptRecord.sequenceNumber =!= update.targetSequenceNumber)
 
     caller <- update.proofs.toList.headOption
       .fold(Async[F].raiseError[Address](CombineRejected("No proof provided")))(
@@ -97,17 +97,17 @@ class ScriptCombiner[F[_]: Async: SecurityProvider](
     outcome <- orchestrator.process(update.fiberId, input, update.proofs.toList)
 
     newState <- outcome match {
-      case TransactionResult.Committed(_, updatedOracles, logEntries, _, _, _) =>
-        updatedOracles.get(update.fiberId) match {
-          case Some(updatedOracle) =>
-            current.withRecord[F](update.fiberId, updatedOracle).map(_.appendLogs(logEntries))
+      case TransactionResult.Committed(_, updatedScripts, logEntries, _, _, _) =>
+        updatedScripts.get(update.fiberId) match {
+          case Some(updatedScript) =>
+            current.withRecord[F](update.fiberId, updatedScript).map(_.appendLogs(logEntries))
 
           case None =>
-            Async[F].raiseError(CombineRejected(s"Oracle ${update.fiberId} not found in orchestrator result"))
+            Async[F].raiseError(CombineRejected(s"Script ${update.fiberId} not found in orchestrator result"))
         }
 
       case TransactionResult.Aborted(reason, _, _) =>
-        Async[F].raiseError(CombineRejected(s"Oracle invocation failed: ${reason.toMessage}"))
+        Async[F].raiseError(CombineRejected(s"Script invocation failed: ${reason.toMessage}"))
     }
   } yield newState
 
@@ -185,8 +185,8 @@ class ScriptCombiner[F[_]: Async: SecurityProvider](
     outcome <- orchestrator.migrateScript(update.fiberId, update.newProgram, newBinding, update.migration)
 
     newState <- outcome match {
-      case TransactionResult.Committed(_, updatedOracles, logEntries, _, _, _) =>
-        updatedOracles.get(update.fiberId) match {
+      case TransactionResult.Committed(_, updatedScripts, logEntries, _, _, _) =>
+        updatedScripts.get(update.fiberId) match {
           case Some(updated) => current.withRecord[F](update.fiberId, updated).map(_.appendLogs(logEntries))
           case None =>
             Async[F].raiseError(CombineRejected(s"Script ${update.fiberId} not in orchestrator result"))

--- a/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/combine/package.scala
+++ b/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/combine/package.scala
@@ -9,7 +9,7 @@ import xyz.kd5ujc.schema.{CalculatedState, OnChain}
  *
  * This package separates state combination (insert) concerns by domain:
  * - **Fiber**: State machine fiber creation, event processing, archiving
- * - **Oracle**: Script oracle creation and invocation
+ * - **Script**: Script script creation and invocation
  *
  * The key pattern mirrors the validation module:
  * - Thin Combiner.scala facade delegates to domain-specific combiners

--- a/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/validate/ScriptValidator.scala
+++ b/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/validate/ScriptValidator.scala
@@ -31,7 +31,7 @@ object ScriptValidator {
   class L1Validator[F[_]: Monad](state: OnChain) {
 
     /** Validates a CreateScript update */
-    def createOracle(update: CreateScript): F[ValidationResult] =
+    def createScript(update: CreateScript): F[ValidationResult] =
       for {
         cidCheck       <- CommonRules.cidNotUsed(update.fiberId, state)
         initialStateOk <- CommonRules.isMapValueOrNull(update.initialState, "initialState")
@@ -48,7 +48,7 @@ object ScriptValidator {
       } yield List(cidCheck, initialStateOk, scriptDepthOk, initialStateSizeOk).combineAll
 
     /** Validates an InvokeScript update */
-    def invokeOracle(update: InvokeScript): F[ValidationResult] =
+    def invokeScript(update: InvokeScript): F[ValidationResult] =
       for {
         cidExists     <- CommonRules.cidIsFound(update.fiberId, state)
         seqNumOk      <- ScriptRules.L1.sequenceNumberMatches(update.fiberId, update.targetSequenceNumber, state)
@@ -83,11 +83,11 @@ object ScriptValidator {
   ) {
 
     /** Validates a CreateScript update (L0 specific checks) */
-    def createOracle(update: CreateScript): F[ValidationResult] =
+    def createScript(update: CreateScript): F[ValidationResult] =
       RegistryRules.L0.scriptRefResolvesAndMatches(update.schemaRef, update.scriptProgram, state.calculated)
 
     /** Validates an InvokeScript update (L0 specific checks) */
-    def invokeOracle(update: InvokeScript): F[ValidationResult] =
+    def invokeScript(update: InvokeScript): F[ValidationResult] =
       ScriptRules.L0.accessControlCheck(update.fiberId, proofs, state.calculated)
 
     /** Validates an UpgradeScript update (active, owner, same-package re-bind + verified hash) */
@@ -117,17 +117,17 @@ object ScriptValidator {
     private val l0 = new L0Validator[F](state, proofs)
 
     /** Validates a CreateScript update (all checks) */
-    def createOracle(update: CreateScript): F[ValidationResult] =
+    def createScript(update: CreateScript): F[ValidationResult] =
       for {
-        l1Result <- l1.createOracle(update)
-        l0Result <- l0.createOracle(update)
+        l1Result <- l1.createScript(update)
+        l0Result <- l0.createScript(update)
       } yield l1Result |+| l0Result
 
     /** Validates an InvokeScript update (all checks) */
-    def invokeOracle(update: InvokeScript): F[ValidationResult] =
+    def invokeScript(update: InvokeScript): F[ValidationResult] =
       for {
-        l1Result <- l1.invokeOracle(update)
-        l0Result <- l0.invokeOracle(update)
+        l1Result <- l1.invokeScript(update)
+        l0Result <- l0.invokeScript(update)
       } yield l1Result |+| l0Result
 
     /** Validates an UpgradeScript update (all checks) */

--- a/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/validate/package.scala
+++ b/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/validate/package.scala
@@ -8,7 +8,7 @@ import io.constellationnetwork.currency.dataApplication.DataApplicationValidatio
  * Validation package for the lifecycle module.
  *
  * This package separates validation concerns by:
- * - **Domain**: Fiber operations vs Oracle operations
+ * - **Domain**: Fiber operations vs Script operations
  * - **Layer**: L1 (structural, pre-consensus) vs L0 (contextual, with proofs)
  *
  * The key distinction:

--- a/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/validate/rules/CommonRules.scala
+++ b/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/validate/rules/CommonRules.scala
@@ -14,7 +14,7 @@ import xyz.kd5ujc.schema.OnChain
 import xyz.kd5ujc.shared_data.lifecycle.validate.{Limits, ValidationResult}
 
 /**
- * Common validation rules shared between fiber and oracle domains.
+ * Common validation rules shared between fiber and script domains.
  *
  * These rules operate on shared concepts like CID uniqueness and
  * structural validation of JsonLogic values/expressions.

--- a/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/validate/rules/RegistryRules.scala
+++ b/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/validate/rules/RegistryRules.scala
@@ -272,7 +272,7 @@ object RegistryRules {
           }
       }
 
-    /** An alias's target fiber must exist as the kind its TLD requires (.machine -> SM, .script -> oracle). */
+    /** An alias's target fiber must exist as the kind its TLD requires (.machine -> SM, .script -> script). */
     def aliasTargetIsKind[F[_]: Applicative](
       name:          RegistryName,
       targetFiberId: UUID,

--- a/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/validate/rules/ScriptRules.scala
+++ b/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/validate/rules/ScriptRules.scala
@@ -33,7 +33,7 @@ object ScriptRules {
 
   object L1 {
 
-    /** Validates that targetSequenceNumber matches the oracle's current sequence number */
+    /** Validates that targetSequenceNumber matches the script's current sequence number */
     def sequenceNumberMatches[F[_]: Applicative](
       fiberId:              UUID,
       targetSequenceNumber: FiberOrdinal,
@@ -48,37 +48,37 @@ object ScriptRules {
 
   object L0 {
 
-    /** Validates oracle access control policy allows the caller */
+    /** Validates script access control policy allows the caller */
     def accessControlCheck[F[_]: Async: SecurityProvider](
-      oracleId: UUID,
+      scriptId: UUID,
       proofs:   NonEmptySet[SignatureProof],
       state:    CalculatedState
     ): F[ValidationResult] = (for {
-      oracle <- EitherT.fromOption[F](
-        state.scripts.get(oracleId),
-        Errors.OracleNotFound(oracleId): DataApplicationValidationError
+      script <- EitherT.fromOption[F](
+        state.scripts.get(scriptId),
+        Errors.ScriptNotFound(scriptId): DataApplicationValidationError
       )
       callerAddresses <- EitherT.liftF(proofs.toList.traverse(_.id.toAddress))
       callerSet = callerAddresses.toSet
       authorized <- EitherT.cond[F](
-        isAuthorized(oracle.accessControl, callerSet, state),
+        isAuthorized(script.accessControl, callerSet, state),
         (),
-        Errors.OracleAccessDenied(oracleId, oracle.accessControl): DataApplicationValidationError
+        Errors.ScriptAccessDenied(scriptId, script.accessControl): DataApplicationValidationError
       )
     } yield authorized).fold(
       _.invalidNec[Unit],
       _.validNec[DataApplicationValidationError]
     )
 
-    /** Validates that an oracle exists */
-    def oracleExists[F[_]: Applicative](
-      oracleId: UUID,
+    /** Validates that an script exists */
+    def scriptExists[F[_]: Applicative](
+      scriptId: UUID,
       state:    CalculatedState
     ): F[ValidationResult] =
       state.scripts
-        .get(oracleId)
+        .get(scriptId)
         .fold(
-          (Errors.OracleNotFound(oracleId): DataApplicationValidationError).invalidNec[Unit].pure[F]
+          (Errors.ScriptNotFound(scriptId): DataApplicationValidationError).invalidNec[Unit].pure[F]
         )(_ => ().validNec[DataApplicationValidationError].pure[F])
 
     /** Validates that a script fiber is in Active status. */
@@ -88,7 +88,7 @@ object ScriptRules {
     ): F[ValidationResult] =
       state.scripts.get(scriptId) match {
         case None =>
-          (Errors.OracleNotFound(scriptId): DataApplicationValidationError).invalidNec[Unit].pure[F]
+          (Errors.ScriptNotFound(scriptId): DataApplicationValidationError).invalidNec[Unit].pure[F]
         case Some(record) =>
           Validated
             .condNec(
@@ -107,7 +107,7 @@ object ScriptRules {
     ): F[ValidationResult] =
       state.scripts.get(scriptId) match {
         case None =>
-          (Errors.OracleNotFound(scriptId): DataApplicationValidationError).invalidNec[Unit].pure[F]
+          (Errors.ScriptNotFound(scriptId): DataApplicationValidationError).invalidNec[Unit].pure[F]
         case Some(record) =>
           proofs.toList.traverse(_.id.toAddress).map { signerList =>
             val signers = signerList.toSet
@@ -130,7 +130,7 @@ object ScriptRules {
     ): F[ValidationResult] =
       state.scripts.get(scriptId) match {
         case None =>
-          (Errors.OracleNotFound(scriptId): DataApplicationValidationError).invalidNec[Unit].pure[F]
+          (Errors.ScriptNotFound(scriptId): DataApplicationValidationError).invalidNec[Unit].pure[F]
         case Some(record) =>
           record.schemaBinding match {
             case Some(b) if b.name === targetName => ().validNec[DataApplicationValidationError].pure[F]
@@ -166,18 +166,18 @@ object ScriptRules {
   }
 
   // ============================================================================
-  // Errors - Oracle-specific validation errors
+  // Errors - Script-specific validation errors
   // ============================================================================
 
   object Errors {
 
-    final case class OracleNotFound(oracleId: UUID) extends DataApplicationValidationError {
-      override val message: String = s"Oracle $oracleId not found"
+    final case class ScriptNotFound(scriptId: UUID) extends DataApplicationValidationError {
+      override val message: String = s"Script $scriptId not found"
     }
 
-    final case class OracleAccessDenied(oracleId: UUID, policy: AccessControlPolicy)
+    final case class ScriptAccessDenied(scriptId: UUID, policy: AccessControlPolicy)
         extends DataApplicationValidationError {
-      override val message: String = s"Access denied to oracle $oracleId (policy: $policy)"
+      override val message: String = s"Access denied to script $scriptId (policy: $policy)"
     }
 
     final case class ScriptNotActive(scriptId: UUID) extends DataApplicationValidationError {

--- a/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/syntax/CalculatedStateOps.scala
+++ b/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/syntax/CalculatedStateOps.scala
@@ -33,8 +33,8 @@ trait CalculatedStateOps {
     def updateFiber(fiber: Records.FiberRecord): CalculatedState = fiber match {
       case sm: Records.StateMachineFiberRecord =>
         state.copy(stateMachines = state.stateMachines.updated(sm.fiberId, sm))
-      case oracle: Records.ScriptFiberRecord =>
-        state.copy(scripts = state.scripts.updated(oracle.fiberId, oracle))
+      case script: Records.ScriptFiberRecord =>
+        state.copy(scripts = state.scripts.updated(script.fiberId, script))
     }
   }
 }

--- a/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/syntax/DataStateOps.scala
+++ b/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/syntax/DataStateOps.scala
@@ -26,12 +26,12 @@ trait DataStateOps {
   implicit class DataStateSyntax(private val state: DataState[OnChain, CalculatedState]) {
 
     /**
-     * Update a single fiber or oracle record with automatic hash computation.
+     * Update a single fiber or script record with automatic hash computation.
      *
      * Computes RecordHash from the full record and extracts stateDataHash from
      * the record's field. Routes to the correct CalculatedState field based on type.
      *
-     * @param id     The fiber/oracle CID
+     * @param id     The fiber/script CID
      * @param record The updated record (StateMachineFiberRecord or ScriptFiberRecord)
      * @return Updated DataState with both OnChain and CalculatedState modified
      */
@@ -49,21 +49,21 @@ trait DataStateOps {
               .focus(_.calculated.stateMachines)
               .modify(_.updated(id, sm))
           }
-        case oracle: Records.ScriptFiberRecord =>
-          oracle.computeDigest.map { recordHash =>
-            val commit = FiberCommit(recordHash, oracle.stateDataHash, oracle.sequenceNumber)
+        case script: Records.ScriptFiberRecord =>
+          script.computeDigest.map { recordHash =>
+            val commit = FiberCommit(recordHash, script.stateDataHash, script.sequenceNumber)
             state
               .focus(_.onChain.fiberCommits)
               .modify(_.updated(id, commit))
               .focus(_.calculated.scripts)
-              .modify(_.updated(id, oracle))
+              .modify(_.updated(id, script))
           }
       }
 
     /**
      * Batch update for multiple records of mixed types.
      *
-     * Separates into state machines and oracles, computes hashes for each,
+     * Separates into state machines and scripts, computes hashes for each,
      * and applies all updates atomically.
      *
      * @param records Map of CIDs to updated records
@@ -73,36 +73,36 @@ trait DataStateOps {
       records: Map[UUID, Records.FiberRecord]
     ): F[DataState[OnChain, CalculatedState]] = {
       val sms = records.collect { case (id, sm: Records.StateMachineFiberRecord) => id -> sm }
-      val oracles = records.collect { case (id, o: Records.ScriptFiberRecord) => id -> o }
+      val scripts = records.collect { case (id, o: Records.ScriptFiberRecord) => id -> o }
 
       for {
         smHashes <- sms.toList.traverse { case (id, sm) =>
           sm.computeDigest.map(recordHash => id -> FiberCommit(recordHash, Some(sm.stateDataHash), sm.sequenceNumber))
         }
-        oracleHashes <- oracles.toList.traverse { case (id, o) =>
+        scriptHashes <- scripts.toList.traverse { case (id, o) =>
           o.computeDigest.map(recordHash => id -> FiberCommit(recordHash, o.stateDataHash, o.sequenceNumber))
         }
       } yield state
         .focus(_.onChain.fiberCommits)
-        .modify(_ ++ smHashes.toMap ++ oracleHashes.toMap)
+        .modify(_ ++ smHashes.toMap ++ scriptHashes.toMap)
         .focus(_.calculated.stateMachines)
         .modify(_ ++ sms)
         .focus(_.calculated.scripts)
-        .modify(_ ++ oracles)
+        .modify(_ ++ scripts)
     }
 
     /**
-     * Batch update for state machines and oracles provided as separate typed maps.
+     * Batch update for state machines and scripts provided as separate typed maps.
      *
      * @param fibers  Map of fiber IDs to updated fiber records
-     * @param oracles Map of oracle IDs to updated oracle records
+     * @param scripts Map of script IDs to updated script records
      * @return Updated DataState with all entities applied
      */
-    def withFibersAndOracles[F[_]: Async](
+    def withFibersAndScripts[F[_]: Async](
       fibers:  Map[UUID, Records.StateMachineFiberRecord],
-      oracles: Map[UUID, Records.ScriptFiberRecord]
+      scripts: Map[UUID, Records.ScriptFiberRecord]
     ): F[DataState[OnChain, CalculatedState]] =
-      withRecords(fibers ++ oracles)
+      withRecords(fibers ++ scripts)
 
     /**
      * Commit a registry entry atomically: store the entry in CalculatedState.registry and its hash in

--- a/modules/shared-data/src/test/resources/tictactoe/state-machine-definition.json
+++ b/modules/shared-data/src/test/resources/tictactoe/state-machine-definition.json
@@ -35,7 +35,7 @@
         ]
       },
       "effect": {
-        "_oracleCall": {
+        "_scriptCall": {
           "fiberId": {"var": "state.oracleFiberId"},
           "method": "initialize",
           "args": {
@@ -59,7 +59,7 @@
         "===": [{"var": "scriptOracles.11111111-1111-1111-1111-111111111111.state.status"}, "InProgress"]
       },
       "effect": {
-        "_oracleCall": {
+        "_scriptCall": {
           "fiberId": {"var": "state.oracleFiberId"},
           "method": "makeMove",
           "args": {
@@ -85,7 +85,7 @@
         ]
       },
       "effect": {
-        "_oracleCall": {
+        "_scriptCall": {
           "fiberId": {"var": "state.oracleFiberId"},
           "method": "makeMove",
           "args": {
@@ -121,7 +121,7 @@
         ]
       },
       "effect": {
-        "_oracleCall": {
+        "_scriptCall": {
           "fiberId": {"var": "state.oracleFiberId"},
           "method": "resetGame",
           "args": {}
@@ -136,7 +136,7 @@
       "eventName": "cancel_game",
       "guard": {"==": [1, 1]},
       "effect": {
-        "_oracleCall": {
+        "_scriptCall": {
           "fiberId": {"var": "state.oracleFiberId"},
           "method": "cancelGame",
           "args": {

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/AuditRendererSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/AuditRendererSuite.scala
@@ -22,7 +22,7 @@ import weaver.SimpleIOSuite
 object AuditRendererSuite extends SimpleIOSuite {
 
   private val fiberA = UUID.fromString("11111111-1111-4111-8111-111111111111")
-  private val oracleId = UUID.fromString("22222222-2222-4222-8222-222222222222")
+  private val scriptId = UUID.fromString("22222222-2222-4222-8222-222222222222")
   private val ord = SnapshotOrdinal.MinValue
   private val v1 = SchemaBinding(RegistryName.unsafe("escrow.package"), SemVer(1, 0, 0), Hash("sh1"), Hash("lh1"))
   private val v2 = SchemaBinding(RegistryName.unsafe("escrow.package"), SemVer(2, 0, 0), Hash("sh2"), Hash("lh2"))
@@ -52,11 +52,11 @@ object AuditRendererSuite extends SimpleIOSuite {
   )
 
   private val invocation =
-    FiberLogEntry.OracleInvocation(oracleId, "compute", MapValue.empty, NullValue, gasUsed = 30L, ord, caller)
+    FiberLogEntry.ScriptInvocation(scriptId, "compute", MapValue.empty, NullValue, gasUsed = 30L, ord, caller)
 
   test("renders each log entry with its fingerprint and the key facts") {
     val mFp = FiberFingerprint.of(fiberA, FiberKind.StateMachine)
-    val sFp = FiberFingerprint.of(oracleId, FiberKind.Script)
+    val sFp = FiberFingerprint.of(scriptId, FiberKind.Script)
     IO.pure(
       expect(AuditRenderer.render(creation).contains(mFp)) and
       expect(AuditRenderer.render(creation).contains("created in state 'initial'")) and

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/E2eSignedPayloadCompatSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/E2eSignedPayloadCompatSuite.scala
@@ -77,8 +77,8 @@ object E2eSignedPayloadCompatSuite extends SimpleIOSuite {
 
   /** CreateScript payload built exactly like e2e-test/lib/script/createScript.ts. */
   private def counterCreateScriptJson: Json = {
-    val oracleDef = loadFixture("e2e-test/examples/counter-script/definition.json")
-    val cursor = oracleDef.hcursor
+    val scriptDef = loadFixture("e2e-test/examples/counter-script/definition.json")
+    val cursor = scriptDef.hcursor
     Json.obj(
       "CreateScript" -> Json.obj(
         "fiberId"       -> Json.fromString(fiberId.toString),
@@ -138,7 +138,7 @@ object E2eSignedPayloadCompatSuite extends SimpleIOSuite {
     val update = decodeMessage(counterCreateScriptJson)
     update match {
       case u: CreateScript =>
-        new ScriptValidator.L1Validator[IO](OnChain.genesis).createOracle(u).map { result =>
+        new ScriptValidator.L1Validator[IO](OnChain.genesis).createScript(u).map { result =>
           expect(
             result.isValid,
             s"L1 validation failed: ${result.fold(_.toNonEmptyList.toList.map(_.message).mkString("; "), _ => "")}"

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/FailureReasonSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/FailureReasonSuite.scala
@@ -577,7 +577,7 @@ object FailureReasonSuite extends SimpleIOSuite {
 
         calculatedState = CalculatedState(SortedMap(fiberId -> fiber), SortedMap.empty)
 
-        // Use MethodCall input (oracle-style) with state machine - type mismatch
+        // Use MethodCall input (script-style) with state machine - type mismatch
         input = FiberInput.MethodCall(
           method = "someMethod",
           args = MapValue(Map.empty),
@@ -615,31 +615,31 @@ object FailureReasonSuite extends SimpleIOSuite {
       implicit val jle: JsonLogicEvaluator[IO] = JsonLogicEvaluator.tailRecursive[IO]
       val ordinal = fixture.ordinal
       for {
-        oracleId <- UUIDGen.randomUUID[IO]
+        scriptId <- UUIDGen.randomUUID[IO]
 
-        // Simple oracle script that just returns state
-        oracleScript = VarExpression(Left("_state"))
+        // Simple script script that just returns state
+        scriptSource = VarExpression(Left("_state"))
 
-        oracleData = MapValue(Map("value" -> IntValue(0)))
-        oracleHash <- (oracleData: JsonLogicValue).computeDigest
+        scriptData = MapValue(Map("value" -> IntValue(0)))
+        scriptHash <- (scriptData: JsonLogicValue).computeDigest
 
         // Create a script fiber
-        oracle = Records.ScriptFiberRecord(
-          fiberId = oracleId,
+        script = Records.ScriptFiberRecord(
+          fiberId = scriptId,
           creationOrdinal = ordinal,
           latestUpdateOrdinal = ordinal,
-          scriptProgram = oracleScript,
-          stateData = Some(oracleData),
-          stateDataHash = Some(oracleHash),
+          scriptProgram = scriptSource,
+          stateData = Some(scriptData),
+          stateDataHash = Some(scriptHash),
           owners = Set.empty,
           status = FiberStatus.Active,
           sequenceNumber = FiberOrdinal.MinValue,
           accessControl = AccessControlPolicy.Public
         )
 
-        calculatedState = CalculatedState(SortedMap.empty, SortedMap(oracleId -> oracle))
+        calculatedState = CalculatedState(SortedMap.empty, SortedMap(scriptId -> script))
 
-        // Use Transition input (state machine-style) with oracle - type mismatch
+        // Use Transition input (state machine-style) with script - type mismatch
         input = FiberInput.Transition(
           "someEvent",
           MapValue(Map.empty)
@@ -648,13 +648,13 @@ object FailureReasonSuite extends SimpleIOSuite {
         limits = ExecutionLimits(maxDepth = 10, maxGas = 10_000L)
         orchestrator = FiberEngine.make[IO](calculatedState, ordinal, limits)
 
-        result <- orchestrator.process(oracleId, input, List.empty)
+        result <- orchestrator.process(scriptId, input, List.empty)
 
       } yield result match {
         case TransactionResult.Aborted(reason, _, _) =>
           reason match {
             case FailureReason.FiberInputMismatch(oid, fiberType, inputType) =>
-              expect(oid == oracleId, s"Expected oracle $oracleId, got $oid") and
+              expect(oid == scriptId, s"Expected script $scriptId, got $oid") and
               expect(
                 fiberType == FiberKind.Script,
                 s"Expected fiberType Script, got $fiberType"

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/RegistryCombinerSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/RegistryCombinerSuite.scala
@@ -560,7 +560,7 @@ object RegistryCombinerSuite extends SimpleIOSuite {
       implicit val l0: L0NodeContext[IO] = fixture.l0Context
       val combiner = Combiner.make[IO]()
       val create = CreateStateMachine(fiberA, minimalDef, emptyData) // a state machine
-      val alias = RegisterAlias(RegistryName.unsafe("oracle.script"), fiberA) // .script wants a script fiber
+      val alias = RegisterAlias(RegistryName.unsafe("script.script"), fiberA) // .script wants a script fiber
       for {
         validator     <- Validator.make[IO]
         prC           <- fixture.registry.generateProofs(create, Set(Alice))

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/RegistryNameSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/RegistryNameSuite.scala
@@ -13,7 +13,7 @@ object RegistryNameSuite extends SimpleIOSuite {
       expect(RegistryName.from("escrow.package").isRight) and
       expect(RegistryName.from("gov.threshold-dao.package").isRight) and
       expect(RegistryName.from("my-fiber.machine").isRight) and
-      expect(RegistryName.from("oracle.script").isRight) and
+      expect(RegistryName.from("script.script").isRight) and
       expect(RegistryName.from("escrow").isLeft) and // no TLD
       expect(RegistryName.from("escrow.acme").isLeft) and // "acme" is not a reserved TLD
       expect(RegistryName.from(".package").isLeft) and // empty labels

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/ScriptAccessControlSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/ScriptAccessControlSuite.scala
@@ -19,10 +19,10 @@ import xyz.kd5ujc.shared_test.TestFixture
 import io.circe.parser._
 import weaver.SimpleIOSuite
 
-object OracleAccessControlSuite extends SimpleIOSuite {
+object ScriptAccessControlSuite extends SimpleIOSuite {
 
   // A denied/aborted invocation no longer raises out of the combiner — it records a RejectionReceipt and
-  // leaves the oracle unmutated (so one rejected invocation can't abort the whole batch). Negative tests
+  // leaves the script unmutated (so one rejected invocation can't abort the whole batch). Negative tests
   // assert a RejectionReceipt was emitted rather than catching an exception.
   private def wasRejected(state: DataState[OnChain, CalculatedState]): Boolean =
     state.onChain.latestLogs.values.flatten.exists {
@@ -30,92 +30,92 @@ object OracleAccessControlSuite extends SimpleIOSuite {
       case _                                 => false
     }
 
-  test("whitelist allows authorized user to invoke oracle directly") {
+  test("whitelist allows authorized user to invoke script directly") {
     TestFixture.resource().use { fixture =>
       implicit val s: SecurityProvider[IO] = fixture.securityProvider
       implicit val l0ctx: L0NodeContext[IO] = fixture.l0Context
       for {
         combiner <- Combiner.make[IO]().pure[IO]
 
-        oracleFiberId <- UUIDGen.randomUUID[IO]
+        scriptFiberId <- UUIDGen.randomUUID[IO]
 
         aliceAddress = fixture.registry.addresses(Alice)
 
-        oracleScript = """{"result": "success"}"""
-        oracleProg <- IO.fromEither(parse(oracleScript).flatMap(_.as[JsonLogicExpression]))
+        scriptSource = """{"result": "success"}"""
+        scriptProg <- IO.fromEither(parse(scriptSource).flatMap(_.as[JsonLogicExpression]))
 
-        createOracle = Updates.CreateScript(
-          fiberId = oracleFiberId,
-          scriptProgram = oracleProg,
+        createScript = Updates.CreateScript(
+          fiberId = scriptFiberId,
+          scriptProgram = scriptProg,
           initialState = None,
           accessControl = AccessControlPolicy.Whitelist(Set(aliceAddress))
         )
 
-        oracleProof <- fixture.registry.generateProofs(createOracle, Set(Alice))
-        stateAfterOracle <- combiner.insert(
+        scriptProof <- fixture.registry.generateProofs(createScript, Set(Alice))
+        stateAfterScript <- combiner.insert(
           DataState(OnChain.genesis, CalculatedState.genesis),
-          Signed(createOracle, oracleProof)
+          Signed(createScript, scriptProof)
         )
 
-        invokeOracle = Updates.InvokeScript(
-          fiberId = oracleFiberId,
+        invokeScript = Updates.InvokeScript(
+          fiberId = scriptFiberId,
           method = "test",
           args = MapValue(Map.empty),
           targetSequenceNumber = FiberOrdinal.MinValue
         )
-        invokeProof <- fixture.registry.generateProofs(invokeOracle, Set(Alice))
-        finalState  <- combiner.insert(stateAfterOracle, Signed(invokeOracle, invokeProof))
+        invokeProof <- fixture.registry.generateProofs(invokeScript, Set(Alice))
+        finalState  <- combiner.insert(stateAfterScript, Signed(invokeScript, invokeProof))
 
-        oracle = finalState.calculated.scripts.get(oracleFiberId)
+        script = finalState.calculated.scripts.get(scriptFiberId)
 
-      } yield expect(oracle.isDefined) and
-      expect(oracle.map(_.sequenceNumber).contains(FiberOrdinal.MinValue.next)) and
-      expect(oracle.flatMap(_.lastInvocation.map(_.invokedBy)).contains(aliceAddress))
+      } yield expect(script.isDefined) and
+      expect(script.map(_.sequenceNumber).contains(FiberOrdinal.MinValue.next)) and
+      expect(script.flatMap(_.lastInvocation.map(_.invokedBy)).contains(aliceAddress))
     }
   }
 
-  test("whitelist denies unauthorized user from invoking oracle directly") {
+  test("whitelist denies unauthorized user from invoking script directly") {
     TestFixture.resource().use { fixture =>
       implicit val s: SecurityProvider[IO] = fixture.securityProvider
       implicit val l0ctx: L0NodeContext[IO] = fixture.l0Context
       for {
         combiner <- Combiner.make[IO]().pure[IO]
 
-        oracleFiberId <- UUIDGen.randomUUID[IO]
+        scriptFiberId <- UUIDGen.randomUUID[IO]
 
         aliceAddress = fixture.registry.addresses(Alice)
 
-        oracleScript = """{"result": "success"}"""
-        oracleProg <- IO.fromEither(parse(oracleScript).flatMap(_.as[JsonLogicExpression]))
+        scriptSource = """{"result": "success"}"""
+        scriptProg <- IO.fromEither(parse(scriptSource).flatMap(_.as[JsonLogicExpression]))
 
-        createOracle = Updates.CreateScript(
-          fiberId = oracleFiberId,
-          scriptProgram = oracleProg,
+        createScript = Updates.CreateScript(
+          fiberId = scriptFiberId,
+          scriptProgram = scriptProg,
           initialState = None,
           accessControl = AccessControlPolicy.Whitelist(Set(aliceAddress))
         )
 
-        oracleProof <- fixture.registry.generateProofs(createOracle, Set(Alice))
-        stateAfterOracle <- combiner.insert(
+        scriptProof <- fixture.registry.generateProofs(createScript, Set(Alice))
+        stateAfterScript <- combiner.insert(
           DataState(OnChain.genesis, CalculatedState.genesis),
-          Signed(createOracle, oracleProof)
+          Signed(createScript, scriptProof)
         )
 
-        invokeOracle = Updates.InvokeScript(
-          fiberId = oracleFiberId,
+        invokeScript = Updates.InvokeScript(
+          fiberId = scriptFiberId,
           method = "test",
           args = MapValue(Map.empty),
           targetSequenceNumber = FiberOrdinal.MinValue
         )
-        invokeProof <- fixture.registry.generateProofs(invokeOracle, Set(Bob))
+        invokeProof <- fixture.registry.generateProofs(invokeScript, Set(Bob))
 
-        rejected <- combiner.insert(stateAfterOracle, Signed(invokeOracle, invokeProof)).map(wasRejected)
+        rejected <- combiner.insert(stateAfterScript, Signed(invokeScript, invokeProof)).map(wasRejected)
 
-        oracle = stateAfterOracle.calculated.scripts.get(oracleFiberId)
+        script = stateAfterScript.calculated.scripts.get(scriptFiberId)
 
       } yield expect(rejected) and
-      expect(oracle.isDefined) and
-      expect(oracle.map(_.sequenceNumber).contains(FiberOrdinal.MinValue))
+      expect(script.isDefined) and
+      expect(script.map(_.sequenceNumber).contains(FiberOrdinal.MinValue))
     }
   }
 
@@ -126,96 +126,96 @@ object OracleAccessControlSuite extends SimpleIOSuite {
       for {
         combiner <- Combiner.make[IO]().pure[IO]
 
-        oracleFiberId <- UUIDGen.randomUUID[IO]
+        scriptFiberId <- UUIDGen.randomUUID[IO]
 
         aliceAddress = fixture.registry.addresses(Alice)
         bobAddress = fixture.registry.addresses(Bob)
 
-        oracleScript = """{"result": "success"}"""
-        oracleProg <- IO.fromEither(parse(oracleScript).flatMap(_.as[JsonLogicExpression]))
+        scriptSource = """{"result": "success"}"""
+        scriptProg <- IO.fromEither(parse(scriptSource).flatMap(_.as[JsonLogicExpression]))
 
-        createOracle = Updates.CreateScript(
-          fiberId = oracleFiberId,
-          scriptProgram = oracleProg,
+        createScript = Updates.CreateScript(
+          fiberId = scriptFiberId,
+          scriptProgram = scriptProg,
           initialState = None,
           accessControl = AccessControlPolicy.Whitelist(Set(aliceAddress, bobAddress))
         )
 
-        oracleProof <- fixture.registry.generateProofs(createOracle, Set(Alice))
-        stateAfterOracle <- combiner.insert(
+        scriptProof <- fixture.registry.generateProofs(createScript, Set(Alice))
+        stateAfterScript <- combiner.insert(
           DataState(OnChain.genesis, CalculatedState.genesis),
-          Signed(createOracle, oracleProof)
+          Signed(createScript, scriptProof)
         )
 
-        invokeOracle1 = Updates.InvokeScript(
-          fiberId = oracleFiberId,
+        invokeScript1 = Updates.InvokeScript(
+          fiberId = scriptFiberId,
           method = "test",
           args = MapValue(Map.empty),
           targetSequenceNumber = FiberOrdinal.MinValue
         )
-        invokeProof1    <- fixture.registry.generateProofs(invokeOracle1, Set(Alice))
-        stateAfterAlice <- combiner.insert(stateAfterOracle, Signed(invokeOracle1, invokeProof1))
+        invokeProof1    <- fixture.registry.generateProofs(invokeScript1, Set(Alice))
+        stateAfterAlice <- combiner.insert(stateAfterScript, Signed(invokeScript1, invokeProof1))
 
-        oracleSeq1 = stateAfterAlice.calculated.scripts(oracleFiberId).sequenceNumber
-        invokeOracle2 = Updates.InvokeScript(
-          fiberId = oracleFiberId,
+        scriptSeq1 = stateAfterAlice.calculated.scripts(scriptFiberId).sequenceNumber
+        invokeScript2 = Updates.InvokeScript(
+          fiberId = scriptFiberId,
           method = "test",
           args = MapValue(Map.empty),
-          targetSequenceNumber = oracleSeq1
+          targetSequenceNumber = scriptSeq1
         )
-        invokeProof2  <- fixture.registry.generateProofs(invokeOracle2, Set(Bob))
-        stateAfterBob <- combiner.insert(stateAfterAlice, Signed(invokeOracle2, invokeProof2))
+        invokeProof2  <- fixture.registry.generateProofs(invokeScript2, Set(Bob))
+        stateAfterBob <- combiner.insert(stateAfterAlice, Signed(invokeScript2, invokeProof2))
 
-        oracleSeq2 = stateAfterBob.calculated.scripts(oracleFiberId).sequenceNumber
-        invokeOracle3 = Updates.InvokeScript(
-          fiberId = oracleFiberId,
+        scriptSeq2 = stateAfterBob.calculated.scripts(scriptFiberId).sequenceNumber
+        invokeScript3 = Updates.InvokeScript(
+          fiberId = scriptFiberId,
           method = "test",
           args = MapValue(Map.empty),
-          targetSequenceNumber = oracleSeq2
+          targetSequenceNumber = scriptSeq2
         )
-        invokeProof3    <- fixture.registry.generateProofs(invokeOracle3, Set(Charlie))
-        charlieRejected <- combiner.insert(stateAfterBob, Signed(invokeOracle3, invokeProof3)).map(wasRejected)
+        invokeProof3    <- fixture.registry.generateProofs(invokeScript3, Set(Charlie))
+        charlieRejected <- combiner.insert(stateAfterBob, Signed(invokeScript3, invokeProof3)).map(wasRejected)
 
-        oracle = stateAfterBob.calculated.scripts.get(oracleFiberId)
+        script = stateAfterBob.calculated.scripts.get(scriptFiberId)
 
-      } yield expect(oracle.isDefined) and
-      expect(oracle.map(_.sequenceNumber).contains(FiberOrdinal.unsafeApply(2L))) and
+      } yield expect(script.isDefined) and
+      expect(script.map(_.sequenceNumber).contains(FiberOrdinal.unsafeApply(2L))) and
       expect(charlieRejected)
     }
   }
 
-  test("state machine _oracleCall respects whitelist - owner is whitelisted") {
+  test("state machine _scriptCall respects whitelist - owner is whitelisted") {
     TestFixture.resource().use { fixture =>
       implicit val s: SecurityProvider[IO] = fixture.securityProvider
       implicit val l0ctx: L0NodeContext[IO] = fixture.l0Context
       for {
         combiner <- Combiner.make[IO]().pure[IO]
 
-        oracleFiberId  <- UUIDGen.randomUUID[IO]
+        scriptFiberId  <- UUIDGen.randomUUID[IO]
         machineFiberId <- UUIDGen.randomUUID[IO]
 
         aliceAddress = fixture.registry.addresses(Alice)
 
-        oracleScript =
+        scriptSource =
           """|{"if":[
              |  {"==":[{"var":"method"},"validate"]},
              |  {"result": "validated"},
              |  false
              |]}""".stripMargin
 
-        oracleProg <- IO.fromEither(parse(oracleScript).flatMap(_.as[JsonLogicExpression]))
+        scriptProg <- IO.fromEither(parse(scriptSource).flatMap(_.as[JsonLogicExpression]))
 
-        createOracle = Updates.CreateScript(
-          fiberId = oracleFiberId,
-          scriptProgram = oracleProg,
+        createScript = Updates.CreateScript(
+          fiberId = scriptFiberId,
+          scriptProgram = scriptProg,
           initialState = None,
           accessControl = AccessControlPolicy.Whitelist(Set(aliceAddress))
         )
 
-        oracleProof <- fixture.registry.generateProofs(createOracle, Set(Alice))
-        stateAfterOracle <- combiner.insert(
+        scriptProof <- fixture.registry.generateProofs(createScript, Set(Alice))
+        stateAfterScript <- combiner.insert(
           DataState(OnChain.genesis, CalculatedState.genesis),
-          Signed(createOracle, oracleProof)
+          Signed(createScript, scriptProof)
         )
 
         machineJson = s"""
@@ -232,8 +232,8 @@ object OracleAccessControlSuite extends SimpleIOSuite {
               "eventName": "validate",
               "guard": true,
               "effect": {
-                "_oracleCall": {
-                  "fiberId": "$oracleFiberId",
+                "_scriptCall": {
+                  "fiberId": "$scriptFiberId",
                   "method": "validate",
                   "args": {}
                 },
@@ -250,7 +250,7 @@ object OracleAccessControlSuite extends SimpleIOSuite {
 
         createMachine = Updates.CreateStateMachine(machineFiberId, machineDef, initialData)
         machineProof      <- fixture.registry.generateProofs(createMachine, Set(Alice))
-        stateAfterMachine <- combiner.insert(stateAfterOracle, Signed(createMachine, machineProof))
+        stateAfterMachine <- combiner.insert(stateAfterScript, Signed(createMachine, machineProof))
 
         validateEvent = Updates.TransitionStateMachine(
           machineFiberId,
@@ -265,47 +265,47 @@ object OracleAccessControlSuite extends SimpleIOSuite {
           .get(machineFiberId)
           .collect { case r: Records.StateMachineFiberRecord => r }
 
-        oracle = finalState.calculated.scripts.get(oracleFiberId)
+        script = finalState.calculated.scripts.get(scriptFiberId)
 
       } yield expect(machine.isDefined) and
       expect(machine.map(_.currentState).contains(StateId("validated"))) and
-      expect(oracle.isDefined) and
-      expect(oracle.map(_.sequenceNumber).contains(FiberOrdinal.MinValue.next))
+      expect(script.isDefined) and
+      expect(script.map(_.sequenceNumber).contains(FiberOrdinal.MinValue.next))
     }
   }
 
-  test("state machine _oracleCall respects whitelist - owner is NOT whitelisted") {
+  test("state machine _scriptCall respects whitelist - owner is NOT whitelisted") {
     TestFixture.resource().use { fixture =>
       implicit val s: SecurityProvider[IO] = fixture.securityProvider
       implicit val l0ctx: L0NodeContext[IO] = fixture.l0Context
       for {
         combiner <- Combiner.make[IO]().pure[IO]
 
-        oracleFiberId  <- UUIDGen.randomUUID[IO]
+        scriptFiberId  <- UUIDGen.randomUUID[IO]
         machineFiberId <- UUIDGen.randomUUID[IO]
 
         aliceAddress = fixture.registry.addresses(Alice)
 
-        oracleScript =
+        scriptSource =
           """|{"if":[
              |  {"==":[{"var":"method"},"validate"]},
              |  {"result": "validated"},
              |  false
              |]}""".stripMargin
 
-        oracleProg <- IO.fromEither(parse(oracleScript).flatMap(_.as[JsonLogicExpression]))
+        scriptProg <- IO.fromEither(parse(scriptSource).flatMap(_.as[JsonLogicExpression]))
 
-        createOracle = Updates.CreateScript(
-          fiberId = oracleFiberId,
-          scriptProgram = oracleProg,
+        createScript = Updates.CreateScript(
+          fiberId = scriptFiberId,
+          scriptProgram = scriptProg,
           initialState = None,
           accessControl = AccessControlPolicy.Whitelist(Set(aliceAddress))
         )
 
-        oracleProof <- fixture.registry.generateProofs(createOracle, Set(Alice))
-        stateAfterOracle <- combiner.insert(
+        scriptProof <- fixture.registry.generateProofs(createScript, Set(Alice))
+        stateAfterScript <- combiner.insert(
           DataState(OnChain.genesis, CalculatedState.genesis),
-          Signed(createOracle, oracleProof)
+          Signed(createScript, scriptProof)
         )
 
         machineJson = s"""
@@ -322,8 +322,8 @@ object OracleAccessControlSuite extends SimpleIOSuite {
               "eventName": "validate",
               "guard": true,
               "effect": {
-                "_oracleCall": {
-                  "fiberId": "$oracleFiberId",
+                "_scriptCall": {
+                  "fiberId": "$scriptFiberId",
                   "method": "validate",
                   "args": {}
                 },
@@ -340,7 +340,7 @@ object OracleAccessControlSuite extends SimpleIOSuite {
 
         createMachine = Updates.CreateStateMachine(machineFiberId, machineDef, initialData)
         machineProof      <- fixture.registry.generateProofs(createMachine, Set(Bob))
-        stateAfterMachine <- combiner.insert(stateAfterOracle, Signed(createMachine, machineProof))
+        stateAfterMachine <- combiner.insert(stateAfterScript, Signed(createMachine, machineProof))
 
         validateEvent = Updates.TransitionStateMachine(
           machineFiberId,
@@ -355,7 +355,7 @@ object OracleAccessControlSuite extends SimpleIOSuite {
           .get(machineFiberId)
           .collect { case r: Records.StateMachineFiberRecord => r }
 
-        oracle = finalState.calculated.scripts.get(oracleFiberId)
+        script = finalState.calculated.scripts.get(scriptFiberId)
 
       } yield expect(machine.isDefined) and
       expect(machine.map(_.currentState).contains(StateId("idle"))) and
@@ -367,47 +367,47 @@ object OracleAccessControlSuite extends SimpleIOSuite {
           )
         )
       ) and
-      expect(oracle.isDefined) and
-      expect(oracle.map(_.sequenceNumber).contains(FiberOrdinal.MinValue))
+      expect(script.isDefined) and
+      expect(script.map(_.sequenceNumber).contains(FiberOrdinal.MinValue))
     }
   }
 
-  test("trigger directive to oracle respects whitelist - unauthorized owner blocked") {
+  test("trigger directive to script respects whitelist - unauthorized owner blocked") {
     TestFixture.resource().use { fixture =>
       implicit val s: SecurityProvider[IO] = fixture.securityProvider
       implicit val l0ctx: L0NodeContext[IO] = fixture.l0Context
       for {
         combiner <- Combiner.make[IO]().pure[IO]
 
-        oracleFiberId  <- UUIDGen.randomUUID[IO]
+        scriptFiberId  <- UUIDGen.randomUUID[IO]
         machineFiberId <- UUIDGen.randomUUID[IO]
 
         aliceAddress = fixture.registry.addresses(Alice)
 
-        // Oracle with whitelist - only Alice allowed
-        oracleScript =
+        // Script with whitelist - only Alice allowed
+        scriptSource =
           """|{"if":[
              |  {"==":[{"var":"method"},"process"]},
              |  {"result": "processed"},
              |  false
              |]}""".stripMargin
 
-        oracleProg <- IO.fromEither(parse(oracleScript).flatMap(_.as[JsonLogicExpression]))
+        scriptProg <- IO.fromEither(parse(scriptSource).flatMap(_.as[JsonLogicExpression]))
 
-        createOracle = Updates.CreateScript(
-          fiberId = oracleFiberId,
-          scriptProgram = oracleProg,
+        createScript = Updates.CreateScript(
+          fiberId = scriptFiberId,
+          scriptProgram = scriptProg,
           initialState = None,
           accessControl = AccessControlPolicy.Whitelist(Set(aliceAddress))
         )
 
-        oracleProof <- fixture.registry.generateProofs(createOracle, Set(Alice))
-        stateAfterOracle <- combiner.insert(
+        scriptProof <- fixture.registry.generateProofs(createScript, Set(Alice))
+        stateAfterScript <- combiner.insert(
           DataState(OnChain.genesis, CalculatedState.genesis),
-          Signed(createOracle, oracleProof)
+          Signed(createScript, scriptProof)
         )
 
-        // State machine that uses _triggers to invoke the oracle (NOT _oracleCall)
+        // State machine that uses _triggers to invoke the script (NOT _scriptCall)
         // Owner is Bob, who is NOT in the whitelist
         machineJson = s"""
         {
@@ -426,7 +426,7 @@ object OracleAccessControlSuite extends SimpleIOSuite {
                 "status": "triggered",
                 "_triggers": [
                   {
-                    "targetMachineId": "$oracleFiberId",
+                    "targetMachineId": "$scriptFiberId",
                     "eventName": "process",
                     "payload": {}
                   }
@@ -444,7 +444,7 @@ object OracleAccessControlSuite extends SimpleIOSuite {
         // Create state machine owned by Bob (not in whitelist)
         createMachine = Updates.CreateStateMachine(machineFiberId, machineDef, initialData)
         machineProof      <- fixture.registry.generateProofs(createMachine, Set(Bob))
-        stateAfterMachine <- combiner.insert(stateAfterOracle, Signed(createMachine, machineProof))
+        stateAfterMachine <- combiner.insert(stateAfterScript, Signed(createMachine, machineProof))
 
         triggerEvent = Updates.TransitionStateMachine(
           machineFiberId,
@@ -459,10 +459,10 @@ object OracleAccessControlSuite extends SimpleIOSuite {
           .get(machineFiberId)
           .collect { case r: Records.StateMachineFiberRecord => r }
 
-        oracle = finalState.calculated.scripts.get(oracleFiberId)
+        script = finalState.calculated.scripts.get(scriptFiberId)
 
       } yield expect(machine.isDefined) and
-      // The SM's transition should have been aborted due to oracle access denial
+      // The SM's transition should have been aborted due to script access denial
       expect(machine.map(_.currentState).contains(StateId("idle"))) and
       expect(
         machine.exists(
@@ -472,9 +472,9 @@ object OracleAccessControlSuite extends SimpleIOSuite {
           )
         )
       ) and
-      expect(oracle.isDefined) and
-      // Oracle should NOT have been invoked
-      expect(oracle.map(_.sequenceNumber).contains(FiberOrdinal.MinValue))
+      expect(script.isDefined) and
+      // Script should NOT have been invoked
+      expect(script.map(_.sequenceNumber).contains(FiberOrdinal.MinValue))
     }
   }
 
@@ -485,10 +485,10 @@ object OracleAccessControlSuite extends SimpleIOSuite {
       for {
         combiner <- Combiner.make[IO]().pure[IO]
 
-        oracleFiberId <- IO.randomUUID
+        scriptFiberId <- IO.randomUUID
         ownerFiberId  <- IO.randomUUID // Non-existent fiber ID
 
-        oracleScript =
+        scriptSource =
           """|{
              |  "if": [
              |    { "==": [{ "var": "method" }, "process"] },
@@ -497,33 +497,33 @@ object OracleAccessControlSuite extends SimpleIOSuite {
              |  ]
              |}""".stripMargin
 
-        oracleProg <- IO.fromEither(parse(oracleScript).flatMap(_.as[JsonLogicExpression]))
+        scriptProg <- IO.fromEither(parse(scriptSource).flatMap(_.as[JsonLogicExpression]))
 
-        // Create oracle with FiberOwned access control (pointing to non-existent fiber)
-        createOracle = Updates.CreateScript(
-          fiberId = oracleFiberId,
-          scriptProgram = oracleProg,
+        // Create script with FiberOwned access control (pointing to non-existent fiber)
+        createScript = Updates.CreateScript(
+          fiberId = scriptFiberId,
+          scriptProgram = scriptProg,
           initialState = None,
           accessControl = AccessControlPolicy.FiberOwned(ownerFiberId)
         )
 
-        oracleProof <- fixture.registry.generateProofs(createOracle, Set(Alice))
-        stateAfterOracle <- combiner.insert(
+        scriptProof <- fixture.registry.generateProofs(createScript, Set(Alice))
+        stateAfterScript <- combiner.insert(
           DataState(OnChain.genesis, CalculatedState.genesis),
-          Signed(createOracle, oracleProof)
+          Signed(createScript, scriptProof)
         )
 
-        // Attempt to invoke the oracle (should fail - owner fiber doesn't exist)
-        invokeOracle = Updates.InvokeScript(
-          fiberId = oracleFiberId,
+        // Attempt to invoke the script (should fail - owner fiber doesn't exist)
+        invokeScript = Updates.InvokeScript(
+          fiberId = scriptFiberId,
           method = "process",
           args = MapValue(Map.empty),
           targetSequenceNumber = FiberOrdinal.MinValue
         )
 
-        invokeProof <- fixture.registry.generateProofs(invokeOracle, Set(Alice))
+        invokeProof <- fixture.registry.generateProofs(invokeScript, Set(Alice))
         // The denied invocation no longer raises — it records a RejectionReceipt; assert on its reason.
-        invokeState <- combiner.insert(stateAfterOracle, Signed(invokeOracle, invokeProof))
+        invokeState <- combiner.insert(stateAfterScript, Signed(invokeScript, invokeProof))
         reasons = invokeState.onChain.latestLogs.values.flatten
           .collect { case r: FiberLogEntry.RejectionReceipt =>
             r.reason.toLowerCase

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/ScriptStateMachineIntegrationSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/ScriptStateMachineIntegrationSuite.scala
@@ -20,9 +20,9 @@ import xyz.kd5ujc.shared_test.TestFixture
 import io.circe.parser._
 import weaver.SimpleIOSuite
 
-object OracleStateMachineIntegrationSuite extends SimpleIOSuite {
+object ScriptStateMachineIntegrationSuite extends SimpleIOSuite {
 
-  test("state machine effect invokes oracle during transition") {
+  test("state machine effect invokes script during transition") {
     TestFixture.resource().use { fixture =>
       implicit val s: SecurityProvider[IO] = fixture.securityProvider
       implicit val l0ctx: L0NodeContext[IO] = fixture.l0Context
@@ -30,29 +30,29 @@ object OracleStateMachineIntegrationSuite extends SimpleIOSuite {
       for {
         combiner <- Combiner.make[IO]().pure[IO]
 
-        oracleFiberId  <- UUIDGen.randomUUID[IO]
+        scriptFiberId  <- UUIDGen.randomUUID[IO]
         machineFiberId <- UUIDGen.randomUUID[IO]
 
-        oracleScript =
+        scriptSource =
           """|{"if":[
              |  {"==":[{"var":"method"},"validateAmount"]},
              |  {">=":[{"var":"args.amount"},100]},
              |  false
              |]}""".stripMargin
 
-        oracleProg <- IO.fromEither(parse(oracleScript).flatMap(_.as[JsonLogicExpression]))
+        scriptProg <- IO.fromEither(parse(scriptSource).flatMap(_.as[JsonLogicExpression]))
 
-        createOracle = Updates.CreateScript(
-          fiberId = oracleFiberId,
-          scriptProgram = oracleProg,
+        createScript = Updates.CreateScript(
+          fiberId = scriptFiberId,
+          scriptProgram = scriptProg,
           initialState = None,
           accessControl = AccessControlPolicy.Public
         )
 
-        oracleProof <- registry.generateProofs(createOracle, Set(Alice))
-        stateAfterOracle <- combiner.insert(
+        scriptProof <- registry.generateProofs(createScript, Set(Alice))
+        stateAfterScript <- combiner.insert(
           DataState(OnChain.genesis, CalculatedState.genesis),
-          Signed(createOracle, oracleProof)
+          Signed(createScript, scriptProof)
         )
 
         machineJson = s"""
@@ -69,8 +69,8 @@ object OracleStateMachineIntegrationSuite extends SimpleIOSuite {
               "eventName": "submit",
               "guard": true,
               "effect": {
-                "_oracleCall": {
-                  "fiberId": "$oracleFiberId",
+                "_scriptCall": {
+                  "fiberId": "$scriptFiberId",
                   "method": "validateAmount",
                   "args": {
                     "amount": { "var": "event.amount" }
@@ -90,7 +90,7 @@ object OracleStateMachineIntegrationSuite extends SimpleIOSuite {
 
         createMachine = Updates.CreateStateMachine(machineFiberId, machineDef, initialData)
         machineProof      <- registry.generateProofs(createMachine, Set(Bob))
-        stateAfterMachine <- combiner.insert(stateAfterOracle, Signed(createMachine, machineProof))
+        stateAfterMachine <- combiner.insert(stateAfterScript, Signed(createMachine, machineProof))
 
         submitEvent = Updates.TransitionStateMachine(
           machineFiberId,
@@ -105,7 +105,7 @@ object OracleStateMachineIntegrationSuite extends SimpleIOSuite {
           .get(machineFiberId)
           .collect { case r: Records.StateMachineFiberRecord => r }
 
-        oracle = finalState.calculated.scripts.get(oracleFiberId)
+        script = finalState.calculated.scripts.get(scriptFiberId)
 
         machineStatus = machine.flatMap { f =>
           f.stateData match {
@@ -125,17 +125,17 @@ object OracleStateMachineIntegrationSuite extends SimpleIOSuite {
       expect(machine.map(_.currentState).contains(StateId("validated"))) and
       expect(machineStatus.contains("validated")) and
       expect(submittedAmount.contains(BigInt(150))) and
-      expect(oracle.isDefined) and
-      expect(oracle.map(_.sequenceNumber).contains(FiberOrdinal.MinValue.next)) and
-      expect(oracle.flatMap(_.lastInvocation.map(_.method)).contains("validateAmount")) and
-      expect(oracle.flatMap(_.lastInvocation.map(_.result)).exists {
+      expect(script.isDefined) and
+      expect(script.map(_.sequenceNumber).contains(FiberOrdinal.MinValue.next)) and
+      expect(script.flatMap(_.lastInvocation.map(_.method)).contains("validateAmount")) and
+      expect(script.flatMap(_.lastInvocation.map(_.result)).exists {
         case BoolValue(true) => true
         case _               => false
       })
     }
   }
 
-  test("state machine effect invokes oracle and oracle call fails - transition should fail") {
+  test("state machine effect invokes script and script call fails - transition should fail") {
     TestFixture.resource().use { fixture =>
       implicit val s: SecurityProvider[IO] = fixture.securityProvider
       implicit val l0ctx: L0NodeContext[IO] = fixture.l0Context
@@ -143,29 +143,29 @@ object OracleStateMachineIntegrationSuite extends SimpleIOSuite {
       for {
         combiner <- Combiner.make[IO]().pure[IO]
 
-        oracleFiberId  <- UUIDGen.randomUUID[IO]
+        scriptFiberId  <- UUIDGen.randomUUID[IO]
         machineFiberId <- UUIDGen.randomUUID[IO]
 
-        oracleScript =
+        scriptSource =
           """|{"if":[
              |  {"==":[{"var":"method"},"validateAmount"]},
              |  {">=":[{"var":"args.amount"},100]},
              |  false
              |]}""".stripMargin
 
-        oracleProg <- IO.fromEither(parse(oracleScript).flatMap(_.as[JsonLogicExpression]))
+        scriptProg <- IO.fromEither(parse(scriptSource).flatMap(_.as[JsonLogicExpression]))
 
-        createOracle = Updates.CreateScript(
-          fiberId = oracleFiberId,
-          scriptProgram = oracleProg,
+        createScript = Updates.CreateScript(
+          fiberId = scriptFiberId,
+          scriptProgram = scriptProg,
           initialState = None,
           accessControl = AccessControlPolicy.Public
         )
 
-        oracleProof <- registry.generateProofs(createOracle, Set(Alice))
-        stateAfterOracle <- combiner.insert(
+        scriptProof <- registry.generateProofs(createScript, Set(Alice))
+        stateAfterScript <- combiner.insert(
           DataState(OnChain.genesis, CalculatedState.genesis),
-          Signed(createOracle, oracleProof)
+          Signed(createScript, scriptProof)
         )
 
         machineJson = s"""
@@ -182,8 +182,8 @@ object OracleStateMachineIntegrationSuite extends SimpleIOSuite {
               "eventName": "submit",
               "guard": true,
               "effect": {
-                "_oracleCall": {
-                  "fiberId": "$oracleFiberId",
+                "_scriptCall": {
+                  "fiberId": "$scriptFiberId",
                   "method": "validateAmount",
                   "args": {
                     "amount": { "var": "event.amount" }
@@ -203,7 +203,7 @@ object OracleStateMachineIntegrationSuite extends SimpleIOSuite {
 
         createMachine = Updates.CreateStateMachine(machineFiberId, machineDef, initialData)
         machineProof      <- registry.generateProofs(createMachine, Set(Bob))
-        stateAfterMachine <- combiner.insert(stateAfterOracle, Signed(createMachine, machineProof))
+        stateAfterMachine <- combiner.insert(stateAfterScript, Signed(createMachine, machineProof))
 
         submitEvent = Updates.TransitionStateMachine(
           machineFiberId,
@@ -218,18 +218,18 @@ object OracleStateMachineIntegrationSuite extends SimpleIOSuite {
           .get(machineFiberId)
           .collect { case r: Records.StateMachineFiberRecord => r }
 
-        oracle = finalState.calculated.scripts.get(oracleFiberId)
+        script = finalState.calculated.scripts.get(scriptFiberId)
 
       } yield expect(machine.isDefined) and
       expect(machine.map(_.currentState).contains(StateId("PENDING"))) and
       expect(machine.exists(_.lastReceipt.exists(r => !r.success))) and
-      expect(oracle.isDefined) and
-      expect(oracle.map(_.sequenceNumber).contains(FiberOrdinal.MinValue)) and
-      expect(oracle.map(_.lastInvocation.isEmpty).contains(true))
+      expect(script.isDefined) and
+      expect(script.map(_.sequenceNumber).contains(FiberOrdinal.MinValue)) and
+      expect(script.map(_.lastInvocation.isEmpty).contains(true))
     }
   }
 
-  test("state machine guard reads oracle state before transition") {
+  test("state machine guard reads script state before transition") {
     TestFixture.resource().use { fixture =>
       implicit val s: SecurityProvider[IO] = fixture.securityProvider
       implicit val l0ctx: L0NodeContext[IO] = fixture.l0Context
@@ -237,24 +237,24 @@ object OracleStateMachineIntegrationSuite extends SimpleIOSuite {
       for {
         combiner <- Combiner.make[IO]().pure[IO]
 
-        oracleFiberId  <- UUIDGen.randomUUID[IO]
+        scriptFiberId  <- UUIDGen.randomUUID[IO]
         machineFiberId <- UUIDGen.randomUUID[IO]
 
-        oracleScript = """{"counter": 5}"""
-        oracleProg <- IO.fromEither(parse(oracleScript).flatMap(_.as[JsonLogicExpression]))
-        initialOracleState = MapValue(Map("counter" -> IntValue(3)))
+        scriptSource = """{"counter": 5}"""
+        scriptProg <- IO.fromEither(parse(scriptSource).flatMap(_.as[JsonLogicExpression]))
+        initialScriptState = MapValue(Map("counter" -> IntValue(3)))
 
-        createOracle = Updates.CreateScript(
-          fiberId = oracleFiberId,
-          scriptProgram = oracleProg,
-          initialState = Some(initialOracleState),
+        createScript = Updates.CreateScript(
+          fiberId = scriptFiberId,
+          scriptProgram = scriptProg,
+          initialState = Some(initialScriptState),
           accessControl = AccessControlPolicy.Public
         )
 
-        oracleProof <- registry.generateProofs(createOracle, Set(Alice))
-        stateAfterOracle <- combiner.insert(
+        scriptProof <- registry.generateProofs(createScript, Set(Alice))
+        stateAfterScript <- combiner.insert(
           DataState(OnChain.genesis, CalculatedState.genesis),
-          Signed(createOracle, oracleProof)
+          Signed(createScript, scriptProof)
         )
 
         machineJson = s"""
@@ -271,14 +271,14 @@ object OracleStateMachineIntegrationSuite extends SimpleIOSuite {
               "eventName": "unlock",
               "guard": {
                 ">=": [
-                  { "var": "scripts.$oracleFiberId.state.counter" },
+                  { "var": "scripts.$scriptFiberId.state.counter" },
                   5
                 ]
               },
               "effect": {
                 "status": "unlocked"
               },
-              "dependencies": ["$oracleFiberId"]
+              "dependencies": ["$scriptFiberId"]
             }
           ]
         }
@@ -289,7 +289,7 @@ object OracleStateMachineIntegrationSuite extends SimpleIOSuite {
 
         createMachine = Updates.CreateStateMachine(machineFiberId, machineDef, initialData)
         machineProof      <- registry.generateProofs(createMachine, Set(Bob))
-        stateAfterMachine <- combiner.insert(stateAfterOracle, Signed(createMachine, machineProof))
+        stateAfterMachine <- combiner.insert(stateAfterScript, Signed(createMachine, machineProof))
 
         unlockEvent = Updates.TransitionStateMachine(
           machineFiberId,
@@ -304,14 +304,14 @@ object OracleStateMachineIntegrationSuite extends SimpleIOSuite {
           .get(machineFiberId)
           .collect { case r: Records.StateMachineFiberRecord => r }
 
-        invokeOracle = Updates.InvokeScript(
-          fiberId = oracleFiberId,
+        invokeScript = Updates.InvokeScript(
+          fiberId = scriptFiberId,
           method = "increment",
           args = MapValue(Map.empty),
           targetSequenceNumber = FiberOrdinal.MinValue
         )
-        invokeProof      <- registry.generateProofs(invokeOracle, Set(Alice))
-        stateAfterInvoke <- combiner.insert(stateAfterFirstUnlock, Signed(invokeOracle, invokeProof))
+        invokeProof      <- registry.generateProofs(invokeScript, Set(Alice))
+        stateAfterInvoke <- combiner.insert(stateAfterFirstUnlock, Signed(invokeScript, invokeProof))
 
         secondUnlockEvent = Updates.TransitionStateMachine(
           machineFiberId,
@@ -334,7 +334,7 @@ object OracleStateMachineIntegrationSuite extends SimpleIOSuite {
     }
   }
 
-  test("state machine uses oracle invocation result in subsequent state") {
+  test("state machine uses script invocation result in subsequent state") {
     TestFixture.resource().use { fixture =>
       implicit val s: SecurityProvider[IO] = fixture.securityProvider
       implicit val l0ctx: L0NodeContext[IO] = fixture.l0Context
@@ -342,29 +342,29 @@ object OracleStateMachineIntegrationSuite extends SimpleIOSuite {
       for {
         combiner <- Combiner.make[IO]().pure[IO]
 
-        oracleFiberId  <- UUIDGen.randomUUID[IO]
+        scriptFiberId  <- UUIDGen.randomUUID[IO]
         machineFiberId <- UUIDGen.randomUUID[IO]
 
-        oracleScript =
+        scriptSource =
           """|{"if":[
              |  {"==":[{"var":"method"},"calculateFee"]},
              |  {"*":[{"var":"args.amount"},0.05]},
              |  0
              |]}""".stripMargin
 
-        oracleProg <- IO.fromEither(parse(oracleScript).flatMap(_.as[JsonLogicExpression]))
+        scriptProg <- IO.fromEither(parse(scriptSource).flatMap(_.as[JsonLogicExpression]))
 
-        createOracle = Updates.CreateScript(
-          fiberId = oracleFiberId,
-          scriptProgram = oracleProg,
+        createScript = Updates.CreateScript(
+          fiberId = scriptFiberId,
+          scriptProgram = scriptProg,
           initialState = None,
           accessControl = AccessControlPolicy.Public
         )
 
-        oracleProof <- registry.generateProofs(createOracle, Set(Alice))
-        stateAfterOracle <- combiner.insert(
+        scriptProof <- registry.generateProofs(createScript, Set(Alice))
+        stateAfterScript <- combiner.insert(
           DataState(OnChain.genesis, CalculatedState.genesis),
-          Signed(createOracle, oracleProof)
+          Signed(createScript, scriptProof)
         )
 
         machineJson = s"""
@@ -382,8 +382,8 @@ object OracleStateMachineIntegrationSuite extends SimpleIOSuite {
               "eventName": "initiate",
               "guard": true,
               "effect": {
-                "_oracleCall": {
-                  "fiberId": "$oracleFiberId",
+                "_scriptCall": {
+                  "fiberId": "$scriptFiberId",
                   "method": "calculateFee",
                   "args": {
                     "amount": { "var": "event.amount" }
@@ -391,7 +391,7 @@ object OracleStateMachineIntegrationSuite extends SimpleIOSuite {
                 },
                 "amount": { "var": "event.amount" }
               },
-              "dependencies": ["$oracleFiberId"]
+              "dependencies": ["$scriptFiberId"]
             },
             {
               "from": "processing",
@@ -401,12 +401,12 @@ object OracleStateMachineIntegrationSuite extends SimpleIOSuite {
               "effect": [
                 ["totalAmount", { "+": [
                   { "var": "state.amount" },
-                  { "var": "scripts.$oracleFiberId.lastInvocation.result" }
+                  { "var": "scripts.$scriptFiberId.lastInvocation.result" }
                 ]}],
-                ["feeCalculated", { "var": "scripts.$oracleFiberId.lastInvocation.result" }],
+                ["feeCalculated", { "var": "scripts.$scriptFiberId.lastInvocation.result" }],
                 ["status", "COMPLETED"]
               ],
-              "dependencies": ["$oracleFiberId"]
+              "dependencies": ["$scriptFiberId"]
             }
           ]
         }
@@ -417,7 +417,7 @@ object OracleStateMachineIntegrationSuite extends SimpleIOSuite {
 
         createMachine = Updates.CreateStateMachine(machineFiberId, machineDef, initialData)
         machineProof      <- registry.generateProofs(createMachine, Set(Bob))
-        stateAfterMachine <- combiner.insert(stateAfterOracle, Signed(createMachine, machineProof))
+        stateAfterMachine <- combiner.insert(stateAfterScript, Signed(createMachine, machineProof))
 
         initiateEvent = Updates.TransitionStateMachine(
           machineFiberId,
@@ -478,7 +478,7 @@ object OracleStateMachineIntegrationSuite extends SimpleIOSuite {
     }
   }
 
-  test("multiple state machines invoking same oracle maintains invocation count") {
+  test("multiple state machines invoking same script maintains invocation count") {
     TestFixture.resource(Set(Alice, Bob, Charlie)).use { fixture =>
       implicit val s: SecurityProvider[IO] = fixture.securityProvider
       implicit val l0ctx: L0NodeContext[IO] = fixture.l0Context
@@ -486,24 +486,24 @@ object OracleStateMachineIntegrationSuite extends SimpleIOSuite {
       for {
         combiner <- Combiner.make[IO]().pure[IO]
 
-        oracleFiberId   <- UUIDGen.randomUUID[IO]
+        scriptFiberId   <- UUIDGen.randomUUID[IO]
         machine1fiberId <- UUIDGen.randomUUID[IO]
         machine2fiberId <- UUIDGen.randomUUID[IO]
 
-        oracleScript = """{"result": "validated"}"""
-        oracleProg <- IO.fromEither(parse(oracleScript).flatMap(_.as[JsonLogicExpression]))
+        scriptSource = """{"result": "validated"}"""
+        scriptProg <- IO.fromEither(parse(scriptSource).flatMap(_.as[JsonLogicExpression]))
 
-        createOracle = Updates.CreateScript(
-          fiberId = oracleFiberId,
-          scriptProgram = oracleProg,
+        createScript = Updates.CreateScript(
+          fiberId = scriptFiberId,
+          scriptProgram = scriptProg,
           initialState = None,
           accessControl = AccessControlPolicy.Public
         )
 
-        oracleProof <- registry.generateProofs(createOracle, Set(Alice))
-        stateAfterOracle <- combiner.insert(
+        scriptProof <- registry.generateProofs(createScript, Set(Alice))
+        stateAfterScript <- combiner.insert(
           DataState(OnChain.genesis, CalculatedState.genesis),
-          Signed(createOracle, oracleProof)
+          Signed(createScript, scriptProof)
         )
 
         machineJson = s"""
@@ -520,8 +520,8 @@ object OracleStateMachineIntegrationSuite extends SimpleIOSuite {
               "eventName": "validate",
               "guard": true,
               "effect": {
-                "_oracleCall": {
-                  "fiberId": "$oracleFiberId",
+                "_scriptCall": {
+                  "fiberId": "$scriptFiberId",
                   "method": "check",
                   "args": {}
                 },
@@ -538,7 +538,7 @@ object OracleStateMachineIntegrationSuite extends SimpleIOSuite {
 
         createMachine1 = Updates.CreateStateMachine(machine1fiberId, machineDef, initialData)
         machine1Proof      <- registry.generateProofs(createMachine1, Set(Bob))
-        stateAfterMachine1 <- combiner.insert(stateAfterOracle, Signed(createMachine1, machine1Proof))
+        stateAfterMachine1 <- combiner.insert(stateAfterScript, Signed(createMachine1, machine1Proof))
 
         createMachine2 = Updates.CreateStateMachine(machine2fiberId, machineDef, initialData)
         machine2Proof      <- registry.generateProofs(createMachine2, Set(Charlie))
@@ -562,13 +562,13 @@ object OracleStateMachineIntegrationSuite extends SimpleIOSuite {
         validate2Proof <- registry.generateProofs(validateEvent2, Set(Charlie))
         finalState     <- combiner.insert(stateAfterValidate1, Signed(validateEvent2, validate2Proof))
 
-        oracle = finalState.calculated.scripts.get(oracleFiberId)
+        script = finalState.calculated.scripts.get(scriptFiberId)
         machine1 = finalState.calculated.stateMachines.get(machine1fiberId)
         machine2 = finalState.calculated.stateMachines.get(machine2fiberId)
 
-      } yield expect(oracle.isDefined) and
-      expect(oracle.map(_.sequenceNumber).contains(FiberOrdinal.unsafeApply(2L))) and
-      expect(oracle.map(_.lastInvocation.isDefined).contains(true)) and
+      } yield expect(script.isDefined) and
+      expect(script.map(_.sequenceNumber).contains(FiberOrdinal.unsafeApply(2L))) and
+      expect(script.map(_.lastInvocation.isDefined).contains(true)) and
       expect(machine1.isDefined) and
       expect(machine2.isDefined) and
       expect(

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/ScriptValidationSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/ScriptValidationSuite.scala
@@ -18,10 +18,10 @@ import xyz.kd5ujc.shared_test.TestFixture
 import io.circe.parser
 import weaver.SimpleIOSuite
 
-object OracleValidationSuite extends SimpleIOSuite {
+object ScriptValidationSuite extends SimpleIOSuite {
 
   test("create script with public access") {
-    val oracleScript =
+    val scriptSource =
       """|{"if":[
          |  {"==":[{"var":"method"},"validate"]},
          |  {">=":[{"var":"args.value"},10]},
@@ -35,7 +35,7 @@ object OracleValidationSuite extends SimpleIOSuite {
         combiner <- Combiner.make[IO]().pure[IO]
 
         fiberId <- IO.randomUUID
-        prog    <- IO.fromEither(parser.parse(oracleScript).flatMap(_.as[JsonLogicExpression]))
+        prog    <- IO.fromEither(parser.parse(scriptSource).flatMap(_.as[JsonLogicExpression]))
 
         createUpdate = Updates.CreateScript(
           fiberId = fiberId,
@@ -47,15 +47,15 @@ object OracleValidationSuite extends SimpleIOSuite {
         createProof <- fixture.registry.generateProofs(createUpdate, Set(Alice))
         state <- combiner.insert(DataState(OnChain.genesis, CalculatedState.genesis), Signed(createUpdate, createProof))
 
-        oracle = state.calculated.scripts.get(fiberId)
-      } yield expect(oracle.isDefined) and
-      expect(oracle.map(_.status).contains(FiberStatus.Active)) and
-      expect(oracle.map(_.owners).contains(Set(fixture.registry.addresses(Alice))))
+        script = state.calculated.scripts.get(fiberId)
+      } yield expect(script.isDefined) and
+      expect(script.map(_.status).contains(FiberStatus.Active)) and
+      expect(script.map(_.owners).contains(Set(fixture.registry.addresses(Alice))))
     }
   }
 
-  test("invoke oracle with validation method") {
-    val oracleScript =
+  test("invoke script with validation method") {
+    val scriptSource =
       """|{"if":[
          |  {"==":[{"var":"method"},"validate"]},
          |  {">=":[{"var":"args.value"},10]},
@@ -69,7 +69,7 @@ object OracleValidationSuite extends SimpleIOSuite {
         combiner <- Combiner.make[IO]().pure[IO]
 
         fiberId <- IO.randomUUID
-        prog    <- IO.fromEither(parser.parse(oracleScript).flatMap(_.as[JsonLogicExpression]))
+        prog    <- IO.fromEither(parser.parse(scriptSource).flatMap(_.as[JsonLogicExpression]))
 
         createUpdate = Updates.CreateScript(
           fiberId = fiberId,
@@ -94,11 +94,11 @@ object OracleValidationSuite extends SimpleIOSuite {
         invokeProof <- fixture.registry.generateProofs(invokeUpdate, Set(Alice))
         state2      <- combiner.insert(state1, Signed(invokeUpdate, invokeProof))
 
-        oracle = state2.calculated.scripts.get(fiberId)
-        lastInvocation = oracle.flatMap(_.lastInvocation)
+        script = state2.calculated.scripts.get(fiberId)
+        lastInvocation = script.flatMap(_.lastInvocation)
 
-      } yield expect(oracle.isDefined) and
-      expect(oracle.map(_.sequenceNumber).contains(FiberOrdinal.MinValue.next)) and
+      } yield expect(script.isDefined) and
+      expect(script.map(_.sequenceNumber).contains(FiberOrdinal.MinValue.next)) and
       expect(lastInvocation.isDefined) and
       expect(lastInvocation.map(_.method).contains("validate")) and
       expect(
@@ -114,8 +114,8 @@ object OracleValidationSuite extends SimpleIOSuite {
     }
   }
 
-  test("invoke oracle validation fails when value too low") {
-    val oracleScript =
+  test("invoke script validation fails when value too low") {
+    val scriptSource =
       """|{"if":[
          |  {"==":[{"var":"method"},"validate"]},
          |  {">=":[{"var":"args.value"},10]},
@@ -129,7 +129,7 @@ object OracleValidationSuite extends SimpleIOSuite {
         combiner <- Combiner.make[IO]().pure[IO]
 
         fiberId <- IO.randomUUID
-        prog    <- IO.fromEither(parser.parse(oracleScript).flatMap(_.as[JsonLogicExpression]))
+        prog    <- IO.fromEither(parser.parse(scriptSource).flatMap(_.as[JsonLogicExpression]))
 
         createUpdate = Updates.CreateScript(
           fiberId = fiberId,

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/StatefulScriptSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/StatefulScriptSuite.scala
@@ -18,10 +18,10 @@ import xyz.kd5ujc.shared_test.TestFixture
 import io.circe.parser
 import weaver.SimpleIOSuite
 
-object StatefulOracleSuite extends SimpleIOSuite {
+object StatefulScriptSuite extends SimpleIOSuite {
 
-  test("oracle state initialization: null initial state") {
-    val oracleScript = """{"method":{"var":"method"},"result":42}"""
+  test("script state initialization: null initial state") {
+    val scriptSource = """{"method":{"var":"method"},"result":42}"""
 
     TestFixture.resource(Set(Alice)).use { fixture =>
       implicit val s: SecurityProvider[IO] = fixture.securityProvider
@@ -30,28 +30,28 @@ object StatefulOracleSuite extends SimpleIOSuite {
         combiner <- Combiner.make[IO]().pure[IO]
 
         fiberId <- IO.randomUUID
-        prog    <- IO.fromEither(parser.parse(oracleScript).flatMap(_.as[JsonLogicExpression]))
+        prog    <- IO.fromEither(parser.parse(scriptSource).flatMap(_.as[JsonLogicExpression]))
 
-        createOracle = Updates.CreateScript(
+        createScript = Updates.CreateScript(
           fiberId = fiberId,
           scriptProgram = prog,
           initialState = None,
           accessControl = AccessControlPolicy.Public
         )
 
-        createProof <- fixture.registry.generateProofs(createOracle, Set(Alice))
-        state <- combiner.insert(DataState(OnChain.genesis, CalculatedState.genesis), Signed(createOracle, createProof))
+        createProof <- fixture.registry.generateProofs(createScript, Set(Alice))
+        state <- combiner.insert(DataState(OnChain.genesis, CalculatedState.genesis), Signed(createScript, createProof))
 
-        oracle = state.calculated.scripts.get(fiberId)
-      } yield expect(oracle.isDefined) and
-      expect(oracle.map(_.stateData).contains(None)) and
-      expect(oracle.map(_.stateDataHash).contains(None)) and
-      expect(oracle.map(_.sequenceNumber).contains(FiberOrdinal.MinValue))
+        script = state.calculated.scripts.get(fiberId)
+      } yield expect(script.isDefined) and
+      expect(script.map(_.stateData).contains(None)) and
+      expect(script.map(_.stateDataHash).contains(None)) and
+      expect(script.map(_.sequenceNumber).contains(FiberOrdinal.MinValue))
     }
   }
 
-  test("oracle state transformation: explicit _state and _result") {
-    val oracleScript = """|{
+  test("script state transformation: explicit _state and _result") {
+    val scriptSource = """|{
                           |  "_state": {"counter": 5},
                           |  "_result": {"success": true, "newValue": 5}
                           |}""".stripMargin
@@ -63,45 +63,45 @@ object StatefulOracleSuite extends SimpleIOSuite {
         combiner <- Combiner.make[IO]().pure[IO]
 
         fiberId <- IO.randomUUID
-        prog    <- IO.fromEither(parser.parse(oracleScript).flatMap(_.as[JsonLogicExpression]))
+        prog    <- IO.fromEither(parser.parse(scriptSource).flatMap(_.as[JsonLogicExpression]))
 
         initialData = MapValue(Map("counter" -> IntValue(0)))
 
-        createOracle = Updates.CreateScript(
+        createScript = Updates.CreateScript(
           fiberId = fiberId,
           scriptProgram = prog,
           initialState = Some(initialData),
           accessControl = AccessControlPolicy.Public
         )
 
-        createProof <- fixture.registry.generateProofs(createOracle, Set(Alice))
+        createProof <- fixture.registry.generateProofs(createScript, Set(Alice))
         state1 <- combiner.insert(
           DataState(OnChain.genesis, CalculatedState.genesis),
-          Signed(createOracle, createProof)
+          Signed(createScript, createProof)
         )
 
-        invokeOracle = Updates.InvokeScript(
+        invokeScript = Updates.InvokeScript(
           fiberId = fiberId,
           method = "increment",
           args = MapValue(Map.empty),
           targetSequenceNumber = FiberOrdinal.MinValue
         )
 
-        invokeProof <- fixture.registry.generateProofs(invokeOracle, Set(Alice))
-        state2      <- combiner.insert(state1, Signed(invokeOracle, invokeProof))
+        invokeProof <- fixture.registry.generateProofs(invokeScript, Set(Alice))
+        state2      <- combiner.insert(state1, Signed(invokeScript, invokeProof))
 
-        oracle = state2.calculated.scripts.get(fiberId)
+        script = state2.calculated.scripts.get(fiberId)
         expectedState = MapValue(Map("counter" -> IntValue(5)))
         expectedResult = MapValue(Map("success" -> BoolValue(true), "newValue" -> IntValue(5)))
-      } yield expect(oracle.isDefined) and
-      expect(oracle.flatMap(_.stateData).contains(expectedState)) and
-      expect(oracle.map(_.sequenceNumber).contains(FiberOrdinal.MinValue.next)) and
-      expect(oracle.flatMap(_.lastInvocation.map(_.result)).contains(expectedResult))
+      } yield expect(script.isDefined) and
+      expect(script.flatMap(_.stateData).contains(expectedState)) and
+      expect(script.map(_.sequenceNumber).contains(FiberOrdinal.MinValue.next)) and
+      expect(script.flatMap(_.lastInvocation.map(_.result)).contains(expectedResult))
     }
   }
 
-  test("oracle state transformation: simple return value becomes state") {
-    val oracleScript = """{"counter": 1}"""
+  test("script state transformation: simple return value becomes state") {
+    val scriptSource = """{"counter": 1}"""
 
     TestFixture.resource(Set(Alice)).use { fixture =>
       implicit val s: SecurityProvider[IO] = fixture.securityProvider
@@ -110,42 +110,42 @@ object StatefulOracleSuite extends SimpleIOSuite {
         combiner <- Combiner.make[IO]().pure[IO]
 
         fiberId <- IO.randomUUID
-        prog    <- IO.fromEither(parser.parse(oracleScript).flatMap(_.as[JsonLogicExpression]))
+        prog    <- IO.fromEither(parser.parse(scriptSource).flatMap(_.as[JsonLogicExpression]))
 
-        createOracle = Updates.CreateScript(
+        createScript = Updates.CreateScript(
           fiberId = fiberId,
           scriptProgram = prog,
           initialState = None,
           accessControl = AccessControlPolicy.Public
         )
 
-        createProof <- fixture.registry.generateProofs(createOracle, Set(Alice))
+        createProof <- fixture.registry.generateProofs(createScript, Set(Alice))
         state1 <- combiner.insert(
           DataState(OnChain.genesis, CalculatedState.genesis),
-          Signed(createOracle, createProof)
+          Signed(createScript, createProof)
         )
 
-        invokeOracle = Updates.InvokeScript(
+        invokeScript = Updates.InvokeScript(
           fiberId = fiberId,
           method = "increment",
           args = MapValue(Map.empty),
           targetSequenceNumber = FiberOrdinal.MinValue
         )
 
-        invokeProof <- fixture.registry.generateProofs(invokeOracle, Set(Alice))
-        state2      <- combiner.insert(state1, Signed(invokeOracle, invokeProof))
+        invokeProof <- fixture.registry.generateProofs(invokeScript, Set(Alice))
+        state2      <- combiner.insert(state1, Signed(invokeScript, invokeProof))
 
-        oracle = state2.calculated.scripts.get(fiberId)
+        script = state2.calculated.scripts.get(fiberId)
         expectedState = MapValue(Map("counter" -> IntValue(1)))
-      } yield expect(oracle.isDefined) and
-      expect(oracle.flatMap(_.stateData).contains(expectedState)) and
-      expect(oracle.map(_.sequenceNumber).contains(FiberOrdinal.MinValue.next)) and
-      expect(oracle.flatMap(_.lastInvocation.map(_.result)).contains(expectedState))
+      } yield expect(script.isDefined) and
+      expect(script.flatMap(_.stateData).contains(expectedState)) and
+      expect(script.map(_.sequenceNumber).contains(FiberOrdinal.MinValue.next)) and
+      expect(script.flatMap(_.lastInvocation.map(_.result)).contains(expectedState))
     }
   }
 
-  test("oracle state transformation: _state only (result is full response)") {
-    val oracleScript = """|{
+  test("script state transformation: _state only (result is full response)") {
+    val scriptSource = """|{
                           |  "_state": {"visits": 1},
                           |  "message": "Visit recorded"
                           |}""".stripMargin
@@ -157,34 +157,34 @@ object StatefulOracleSuite extends SimpleIOSuite {
         combiner <- Combiner.make[IO]().pure[IO]
 
         fiberId <- IO.randomUUID
-        prog    <- IO.fromEither(parser.parse(oracleScript).flatMap(_.as[JsonLogicExpression]))
+        prog    <- IO.fromEither(parser.parse(scriptSource).flatMap(_.as[JsonLogicExpression]))
 
         initialData = MapValue(Map("visits" -> IntValue(0)))
 
-        createOracle = Updates.CreateScript(
+        createScript = Updates.CreateScript(
           fiberId = fiberId,
           scriptProgram = prog,
           initialState = Some(initialData),
           accessControl = AccessControlPolicy.Public
         )
 
-        createProof <- fixture.registry.generateProofs(createOracle, Set(Alice))
+        createProof <- fixture.registry.generateProofs(createScript, Set(Alice))
         state1 <- combiner.insert(
           DataState(OnChain.genesis, CalculatedState.genesis),
-          Signed(createOracle, createProof)
+          Signed(createScript, createProof)
         )
 
-        invokeOracle = Updates.InvokeScript(
+        invokeScript = Updates.InvokeScript(
           fiberId = fiberId,
           method = "visit",
           args = MapValue(Map.empty),
           targetSequenceNumber = FiberOrdinal.MinValue
         )
 
-        invokeProof <- fixture.registry.generateProofs(invokeOracle, Set(Alice))
-        state2      <- combiner.insert(state1, Signed(invokeOracle, invokeProof))
+        invokeProof <- fixture.registry.generateProofs(invokeScript, Set(Alice))
+        state2      <- combiner.insert(state1, Signed(invokeScript, invokeProof))
 
-        oracle = state2.calculated.scripts.get(fiberId)
+        script = state2.calculated.scripts.get(fiberId)
         expectedState = MapValue(Map("visits" -> IntValue(1)))
         expectedResult = MapValue(
           Map(
@@ -192,14 +192,14 @@ object StatefulOracleSuite extends SimpleIOSuite {
             "message" -> StrValue("Visit recorded")
           )
         )
-      } yield expect(oracle.isDefined) and
-      expect(oracle.flatMap(_.stateData).contains(expectedState)) and
-      expect(oracle.flatMap(_.lastInvocation.map(_.result)).contains(expectedResult))
+      } yield expect(script.isDefined) and
+      expect(script.flatMap(_.stateData).contains(expectedState)) and
+      expect(script.flatMap(_.lastInvocation.map(_.result)).contains(expectedResult))
     }
   }
 
-  test("oracle state persistence: multiple invocations maintain state") {
-    val oracleScript = """|{
+  test("script state persistence: multiple invocations maintain state") {
+    val scriptSource = """|{
                           |  "_state": {"callCount": 99},
                           |  "_result": "incremented"
                           |}""".stripMargin
@@ -211,21 +211,21 @@ object StatefulOracleSuite extends SimpleIOSuite {
         combiner <- Combiner.make[IO]().pure[IO]
 
         fiberId <- IO.randomUUID
-        prog    <- IO.fromEither(parser.parse(oracleScript).flatMap(_.as[JsonLogicExpression]))
+        prog    <- IO.fromEither(parser.parse(scriptSource).flatMap(_.as[JsonLogicExpression]))
 
         initialData = MapValue(Map("callCount" -> IntValue(0)))
 
-        createOracle = Updates.CreateScript(
+        createScript = Updates.CreateScript(
           fiberId = fiberId,
           scriptProgram = prog,
           initialState = Some(initialData),
           accessControl = AccessControlPolicy.Public
         )
 
-        createProof <- fixture.registry.generateProofs(createOracle, Set(Alice))
+        createProof <- fixture.registry.generateProofs(createScript, Set(Alice))
         state0 <- combiner.insert(
           DataState(OnChain.genesis, CalculatedState.genesis),
-          Signed(createOracle, createProof)
+          Signed(createScript, createProof)
         )
 
         // First invocation
@@ -233,7 +233,7 @@ object StatefulOracleSuite extends SimpleIOSuite {
         proof1 <- fixture.registry.generateProofs(invoke1, Set(Alice))
         state1 <- combiner.insert(state0, Signed(invoke1, proof1))
 
-        oracle1 = state1.calculated.scripts.get(fiberId)
+        script1 = state1.calculated.scripts.get(fiberId)
 
         // Second invocation
         invoke2 = Updates
@@ -246,13 +246,13 @@ object StatefulOracleSuite extends SimpleIOSuite {
         proof2 <- fixture.registry.generateProofs(invoke2, Set(Alice))
         state2 <- combiner.insert(state1, Signed(invoke2, proof2))
 
-        oracle2 = state2.calculated.scripts.get(fiberId)
+        script2 = state2.calculated.scripts.get(fiberId)
 
-      } yield expect(oracle1.map(_.sequenceNumber).contains(FiberOrdinal.MinValue.next)) and
-      expect(oracle1.flatMap(_.stateData).contains(MapValue(Map("callCount" -> IntValue(99))))) and
-      expect(oracle2.map(_.sequenceNumber).contains(FiberOrdinal.unsafeApply(2L))) and
-      expect(oracle2.flatMap(_.stateData).contains(MapValue(Map("callCount" -> IntValue(99))))) and
-      expect(oracle2.map(_.lastInvocation.isDefined).contains(true))
+      } yield expect(script1.map(_.sequenceNumber).contains(FiberOrdinal.MinValue.next)) and
+      expect(script1.flatMap(_.stateData).contains(MapValue(Map("callCount" -> IntValue(99))))) and
+      expect(script2.map(_.sequenceNumber).contains(FiberOrdinal.unsafeApply(2L))) and
+      expect(script2.flatMap(_.stateData).contains(MapValue(Map("callCount" -> IntValue(99))))) and
+      expect(script2.map(_.lastInvocation.isDefined).contains(true))
     }
   }
 }

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/ValidatorSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/ValidatorSuite.scala
@@ -214,7 +214,7 @@ object ValidatorSuite extends SimpleIOSuite {
       )
     }
 
-    def simpleOracleScript(): JsonLogicExpression =
+    def simpleScript(): JsonLogicExpression =
       ConstExpression(MapValue(Map("result" -> IntValue(42))))
 
     /** Definition with a reserved operator name used as a field in guard */
@@ -732,7 +732,7 @@ object ValidatorSuite extends SimpleIOSuite {
     }
   }
 
-  // ============== Oracle Initial State Tests (L1) ==============
+  // ============== Script Initial State Tests (L1) ==============
 
   test("initialStateIsMapValueOrNull: None accepted") {
     TestFixture.resource().use { fixture =>
@@ -742,7 +742,7 @@ object ValidatorSuite extends SimpleIOSuite {
         validator <- Validator.make[IO]
         fiberId   <- UUIDGen.randomUUID[IO]
         update = Updates
-          .CreateScript(fiberId, Fixtures.simpleOracleScript(), None, AccessControlPolicy.Public)
+          .CreateScript(fiberId, Fixtures.simpleScript(), None, AccessControlPolicy.Public)
         result <- validator.validateUpdate(update)
       } yield expect(result.isValid)
     }
@@ -757,7 +757,7 @@ object ValidatorSuite extends SimpleIOSuite {
         fiberId   <- UUIDGen.randomUUID[IO]
         update = Updates.CreateScript(
           fiberId,
-          Fixtures.simpleOracleScript(),
+          Fixtures.simpleScript(),
           Some(MapValue(Map("counter" -> IntValue(0)))),
           AccessControlPolicy.Public
         )
@@ -775,7 +775,7 @@ object ValidatorSuite extends SimpleIOSuite {
         fiberId   <- UUIDGen.randomUUID[IO]
         update = Updates.CreateScript(
           fiberId,
-          Fixtures.simpleOracleScript(),
+          Fixtures.simpleScript(),
           Some(ArrayValue(List(IntValue(1)))),
           AccessControlPolicy.Public
         )
@@ -856,9 +856,9 @@ object ValidatorSuite extends SimpleIOSuite {
     }
   }
 
-  // ============== Oracle Access Control Tests (L0) ==============
+  // ============== Script Access Control Tests (L0) ==============
 
-  test("oracleAccessControlCheck: public policy allows any caller") {
+  test("scriptAccessControlCheck: public policy allows any caller") {
     TestFixture.resource().use { fixture =>
       implicit val s: SecurityProvider[IO] = fixture.securityProvider
       implicit val l0ctx: L0NodeContext[IO] = fixture.l0Context
@@ -866,22 +866,22 @@ object ValidatorSuite extends SimpleIOSuite {
       for {
         combiner  <- Combiner.make[IO]().pure[IO]
         validator <- Validator.make[IO]
-        oracleId  <- UUIDGen.randomUUID[IO]
+        scriptId  <- UUIDGen.randomUUID[IO]
 
-        createOracle = Updates
-          .CreateScript(oracleId, Fixtures.simpleOracleScript(), None, AccessControlPolicy.Public)
-        createProof <- fixture.registry.generateProofs(createOracle, Set(Alice))
+        createScript = Updates
+          .CreateScript(scriptId, Fixtures.simpleScript(), None, AccessControlPolicy.Public)
+        createProof <- fixture.registry.generateProofs(createScript, Set(Alice))
         stateAfterCreate <- combiner
-          .insert(DataState(OnChain.genesis, CalculatedState.genesis), Signed(createOracle, createProof))
+          .insert(DataState(OnChain.genesis, CalculatedState.genesis), Signed(createScript, createProof))
 
-        invokeOracle = Updates.InvokeScript(oracleId, "test", MapValue(Map.empty), FiberOrdinal.MinValue)
-        invokeProof <- fixture.registry.generateProofs(invokeOracle, Set(Bob))
-        result      <- validator.validateSignedUpdate(stateAfterCreate, Signed(invokeOracle, invokeProof))
+        invokeScript = Updates.InvokeScript(scriptId, "test", MapValue(Map.empty), FiberOrdinal.MinValue)
+        invokeProof <- fixture.registry.generateProofs(invokeScript, Set(Bob))
+        result      <- validator.validateSignedUpdate(stateAfterCreate, Signed(invokeScript, invokeProof))
       } yield expect(result.isValid)
     }
   }
 
-  test("oracleAccessControlCheck: whitelist allows authorized caller") {
+  test("scriptAccessControlCheck: whitelist allows authorized caller") {
     TestFixture.resource().use { fixture =>
       implicit val s: SecurityProvider[IO] = fixture.securityProvider
       implicit val l0ctx: L0NodeContext[IO] = fixture.l0Context
@@ -889,27 +889,27 @@ object ValidatorSuite extends SimpleIOSuite {
       for {
         combiner  <- Combiner.make[IO]().pure[IO]
         validator <- Validator.make[IO]
-        oracleId  <- UUIDGen.randomUUID[IO]
+        scriptId  <- UUIDGen.randomUUID[IO]
         bobAddr   <- fixture.registry.addresses(Bob).pure[IO]
 
-        createOracle = Updates.CreateScript(
-          oracleId,
-          Fixtures.simpleOracleScript(),
+        createScript = Updates.CreateScript(
+          scriptId,
+          Fixtures.simpleScript(),
           None,
           AccessControlPolicy.Whitelist(Set(bobAddr))
         )
-        createProof <- fixture.registry.generateProofs(createOracle, Set(Alice))
+        createProof <- fixture.registry.generateProofs(createScript, Set(Alice))
         stateAfterCreate <- combiner
-          .insert(DataState(OnChain.genesis, CalculatedState.genesis), Signed(createOracle, createProof))
+          .insert(DataState(OnChain.genesis, CalculatedState.genesis), Signed(createScript, createProof))
 
-        invokeOracle = Updates.InvokeScript(oracleId, "test", MapValue(Map.empty), FiberOrdinal.MinValue)
-        invokeProof <- fixture.registry.generateProofs(invokeOracle, Set(Bob))
-        result      <- validator.validateSignedUpdate(stateAfterCreate, Signed(invokeOracle, invokeProof))
+        invokeScript = Updates.InvokeScript(scriptId, "test", MapValue(Map.empty), FiberOrdinal.MinValue)
+        invokeProof <- fixture.registry.generateProofs(invokeScript, Set(Bob))
+        result      <- validator.validateSignedUpdate(stateAfterCreate, Signed(invokeScript, invokeProof))
       } yield expect(result.isValid)
     }
   }
 
-  test("oracleAccessControlCheck: whitelist denies unauthorized caller") {
+  test("scriptAccessControlCheck: whitelist denies unauthorized caller") {
     TestFixture.resource(Set(Alice, Bob, Charlie)).use { fixture =>
       implicit val s: SecurityProvider[IO] = fixture.securityProvider
       implicit val l0ctx: L0NodeContext[IO] = fixture.l0Context
@@ -917,22 +917,22 @@ object ValidatorSuite extends SimpleIOSuite {
       for {
         combiner  <- Combiner.make[IO]().pure[IO]
         validator <- Validator.make[IO]
-        oracleId  <- UUIDGen.randomUUID[IO]
+        scriptId  <- UUIDGen.randomUUID[IO]
         bobAddr   <- fixture.registry.addresses(Bob).pure[IO]
 
-        createOracle = Updates.CreateScript(
-          oracleId,
-          Fixtures.simpleOracleScript(),
+        createScript = Updates.CreateScript(
+          scriptId,
+          Fixtures.simpleScript(),
           None,
           AccessControlPolicy.Whitelist(Set(bobAddr))
         )
-        createProof <- fixture.registry.generateProofs(createOracle, Set(Alice))
+        createProof <- fixture.registry.generateProofs(createScript, Set(Alice))
         stateAfterCreate <- combiner
-          .insert(DataState(OnChain.genesis, CalculatedState.genesis), Signed(createOracle, createProof))
+          .insert(DataState(OnChain.genesis, CalculatedState.genesis), Signed(createScript, createProof))
 
-        invokeOracle = Updates.InvokeScript(oracleId, "test", MapValue(Map.empty), FiberOrdinal.MinValue)
-        invokeProof <- fixture.registry.generateProofs(invokeOracle, Set(Charlie))
-        result      <- validator.validateSignedUpdate(stateAfterCreate, Signed(invokeOracle, invokeProof))
+        invokeScript = Updates.InvokeScript(scriptId, "test", MapValue(Map.empty), FiberOrdinal.MinValue)
+        invokeProof <- fixture.registry.generateProofs(invokeScript, Set(Charlie))
+        result      <- validator.validateSignedUpdate(stateAfterCreate, Signed(invokeScript, invokeProof))
       } yield expect(result.isInvalid) and
       expect(result.swap.exists(_.exists(_.message.toLowerCase.contains("access denied"))))
     }

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/examples/AgentIdentityLifecycleSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/examples/AgentIdentityLifecycleSuite.scala
@@ -34,7 +34,7 @@ import weaver.SimpleIOSuite
  * Fiber Architecture:
  *   - AgentIdentity: Core identity + reputation state machine per agent
  *   - PlatformRegistry: Tracks registered attestation source platforms
- *   - ReputationOracle: Script oracle that computes composite reputation scores
+ *   - ReputationScript: Script that computes composite reputation scores
  *
  * State Lifecycle:
  *   Registered → Active → Challenged → Suspended → Probation → Active (recovery)

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/examples/CalculatorScriptSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/examples/CalculatorScriptSuite.scala
@@ -20,14 +20,14 @@ import io.circe.parser
 import weaver.SimpleIOSuite
 
 /**
- * Unit tests for the calculator oracle (stateless - initialState: null).
- * Based on e2e-test/examples/calculator-oracle/definition.json
+ * Unit tests for the calculator script (stateless - initialState: null).
+ * Based on e2e-test/examples/calculator-script/definition.json
  */
-object CalculatorOracleSuite extends SimpleIOSuite {
+object CalculatorScriptSuite extends SimpleIOSuite {
 
   import DataStateTestOps._
 
-  // Calculator Oracle definition (stateless) - matches e2e definition
+  // Calculator Script definition (stateless) - matches e2e definition
   private val calculatorScript =
     """|{
        |  "if": [
@@ -55,35 +55,35 @@ object CalculatorOracleSuite extends SimpleIOSuite {
         cid  <- IO.randomUUID
         prog <- IO.fromEither(parser.parse(calculatorScript).flatMap(_.as[JsonLogicExpression]))
 
-        createOracle = Updates.CreateScript(
+        createScript = Updates.CreateScript(
           fiberId = cid,
           scriptProgram = prog,
           initialState = None,
           accessControl = AccessControlPolicy.Public
         )
 
-        createProof <- registry.generateProofs(createOracle, Set(Alice))
+        createProof <- registry.generateProofs(createScript, Set(Alice))
         state1 <- combiner.insert(
           DataState(OnChain.genesis, CalculatedState.genesis),
-          Signed(createOracle, createProof)
+          Signed(createScript, createProof)
         )
 
-        invokeOracle = Updates.InvokeScript(
+        invokeScript = Updates.InvokeScript(
           fiberId = cid,
           method = "add",
           args = MapValue(Map("a" -> IntValue(10), "b" -> IntValue(5))),
           targetSequenceNumber = FiberOrdinal.MinValue
         )
 
-        invokeProof <- registry.generateProofs(invokeOracle, Set(Alice))
-        state2      <- combiner.insert(state1, Signed(invokeOracle, invokeProof))
+        invokeProof <- registry.generateProofs(invokeScript, Set(Alice))
+        state2      <- combiner.insert(state1, Signed(invokeScript, invokeProof))
 
-        oracle = state2.oracleRecord(cid)
-        result = oracle.flatMap(_.lastInvocation.map(_.result))
+        script = state2.scriptRecord(cid)
+        result = script.flatMap(_.lastInvocation.map(_.result))
       } yield expect.all(
-        oracle.isDefined,
+        script.isDefined,
         result.contains(IntValue(15)),
-        oracle.map(_.sequenceNumber).contains(FiberOrdinal.MinValue.next)
+        script.map(_.sequenceNumber).contains(FiberOrdinal.MinValue.next)
       )
     }
   }
@@ -100,33 +100,33 @@ object CalculatorOracleSuite extends SimpleIOSuite {
         cid  <- IO.randomUUID
         prog <- IO.fromEither(parser.parse(calculatorScript).flatMap(_.as[JsonLogicExpression]))
 
-        createOracle = Updates.CreateScript(
+        createScript = Updates.CreateScript(
           fiberId = cid,
           scriptProgram = prog,
           initialState = None,
           accessControl = AccessControlPolicy.Public
         )
 
-        createProof <- registry.generateProofs(createOracle, Set(Alice))
+        createProof <- registry.generateProofs(createScript, Set(Alice))
         state1 <- combiner.insert(
           DataState(OnChain.genesis, CalculatedState.genesis),
-          Signed(createOracle, createProof)
+          Signed(createScript, createProof)
         )
 
-        invokeOracle = Updates.InvokeScript(
+        invokeScript = Updates.InvokeScript(
           fiberId = cid,
           method = "subtract",
           args = MapValue(Map("a" -> IntValue(20), "b" -> IntValue(8))),
           targetSequenceNumber = FiberOrdinal.MinValue
         )
 
-        invokeProof <- registry.generateProofs(invokeOracle, Set(Alice))
-        state2      <- combiner.insert(state1, Signed(invokeOracle, invokeProof))
+        invokeProof <- registry.generateProofs(invokeScript, Set(Alice))
+        state2      <- combiner.insert(state1, Signed(invokeScript, invokeProof))
 
-        oracle = state2.oracleRecord(cid)
-        result = oracle.flatMap(_.lastInvocation.map(_.result))
+        script = state2.scriptRecord(cid)
+        result = script.flatMap(_.lastInvocation.map(_.result))
       } yield expect.all(
-        oracle.isDefined,
+        script.isDefined,
         result.contains(IntValue(12))
       )
     }
@@ -144,33 +144,33 @@ object CalculatorOracleSuite extends SimpleIOSuite {
         cid  <- IO.randomUUID
         prog <- IO.fromEither(parser.parse(calculatorScript).flatMap(_.as[JsonLogicExpression]))
 
-        createOracle = Updates.CreateScript(
+        createScript = Updates.CreateScript(
           fiberId = cid,
           scriptProgram = prog,
           initialState = None,
           accessControl = AccessControlPolicy.Public
         )
 
-        createProof <- registry.generateProofs(createOracle, Set(Alice))
+        createProof <- registry.generateProofs(createScript, Set(Alice))
         state1 <- combiner.insert(
           DataState(OnChain.genesis, CalculatedState.genesis),
-          Signed(createOracle, createProof)
+          Signed(createScript, createProof)
         )
 
-        invokeOracle = Updates.InvokeScript(
+        invokeScript = Updates.InvokeScript(
           fiberId = cid,
           method = "multiply",
           args = MapValue(Map("a" -> IntValue(7), "b" -> IntValue(6))),
           targetSequenceNumber = FiberOrdinal.MinValue
         )
 
-        invokeProof <- registry.generateProofs(invokeOracle, Set(Alice))
-        state2      <- combiner.insert(state1, Signed(invokeOracle, invokeProof))
+        invokeProof <- registry.generateProofs(invokeScript, Set(Alice))
+        state2      <- combiner.insert(state1, Signed(invokeScript, invokeProof))
 
-        oracle = state2.oracleRecord(cid)
-        result = oracle.flatMap(_.lastInvocation.map(_.result))
+        script = state2.scriptRecord(cid)
+        result = script.flatMap(_.lastInvocation.map(_.result))
       } yield expect.all(
-        oracle.isDefined,
+        script.isDefined,
         result.contains(IntValue(42))
       )
     }
@@ -188,33 +188,33 @@ object CalculatorOracleSuite extends SimpleIOSuite {
         cid  <- IO.randomUUID
         prog <- IO.fromEither(parser.parse(calculatorScript).flatMap(_.as[JsonLogicExpression]))
 
-        createOracle = Updates.CreateScript(
+        createScript = Updates.CreateScript(
           fiberId = cid,
           scriptProgram = prog,
           initialState = None,
           accessControl = AccessControlPolicy.Public
         )
 
-        createProof <- registry.generateProofs(createOracle, Set(Alice))
+        createProof <- registry.generateProofs(createScript, Set(Alice))
         state1 <- combiner.insert(
           DataState(OnChain.genesis, CalculatedState.genesis),
-          Signed(createOracle, createProof)
+          Signed(createScript, createProof)
         )
 
-        invokeOracle = Updates.InvokeScript(
+        invokeScript = Updates.InvokeScript(
           fiberId = cid,
           method = "divide",
           args = MapValue(Map("a" -> IntValue(100), "b" -> IntValue(4))),
           targetSequenceNumber = FiberOrdinal.MinValue
         )
 
-        invokeProof <- registry.generateProofs(invokeOracle, Set(Alice))
-        state2      <- combiner.insert(state1, Signed(invokeOracle, invokeProof))
+        invokeProof <- registry.generateProofs(invokeScript, Set(Alice))
+        state2      <- combiner.insert(state1, Signed(invokeScript, invokeProof))
 
-        oracle = state2.oracleRecord(cid)
-        result = oracle.flatMap(_.lastInvocation.map(_.result))
+        script = state2.scriptRecord(cid)
+        result = script.flatMap(_.lastInvocation.map(_.result))
       } yield expect.all(
-        oracle.isDefined,
+        script.isDefined,
         result.contains(IntValue(25))
       )
     }
@@ -232,33 +232,33 @@ object CalculatorOracleSuite extends SimpleIOSuite {
         cid  <- IO.randomUUID
         prog <- IO.fromEither(parser.parse(calculatorScript).flatMap(_.as[JsonLogicExpression]))
 
-        createOracle = Updates.CreateScript(
+        createScript = Updates.CreateScript(
           fiberId = cid,
           scriptProgram = prog,
           initialState = None,
           accessControl = AccessControlPolicy.Public
         )
 
-        createProof <- registry.generateProofs(createOracle, Set(Alice))
+        createProof <- registry.generateProofs(createScript, Set(Alice))
         state1 <- combiner.insert(
           DataState(OnChain.genesis, CalculatedState.genesis),
-          Signed(createOracle, createProof)
+          Signed(createScript, createProof)
         )
 
-        invokeOracle = Updates.InvokeScript(
+        invokeScript = Updates.InvokeScript(
           fiberId = cid,
           method = "unknownMethod",
           args = MapValue(Map("a" -> IntValue(1), "b" -> IntValue(2))),
           targetSequenceNumber = FiberOrdinal.MinValue
         )
 
-        invokeProof <- registry.generateProofs(invokeOracle, Set(Alice))
-        state2      <- combiner.insert(state1, Signed(invokeOracle, invokeProof))
+        invokeProof <- registry.generateProofs(invokeScript, Set(Alice))
+        state2      <- combiner.insert(state1, Signed(invokeScript, invokeProof))
 
-        oracle = state2.oracleRecord(cid)
-        result = oracle.flatMap(_.lastInvocation.map(_.result))
+        script = state2.scriptRecord(cid)
+        result = script.flatMap(_.lastInvocation.map(_.result))
       } yield expect.all(
-        oracle.isDefined,
+        script.isDefined,
         result.contains(NullValue)
       )
     }
@@ -276,17 +276,17 @@ object CalculatorOracleSuite extends SimpleIOSuite {
         cid  <- IO.randomUUID
         prog <- IO.fromEither(parser.parse(calculatorScript).flatMap(_.as[JsonLogicExpression]))
 
-        createOracle = Updates.CreateScript(
+        createScript = Updates.CreateScript(
           fiberId = cid,
           scriptProgram = prog,
           initialState = None,
           accessControl = AccessControlPolicy.Public
         )
 
-        createProof <- registry.generateProofs(createOracle, Set(Alice))
+        createProof <- registry.generateProofs(createScript, Set(Alice))
         state0 <- combiner.insert(
           DataState(OnChain.genesis, CalculatedState.genesis),
-          Signed(createOracle, createProof)
+          Signed(createScript, createProof)
         )
 
         // First invocation: add
@@ -319,10 +319,10 @@ object CalculatorOracleSuite extends SimpleIOSuite {
         proof3 <- registry.generateProofs(invoke3, Set(Alice))
         state3 <- combiner.insert(state2, Signed(invoke3, proof3))
 
-        oracle = state3.oracleRecord(cid)
+        script = state3.scriptRecord(cid)
       } yield expect.all(
-        oracle.map(_.sequenceNumber).contains(FiberOrdinal.unsafeApply(3L)),
-        oracle.flatMap(_.lastInvocation).isDefined
+        script.map(_.sequenceNumber).contains(FiberOrdinal.unsafeApply(3L)),
+        script.flatMap(_.lastInvocation).isDefined
       )
     }
   }
@@ -339,7 +339,7 @@ object CalculatorOracleSuite extends SimpleIOSuite {
         cid  <- IO.randomUUID
         prog <- IO.fromEither(parser.parse(calculatorScript).flatMap(_.as[JsonLogicExpression]))
 
-        createOracle = Updates.CreateScript(
+        createScript = Updates.CreateScript(
           fiberId = cid,
           scriptProgram = prog,
           initialState = None,
@@ -347,13 +347,13 @@ object CalculatorOracleSuite extends SimpleIOSuite {
         )
 
         // Alice creates
-        createProof <- registry.generateProofs(createOracle, Set(Alice))
+        createProof <- registry.generateProofs(createScript, Set(Alice))
         state1 <- combiner.insert(
           DataState(OnChain.genesis, CalculatedState.genesis),
-          Signed(createOracle, createProof)
+          Signed(createScript, createProof)
         )
 
-        invokeOracle = Updates.InvokeScript(
+        invokeScript = Updates.InvokeScript(
           fiberId = cid,
           method = "add",
           args = MapValue(Map("a" -> IntValue(5), "b" -> IntValue(3))),
@@ -361,13 +361,13 @@ object CalculatorOracleSuite extends SimpleIOSuite {
         )
 
         // Bob invokes
-        invokeProof <- registry.generateProofs(invokeOracle, Set(Bob))
-        state2      <- combiner.insert(state1, Signed(invokeOracle, invokeProof))
+        invokeProof <- registry.generateProofs(invokeScript, Set(Bob))
+        state2      <- combiner.insert(state1, Signed(invokeScript, invokeProof))
 
-        oracle = state2.oracleRecord(cid)
-        result = oracle.flatMap(_.lastInvocation.map(_.result))
+        script = state2.scriptRecord(cid)
+        result = script.flatMap(_.lastInvocation.map(_.result))
       } yield expect.all(
-        oracle.isDefined,
+        script.isDefined,
         result.contains(IntValue(8))
       )
     }

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/examples/CounterScriptSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/examples/CounterScriptSuite.scala
@@ -20,7 +20,7 @@ import io.circe.parser
 import weaver.SimpleIOSuite
 
 /**
- * Unit tests for the counter oracle (stateful with non-null initialState).
+ * Unit tests for the counter script (stateful with non-null initialState).
  *
  * NOTE: The e2e definition uses "count" as a field name, but "count" is a reserved
  * JLVM operation (see metakit JsonLogicOp.scala line 55). Single-key objects like
@@ -28,7 +28,7 @@ import weaver.SimpleIOSuite
  *
  * Solution: Use "value" instead of "count" to avoid the reserved operation name.
  */
-object CounterOracleSuite extends SimpleIOSuite {
+object CounterScriptSuite extends SimpleIOSuite {
 
   import DataStateTestOps._
 
@@ -59,22 +59,22 @@ object CounterOracleSuite extends SimpleIOSuite {
         cid  <- IO.randomUUID
         prog <- IO.fromEither(parser.parse(counterScript).flatMap(_.as[JsonLogicExpression]))
 
-        createOracle = Updates.CreateScript(
+        createScript = Updates.CreateScript(
           fiberId = cid,
           scriptProgram = prog,
           initialState = Some(counterInitialState),
           accessControl = AccessControlPolicy.Public
         )
 
-        createProof <- registry.generateProofs(createOracle, Set(Alice))
-        state <- combiner.insert(DataState(OnChain.genesis, CalculatedState.genesis), Signed(createOracle, createProof))
+        createProof <- registry.generateProofs(createScript, Set(Alice))
+        state <- combiner.insert(DataState(OnChain.genesis, CalculatedState.genesis), Signed(createScript, createProof))
 
-        oracle = state.oracleRecord(cid)
+        script = state.scriptRecord(cid)
       } yield expect.all(
-        oracle.isDefined,
-        oracle.flatMap(_.stateData).contains(counterInitialState),
-        oracle.flatMap(_.stateDataHash).isDefined,
-        oracle.map(_.sequenceNumber).contains(FiberOrdinal.MinValue)
+        script.isDefined,
+        script.flatMap(_.stateData).contains(counterInitialState),
+        script.flatMap(_.stateDataHash).isDefined,
+        script.map(_.sequenceNumber).contains(FiberOrdinal.MinValue)
       )
     }
   }
@@ -91,35 +91,35 @@ object CounterOracleSuite extends SimpleIOSuite {
         cid  <- IO.randomUUID
         prog <- IO.fromEither(parser.parse(counterScript).flatMap(_.as[JsonLogicExpression]))
 
-        createOracle = Updates.CreateScript(
+        createScript = Updates.CreateScript(
           fiberId = cid,
           scriptProgram = prog,
           initialState = Some(counterInitialState),
           accessControl = AccessControlPolicy.Public
         )
 
-        createProof <- registry.generateProofs(createOracle, Set(Alice))
+        createProof <- registry.generateProofs(createScript, Set(Alice))
         state1 <- combiner.insert(
           DataState(OnChain.genesis, CalculatedState.genesis),
-          Signed(createOracle, createProof)
+          Signed(createScript, createProof)
         )
 
-        invokeOracle = Updates.InvokeScript(
+        invokeScript = Updates.InvokeScript(
           fiberId = cid,
           method = "increment",
           args = MapValue(Map.empty),
           targetSequenceNumber = FiberOrdinal.MinValue
         )
 
-        invokeProof <- registry.generateProofs(invokeOracle, Set(Alice))
-        state2      <- combiner.insert(state1, Signed(invokeOracle, invokeProof))
+        invokeProof <- registry.generateProofs(invokeScript, Set(Alice))
+        state2      <- combiner.insert(state1, Signed(invokeScript, invokeProof))
 
-        oracle = state2.oracleRecord(cid)
+        script = state2.scriptRecord(cid)
         expectedState = MapValue(Map("value" -> IntValue(1)))
       } yield expect.all(
-        oracle.isDefined,
-        oracle.flatMap(_.stateData).contains(expectedState),
-        oracle.map(_.sequenceNumber).contains(FiberOrdinal.MinValue.next)
+        script.isDefined,
+        script.flatMap(_.stateData).contains(expectedState),
+        script.map(_.sequenceNumber).contains(FiberOrdinal.MinValue.next)
       )
     }
   }
@@ -136,35 +136,35 @@ object CounterOracleSuite extends SimpleIOSuite {
         cid  <- IO.randomUUID
         prog <- IO.fromEither(parser.parse(counterScript).flatMap(_.as[JsonLogicExpression]))
 
-        createOracle = Updates.CreateScript(
+        createScript = Updates.CreateScript(
           fiberId = cid,
           scriptProgram = prog,
           initialState = Some(counterInitialState),
           accessControl = AccessControlPolicy.Public
         )
 
-        createProof <- registry.generateProofs(createOracle, Set(Alice))
+        createProof <- registry.generateProofs(createScript, Set(Alice))
         state1 <- combiner.insert(
           DataState(OnChain.genesis, CalculatedState.genesis),
-          Signed(createOracle, createProof)
+          Signed(createScript, createProof)
         )
 
-        invokeOracle = Updates.InvokeScript(
+        invokeScript = Updates.InvokeScript(
           fiberId = cid,
           method = "decrement",
           args = MapValue(Map.empty),
           targetSequenceNumber = FiberOrdinal.MinValue
         )
 
-        invokeProof <- registry.generateProofs(invokeOracle, Set(Alice))
-        state2      <- combiner.insert(state1, Signed(invokeOracle, invokeProof))
+        invokeProof <- registry.generateProofs(invokeScript, Set(Alice))
+        state2      <- combiner.insert(state1, Signed(invokeScript, invokeProof))
 
-        oracle = state2.oracleRecord(cid)
+        script = state2.scriptRecord(cid)
         expectedState = MapValue(Map("value" -> IntValue(-1)))
       } yield expect.all(
-        oracle.isDefined,
-        oracle.flatMap(_.stateData).contains(expectedState),
-        oracle.map(_.sequenceNumber).contains(FiberOrdinal.MinValue.next)
+        script.isDefined,
+        script.flatMap(_.stateData).contains(expectedState),
+        script.map(_.sequenceNumber).contains(FiberOrdinal.MinValue.next)
       )
     }
   }
@@ -184,35 +184,35 @@ object CounterOracleSuite extends SimpleIOSuite {
         // Start with non-zero initial state
         nonZeroInitial = MapValue(Map("value" -> IntValue(42)))
 
-        createOracle = Updates.CreateScript(
+        createScript = Updates.CreateScript(
           fiberId = cid,
           scriptProgram = prog,
           initialState = Some(nonZeroInitial),
           accessControl = AccessControlPolicy.Public
         )
 
-        createProof <- registry.generateProofs(createOracle, Set(Alice))
+        createProof <- registry.generateProofs(createScript, Set(Alice))
         state1 <- combiner.insert(
           DataState(OnChain.genesis, CalculatedState.genesis),
-          Signed(createOracle, createProof)
+          Signed(createScript, createProof)
         )
 
-        invokeOracle = Updates.InvokeScript(
+        invokeScript = Updates.InvokeScript(
           fiberId = cid,
           method = "reset",
           args = MapValue(Map.empty),
           targetSequenceNumber = FiberOrdinal.MinValue
         )
 
-        invokeProof <- registry.generateProofs(invokeOracle, Set(Alice))
-        state2      <- combiner.insert(state1, Signed(invokeOracle, invokeProof))
+        invokeProof <- registry.generateProofs(invokeScript, Set(Alice))
+        state2      <- combiner.insert(state1, Signed(invokeScript, invokeProof))
 
-        oracle = state2.oracleRecord(cid)
+        script = state2.scriptRecord(cid)
         expectedState = MapValue(Map("value" -> IntValue(0)))
       } yield expect.all(
-        oracle.isDefined,
-        oracle.flatMap(_.stateData).contains(expectedState),
-        oracle.map(_.sequenceNumber).contains(FiberOrdinal.MinValue.next)
+        script.isDefined,
+        script.flatMap(_.stateData).contains(expectedState),
+        script.map(_.sequenceNumber).contains(FiberOrdinal.MinValue.next)
       )
     }
   }
@@ -229,17 +229,17 @@ object CounterOracleSuite extends SimpleIOSuite {
         cid  <- IO.randomUUID
         prog <- IO.fromEither(parser.parse(counterScript).flatMap(_.as[JsonLogicExpression]))
 
-        createOracle = Updates.CreateScript(
+        createScript = Updates.CreateScript(
           fiberId = cid,
           scriptProgram = prog,
           initialState = Some(counterInitialState),
           accessControl = AccessControlPolicy.Public
         )
 
-        createProof <- registry.generateProofs(createOracle, Set(Alice))
+        createProof <- registry.generateProofs(createScript, Set(Alice))
         state0 <- combiner.insert(
           DataState(OnChain.genesis, CalculatedState.genesis),
-          Signed(createOracle, createProof)
+          Signed(createScript, createProof)
         )
 
         // First increment (0 -> 1)
@@ -247,7 +247,7 @@ object CounterOracleSuite extends SimpleIOSuite {
         proof1 <- registry.generateProofs(invoke1, Set(Alice))
         state1 <- combiner.insert(state0, Signed(invoke1, proof1))
 
-        oracle1 = state1.oracleRecord(cid)
+        script1 = state1.scriptRecord(cid)
 
         // Second increment (1 -> 2)
         invoke2 = Updates.InvokeScript(
@@ -259,7 +259,7 @@ object CounterOracleSuite extends SimpleIOSuite {
         proof2 <- registry.generateProofs(invoke2, Set(Alice))
         state2 <- combiner.insert(state1, Signed(invoke2, proof2))
 
-        oracle2 = state2.oracleRecord(cid)
+        script2 = state2.scriptRecord(cid)
 
         // Third increment (2 -> 3)
         invoke3 = Updates.InvokeScript(
@@ -271,13 +271,13 @@ object CounterOracleSuite extends SimpleIOSuite {
         proof3 <- registry.generateProofs(invoke3, Set(Alice))
         state3 <- combiner.insert(state2, Signed(invoke3, proof3))
 
-        oracle3 = state3.oracleRecord(cid)
+        script3 = state3.scriptRecord(cid)
       } yield expect.all(
-        oracle1.flatMap(_.stateData).contains(MapValue(Map("value" -> IntValue(1)))),
-        oracle2.flatMap(_.stateData).contains(MapValue(Map("value" -> IntValue(2)))),
-        oracle3.flatMap(_.stateData).contains(MapValue(Map("value" -> IntValue(3)))),
-        oracle3.map(_.sequenceNumber).contains(FiberOrdinal.unsafeApply(3L)),
-        oracle3.flatMap(_.lastInvocation).isDefined
+        script1.flatMap(_.stateData).contains(MapValue(Map("value" -> IntValue(1)))),
+        script2.flatMap(_.stateData).contains(MapValue(Map("value" -> IntValue(2)))),
+        script3.flatMap(_.stateData).contains(MapValue(Map("value" -> IntValue(3)))),
+        script3.map(_.sequenceNumber).contains(FiberOrdinal.unsafeApply(3L)),
+        script3.flatMap(_.lastInvocation).isDefined
       )
     }
   }
@@ -294,17 +294,17 @@ object CounterOracleSuite extends SimpleIOSuite {
         cid  <- IO.randomUUID
         prog <- IO.fromEither(parser.parse(counterScript).flatMap(_.as[JsonLogicExpression]))
 
-        createOracle = Updates.CreateScript(
+        createScript = Updates.CreateScript(
           fiberId = cid,
           scriptProgram = prog,
           initialState = Some(counterInitialState),
           accessControl = AccessControlPolicy.Public
         )
 
-        createProof <- registry.generateProofs(createOracle, Set(Alice))
+        createProof <- registry.generateProofs(createScript, Set(Alice))
         state0 <- combiner.insert(
           DataState(OnChain.genesis, CalculatedState.genesis),
-          Signed(createOracle, createProof)
+          Signed(createScript, createProof)
         )
 
         // First increment (0 -> 1)
@@ -332,12 +332,12 @@ object CounterOracleSuite extends SimpleIOSuite {
         proof3 <- registry.generateProofs(invoke3, Set(Alice))
         state3 <- combiner.insert(state2, Signed(invoke3, proof3))
 
-        oracle = state3.oracleRecord(cid)
+        script = state3.scriptRecord(cid)
         expectedState = MapValue(Map("value" -> IntValue(1)))
       } yield expect.all(
-        oracle.isDefined,
-        oracle.flatMap(_.stateData).contains(expectedState),
-        oracle.map(_.sequenceNumber).contains(FiberOrdinal.unsafeApply(3L))
+        script.isDefined,
+        script.flatMap(_.stateData).contains(expectedState),
+        script.map(_.sequenceNumber).contains(FiberOrdinal.unsafeApply(3L))
       )
     }
   }
@@ -357,35 +357,35 @@ object CounterOracleSuite extends SimpleIOSuite {
         // Start with non-zero value
         initialState = MapValue(Map("value" -> IntValue(5)))
 
-        createOracle = Updates.CreateScript(
+        createScript = Updates.CreateScript(
           fiberId = cid,
           scriptProgram = prog,
           initialState = Some(initialState),
           accessControl = AccessControlPolicy.Public
         )
 
-        createProof <- registry.generateProofs(createOracle, Set(Alice))
+        createProof <- registry.generateProofs(createScript, Set(Alice))
         state1 <- combiner.insert(
           DataState(OnChain.genesis, CalculatedState.genesis),
-          Signed(createOracle, createProof)
+          Signed(createScript, createProof)
         )
 
-        invokeOracle = Updates.InvokeScript(
+        invokeScript = Updates.InvokeScript(
           fiberId = cid,
           method = "increment",
           args = MapValue(Map.empty),
           targetSequenceNumber = FiberOrdinal.MinValue
         )
 
-        invokeProof <- registry.generateProofs(invokeOracle, Set(Alice))
-        state2      <- combiner.insert(state1, Signed(invokeOracle, invokeProof))
+        invokeProof <- registry.generateProofs(invokeScript, Set(Alice))
+        state2      <- combiner.insert(state1, Signed(invokeScript, invokeProof))
 
-        oracle = state2.oracleRecord(cid)
+        script = state2.scriptRecord(cid)
         expectedState = MapValue(Map("value" -> IntValue(6)))
       } yield expect.all(
-        oracle.isDefined,
-        oracle.flatMap(_.stateData).contains(expectedState),
-        oracle.map(_.sequenceNumber).contains(FiberOrdinal.MinValue.next)
+        script.isDefined,
+        script.flatMap(_.stateData).contains(expectedState),
+        script.map(_.sequenceNumber).contains(FiberOrdinal.MinValue.next)
       )
     }
   }
@@ -402,39 +402,39 @@ object CounterOracleSuite extends SimpleIOSuite {
         cid  <- IO.randomUUID
         prog <- IO.fromEither(parser.parse(counterScript).flatMap(_.as[JsonLogicExpression]))
 
-        createOracle = Updates.CreateScript(
+        createScript = Updates.CreateScript(
           fiberId = cid,
           scriptProgram = prog,
           initialState = Some(counterInitialState),
           accessControl = AccessControlPolicy.Public
         )
 
-        createProof <- registry.generateProofs(createOracle, Set(Alice))
+        createProof <- registry.generateProofs(createScript, Set(Alice))
         state1 <- combiner.insert(
           DataState(OnChain.genesis, CalculatedState.genesis),
-          Signed(createOracle, createProof)
+          Signed(createScript, createProof)
         )
 
-        oracleBefore = state1.oracleRecord(cid)
-        hashBefore = oracleBefore.flatMap(_.stateDataHash)
+        scriptBefore = state1.scriptRecord(cid)
+        hashBefore = scriptBefore.flatMap(_.stateDataHash)
 
-        invokeOracle = Updates.InvokeScript(
+        invokeScript = Updates.InvokeScript(
           fiberId = cid,
           method = "increment",
           args = MapValue(Map.empty),
           targetSequenceNumber = FiberOrdinal.MinValue
         )
 
-        invokeProof <- registry.generateProofs(invokeOracle, Set(Alice))
-        state2      <- combiner.insert(state1, Signed(invokeOracle, invokeProof))
+        invokeProof <- registry.generateProofs(invokeScript, Set(Alice))
+        state2      <- combiner.insert(state1, Signed(invokeScript, invokeProof))
 
-        oracleAfter = state2.oracleRecord(cid)
-        hashAfter = oracleAfter.flatMap(_.stateDataHash)
+        scriptAfter = state2.scriptRecord(cid)
+        hashAfter = scriptAfter.flatMap(_.stateDataHash)
       } yield expect.all(
         hashBefore.isDefined,
         hashAfter.isDefined,
         hashBefore != hashAfter,
-        oracleBefore.flatMap(_.stateData) != oracleAfter.flatMap(_.stateData)
+        scriptBefore.flatMap(_.stateData) != scriptAfter.flatMap(_.stateData)
       )
     }
   }
@@ -451,7 +451,7 @@ object CounterOracleSuite extends SimpleIOSuite {
         cid  <- IO.randomUUID
         prog <- IO.fromEither(parser.parse(counterScript).flatMap(_.as[JsonLogicExpression]))
 
-        createOracle = Updates.CreateScript(
+        createScript = Updates.CreateScript(
           fiberId = cid,
           scriptProgram = prog,
           initialState = Some(counterInitialState),
@@ -459,17 +459,17 @@ object CounterOracleSuite extends SimpleIOSuite {
         )
 
         // Create with both Alice and Bob signing
-        createProof <- registry.generateProofs(createOracle, Set(Alice, Bob))
+        createProof <- registry.generateProofs(createScript, Set(Alice, Bob))
         state1 <- combiner.insert(
           DataState(OnChain.genesis, CalculatedState.genesis),
-          Signed(createOracle, createProof)
+          Signed(createScript, createProof)
         )
 
-        oracle = state1.oracleRecord(cid)
+        script = state1.scriptRecord(cid)
       } yield expect.all(
-        oracle.isDefined,
-        oracle.flatMap(_.stateData).contains(counterInitialState),
-        oracle.map(_.owners.size).contains(2)
+        script.isDefined,
+        script.flatMap(_.stateData).contains(counterInitialState),
+        script.map(_.owners.size).contains(2)
       )
     }
   }
@@ -486,37 +486,37 @@ object CounterOracleSuite extends SimpleIOSuite {
         cid  <- IO.randomUUID
         prog <- IO.fromEither(parser.parse(counterScript).flatMap(_.as[JsonLogicExpression]))
 
-        createOracle = Updates.CreateScript(
+        createScript = Updates.CreateScript(
           fiberId = cid,
           scriptProgram = prog,
           initialState = Some(counterInitialState),
           accessControl = AccessControlPolicy.Public
         )
 
-        // Alice creates the oracle
-        createProof <- registry.generateProofs(createOracle, Set(Alice))
+        // Alice creates the script
+        createProof <- registry.generateProofs(createScript, Set(Alice))
         state1 <- combiner.insert(
           DataState(OnChain.genesis, CalculatedState.genesis),
-          Signed(createOracle, createProof)
+          Signed(createScript, createProof)
         )
 
-        invokeOracle = Updates.InvokeScript(
+        invokeScript = Updates.InvokeScript(
           fiberId = cid,
           method = "increment",
           args = MapValue(Map.empty),
           targetSequenceNumber = FiberOrdinal.MinValue
         )
 
-        // Bob invokes the oracle (should work for Public access control)
-        invokeProof <- registry.generateProofs(invokeOracle, Set(Bob))
-        state2      <- combiner.insert(state1, Signed(invokeOracle, invokeProof))
+        // Bob invokes the script (should work for Public access control)
+        invokeProof <- registry.generateProofs(invokeScript, Set(Bob))
+        state2      <- combiner.insert(state1, Signed(invokeScript, invokeProof))
 
-        oracle = state2.oracleRecord(cid)
+        script = state2.scriptRecord(cid)
         expectedState = MapValue(Map("value" -> IntValue(1)))
       } yield expect.all(
-        oracle.isDefined,
-        oracle.flatMap(_.stateData).contains(expectedState),
-        oracle.map(_.sequenceNumber).contains(FiberOrdinal.MinValue.next)
+        script.isDefined,
+        script.flatMap(_.stateData).contains(expectedState),
+        script.map(_.sequenceNumber).contains(FiberOrdinal.MinValue.next)
       )
     }
   }
@@ -533,36 +533,36 @@ object CounterOracleSuite extends SimpleIOSuite {
         cid  <- IO.randomUUID
         prog <- IO.fromEither(parser.parse(counterScript).flatMap(_.as[JsonLogicExpression]))
 
-        createOracle = Updates.CreateScript(
+        createScript = Updates.CreateScript(
           fiberId = cid,
           scriptProgram = prog,
           initialState = Some(counterInitialState),
           accessControl = AccessControlPolicy.Public
         )
 
-        createProof <- registry.generateProofs(createOracle, Set(Alice))
+        createProof <- registry.generateProofs(createScript, Set(Alice))
         state1 <- combiner.insert(
           DataState(OnChain.genesis, CalculatedState.genesis),
-          Signed(createOracle, createProof)
+          Signed(createScript, createProof)
         )
 
-        // Check onChain has hashes for this oracle
+        // Check onChain has hashes for this script
         initialOnChainHashes = state1.onChain.fiberCommits.get(cid)
-        initialStateHash = state1.oracleRecord(cid).flatMap(_.stateDataHash)
+        initialStateHash = state1.scriptRecord(cid).flatMap(_.stateDataHash)
 
-        invokeOracle = Updates.InvokeScript(
+        invokeScript = Updates.InvokeScript(
           fiberId = cid,
           method = "increment",
           args = MapValue(Map.empty),
           targetSequenceNumber = FiberOrdinal.MinValue
         )
 
-        invokeProof <- registry.generateProofs(invokeOracle, Set(Alice))
-        state2      <- combiner.insert(state1, Signed(invokeOracle, invokeProof))
+        invokeProof <- registry.generateProofs(invokeScript, Set(Alice))
+        state2      <- combiner.insert(state1, Signed(invokeScript, invokeProof))
 
         // Check onChain hashes were updated
         updatedOnChainHashes = state2.onChain.fiberCommits.get(cid)
-        updatedStateHash = state2.oracleRecord(cid).flatMap(_.stateDataHash)
+        updatedStateHash = state2.scriptRecord(cid).flatMap(_.stateDataHash)
       } yield expect.all(
         initialOnChainHashes.isDefined,
         initialStateHash.isDefined,

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/examples/NftMarketplaceSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/examples/NftMarketplaceSuite.scala
@@ -25,7 +25,7 @@ object NftMarketplaceSuite extends SimpleIOSuite {
   import DataStateTestOps._
   import TestImports.optionFiberRecordOps
 
-  test("nft-marketplace: spawned listing triggers royalty oracle on sale") {
+  test("nft-marketplace: spawned listing triggers royalty script on sale") {
     import io.circe.parser._
 
     TestFixture.resource(Set(Alice, Bob, Charlie)).use { fixture =>
@@ -37,11 +37,11 @@ object NftMarketplaceSuite extends SimpleIOSuite {
       for {
         combiner <- Combiner.make[IO]().pure[IO]
 
-        // Get royalty oracle ID early to reference in NFT listing definition
-        royaltyOracleId <- UUIDGen.randomUUID[IO]
+        // Get royalty script ID early to reference in NFT listing definition
+        royaltyScriptId <- UUIDGen.randomUUID[IO]
 
-        // JSON-encoded oracle program for calculating and recording royalties
-        royaltyOracleJson =
+        // JSON-encoded script program for calculating and recording royalties
+        royaltyScriptJson =
           """{
             "if": [
               { "===": [{ "var": "method" }, "recordRoyalty" ] },
@@ -85,20 +85,20 @@ object NftMarketplaceSuite extends SimpleIOSuite {
           }"""
 
         royaltyProgramExpr <- IO.fromEither(
-          decode[JsonLogicExpression](royaltyOracleJson).left
-            .map(err => new RuntimeException(s"Failed to decode oracle JSON: $err"))
+          decode[JsonLogicExpression](royaltyScriptJson).left
+            .map(err => new RuntimeException(s"Failed to decode script JSON: $err"))
         )
 
-        // Create royalty oracle
-        royaltyOracleData = MapValue(Map("totalRoyalties" -> IntValue(0)))
-        royaltyHash <- (royaltyOracleData: JsonLogicValue).computeDigest
+        // Create royalty script
+        royaltyScriptData = MapValue(Map("totalRoyalties" -> IntValue(0)))
+        royaltyHash <- (royaltyScriptData: JsonLogicValue).computeDigest
 
-        royaltyOracle = Records.ScriptFiberRecord(
-          fiberId = royaltyOracleId,
+        royaltyScript = Records.ScriptFiberRecord(
+          fiberId = royaltyScriptId,
           creationOrdinal = ordinal,
           latestUpdateOrdinal = ordinal,
           scriptProgram = royaltyProgramExpr,
-          stateData = Some(royaltyOracleData),
+          stateData = Some(royaltyScriptData),
           stateDataHash = Some(royaltyHash),
           accessControl = AccessControlPolicy.Public,
           owners = Set(registry.addresses(Alice)),
@@ -106,7 +106,7 @@ object NftMarketplaceSuite extends SimpleIOSuite {
           sequenceNumber = FiberOrdinal.MinValue
         )
 
-        // JSON-encoded NFT listing state machine with oracle trigger on sale
+        // JSON-encoded NFT listing state machine with script trigger on sale
         nftListingJson =
           s"""{
           "states": {
@@ -150,7 +150,7 @@ object NftMarketplaceSuite extends SimpleIOSuite {
                 },
                 "_triggers": [
                   {
-                    "targetMachineId": "${royaltyOracleId}",
+                    "targetMachineId": "${royaltyScriptId}",
                     "eventName": "recordRoyalty",
                     "payload": {
                       "nftId": { "var": "state.nftId" },
@@ -166,7 +166,7 @@ object NftMarketplaceSuite extends SimpleIOSuite {
                   }
                 ]
               },
-              "dependencies": ["${royaltyOracleId}"]
+              "dependencies": ["${royaltyScriptId}"]
             },
             {
               "from": "listed",
@@ -266,7 +266,7 @@ object NftMarketplaceSuite extends SimpleIOSuite {
                             },
                             "_triggers": [
                               {
-                                "targetMachineId": "${royaltyOracleId}",
+                                "targetMachineId": "${royaltyScriptId}",
                                 "eventName": "recordRoyalty",
                                 "payload": {
                                   "nftId": { "var": "state.nftId" },
@@ -282,7 +282,7 @@ object NftMarketplaceSuite extends SimpleIOSuite {
                               }
                             ]
                           },
-                          "dependencies": ["${royaltyOracleId}"]
+                          "dependencies": ["${royaltyScriptId}"]
                         },
                         {
                           "from": "listed",
@@ -339,7 +339,7 @@ object NftMarketplaceSuite extends SimpleIOSuite {
 
         inState <- DataState(OnChain.genesis, CalculatedState.genesis)
           .withRecord[IO](marketplacefiberId, marketplaceFiber)
-          .flatMap(_.withRecord[IO](royaltyOracleId, royaltyOracle))
+          .flatMap(_.withRecord[IO](royaltyScriptId, royaltyScript))
 
         // Alice creates an NFT listing (spawns child)
         nftListingId1 <- UUIDGen.randomUUID[IO]
@@ -398,7 +398,7 @@ object NftMarketplaceSuite extends SimpleIOSuite {
 
         nftListing2 = state2.fiberRecord(nftListingId2)
 
-        // Bob purchases Alice's NFT (should trigger royalty oracle)
+        // Bob purchases Alice's NFT (should trigger royalty script)
         state3 <- state2.transition(
           nftListingId1,
           "purchase",
@@ -418,15 +418,15 @@ object NftMarketplaceSuite extends SimpleIOSuite {
         salePrice1 = nftListing1AfterSale.extractInt("salePrice")
         royaltyAmount1 = nftListing1AfterSale.extractInt("royaltyAmount")
 
-        // Verify royalty oracle was triggered and state updated
-        oracleAfterSale1 = state3.oracleRecord(royaltyOracleId)
-        totalRoyalties1: Option[BigInt] = oracleAfterSale1.flatMap { o =>
+        // Verify royalty script was triggered and state updated
+        scriptAfterSale1 = state3.scriptRecord(royaltyScriptId)
+        totalRoyalties1: Option[BigInt] = scriptAfterSale1.flatMap { o =>
           o.stateData.flatMap {
             case MapValue(m) => m.get("totalRoyalties").collect { case IntValue(t) => t }
             case _           => None
           }
         }
-        lastRecordedNft1: Option[String] = oracleAfterSale1.flatMap { o =>
+        lastRecordedNft1: Option[String] = scriptAfterSale1.flatMap { o =>
           o.stateData.flatMap {
             case MapValue(m) =>
               m.get("lastRecorded").flatMap {
@@ -436,7 +436,7 @@ object NftMarketplaceSuite extends SimpleIOSuite {
             case _ => None
           }
         }
-        lastRecordedCreator1: Option[String] = oracleAfterSale1.flatMap { o =>
+        lastRecordedCreator1: Option[String] = scriptAfterSale1.flatMap { o =>
           o.stateData.flatMap {
             case MapValue(m) =>
               m.get("lastRecorded").flatMap {
@@ -461,15 +461,15 @@ object NftMarketplaceSuite extends SimpleIOSuite {
           Bob
         )(registry, combiner)
 
-        // Verify second sale triggered oracle again
-        oracleFinal = finalState.oracleRecord(royaltyOracleId)
-        totalRoyaltiesFinal: Option[BigInt] = oracleFinal.flatMap { o =>
+        // Verify second sale triggered script again
+        scriptFinal = finalState.scriptRecord(royaltyScriptId)
+        totalRoyaltiesFinal: Option[BigInt] = scriptFinal.flatMap { o =>
           o.stateData.flatMap {
             case MapValue(m) => m.get("totalRoyalties").collect { case IntValue(t) => t }
             case _           => None
           }
         }
-        lastRecordedNft2: Option[String] = oracleFinal.flatMap { o =>
+        lastRecordedNft2: Option[String] = scriptFinal.flatMap { o =>
           o.stateData.flatMap {
             case MapValue(m) =>
               m.get("lastRecorded").flatMap {
@@ -479,7 +479,7 @@ object NftMarketplaceSuite extends SimpleIOSuite {
             case _ => None
           }
         }
-        oracleInvocationCount: Option[FiberOrdinal] = oracleFinal.map(_.sequenceNumber)
+        scriptInvocationCount: Option[FiberOrdinal] = scriptFinal.map(_.sequenceNumber)
 
         // Verify marketplace still active with 2 listings
         listingCountFinal = finalState.fiberRecord(marketplacefiberId).extractInt("listingCount")
@@ -504,15 +504,15 @@ object NftMarketplaceSuite extends SimpleIOSuite {
         buyer1.contains(registry.addresses(Bob).toString),
         salePrice1.contains(BigInt(1200)),
         royaltyAmount1.contains(BigInt(6000)), // 1200 * 5
-        // Verify royalty oracle was triggered after first sale
-        oracleAfterSale1.isDefined,
-        oracleAfterSale1.map(_.sequenceNumber).contains(FiberOrdinal.MinValue.next),
+        // Verify royalty script was triggered after first sale
+        scriptAfterSale1.isDefined,
+        scriptAfterSale1.map(_.sequenceNumber).contains(FiberOrdinal.MinValue.next),
         totalRoyalties1.contains(BigInt(6000)),
         lastRecordedNft1.contains("nft-001"),
         lastRecordedCreator1.contains(registry.addresses(Alice).toString),
-        // Verify oracle was triggered again after second sale
-        oracleFinal.isDefined,
-        oracleInvocationCount.contains(FiberOrdinal.unsafeApply(2L)),
+        // Verify script was triggered again after second sale
+        scriptFinal.isDefined,
+        scriptInvocationCount.contains(FiberOrdinal.unsafeApply(2L)),
         totalRoyaltiesFinal.contains(BigInt(9000)), // 6000 + 3000
         lastRecordedNft2.contains("nft-002"),
         // Verify marketplace final state

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/examples/PredictionMarketSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/examples/PredictionMarketSuite.scala
@@ -388,7 +388,7 @@ object PredictionMarketSuite extends SimpleIOSuite {
         invokeProof <- fixture.registry.generateProofs(invokeOp, Set(Alice))
         state2      <- combiner.insert(state1, Signed(invokeOp, invokeProof))
 
-        result = state2.oracleRecord(scriptId).flatMap(_.lastInvocation).map(_.result)
+        result = state2.scriptRecord(scriptId).flatMap(_.lastInvocation).map(_.result)
 
       } yield expect.all(
         result.isDefined,
@@ -447,7 +447,7 @@ object PredictionMarketSuite extends SimpleIOSuite {
         invokeProof <- fixture.registry.generateProofs(invokeOp, Set(Alice))
         state2      <- combiner.insert(state1, Signed(invokeOp, invokeProof))
 
-        result = state2.oracleRecord(scriptId).flatMap(_.lastInvocation).map(_.result)
+        result = state2.scriptRecord(scriptId).flatMap(_.lastInvocation).map(_.result)
 
       } yield expect.all(
         result.isDefined,
@@ -600,7 +600,7 @@ object PredictionMarketSuite extends SimpleIOSuite {
         scriptInvokeProof <- fixture.registry.generateProofs(invokeScript, Set(Alice))
         state10           <- combiner.insert(state9, Signed(invokeScript, scriptInvokeProof))
 
-        scriptResult = state10.oracleRecord(scriptId).flatMap(_.lastInvocation).map(_.result)
+        scriptResult = state10.scriptRecord(scriptId).flatMap(_.lastInvocation).map(_.result)
         outcome = scriptResult.flatMap {
           case MapValue(m) => m.get("outcome")
           case _           => None

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/examples/ScriptEscrowSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/examples/ScriptEscrowSuite.scala
@@ -18,17 +18,17 @@ import io.circe.parser._
 import weaver.SimpleIOSuite
 
 /**
- * Oracle Escrow State Machine — Unit Tests
+ * Script Escrow State Machine — Unit Tests
  *
  * An escrow contract that uses a script to determine release conditions.
  * Demonstrates:
  * - State machine with conditional transitions (guards)
- * - Script oracle creation and invocation
- * - Integration of oracle results into state transitions
+ * - Script script creation and invocation
+ * - Integration of script results into state transitions
  */
-object OracleEscrowSuite extends SimpleIOSuite {
+object ScriptEscrowSuite extends SimpleIOSuite {
 
-  test("Oracle Escrow: Fund, Oracle Check, Release") {
+  test("Script Escrow: Fund, Script Check, Release") {
     TestFixture.resource(Set(Alice)).use { fixture =>
       implicit val s: SecurityProvider[IO] = fixture.securityProvider
       implicit val l0ctx: L0NodeContext[IO] = fixture.l0Context
@@ -36,7 +36,7 @@ object OracleEscrowSuite extends SimpleIOSuite {
       for {
         combiner <- Combiner.make[IO]().pure[IO]
         fiberId  <- IO.randomUUID
-        oracleId <- IO.randomUUID
+        scriptId <- IO.randomUUID
 
         // State machine definition
         machineJson = """
@@ -65,7 +65,7 @@ object OracleEscrowSuite extends SimpleIOSuite {
               "dependencies": []
             }
           ],
-          "metadata": { "name": "OracleEscrow" }
+          "metadata": { "name": "ScriptEscrow" }
         }
         """
 
@@ -80,19 +80,19 @@ object OracleEscrowSuite extends SimpleIOSuite {
           Signed(createOp, createProof)
         )
 
-        // Create the oracle script (always returns true)
-        oracleScript = """{"==": [1, 1]}"""
-        oracleProg <- IO.fromEither(parse(oracleScript).flatMap(_.as[JsonLogicExpression]))
+        // Create the script script (always returns true)
+        scriptSource = """{"==": [1, 1]}"""
+        scriptProg <- IO.fromEither(parse(scriptSource).flatMap(_.as[JsonLogicExpression]))
 
-        // Create the oracle
-        createOracle = Updates.CreateScript(
-          fiberId = oracleId,
-          scriptProgram = oracleProg,
+        // Create the script
+        createScript = Updates.CreateScript(
+          fiberId = scriptId,
+          scriptProgram = scriptProg,
           initialState = None,
           accessControl = AccessControlPolicy.Public
         )
-        oracleProof <- fixture.registry.generateProofs(createOracle, Set(Alice))
-        state2      <- combiner.insert(state1, Signed(createOracle, oracleProof))
+        scriptProof <- fixture.registry.generateProofs(createScript, Set(Alice))
+        state2      <- combiner.insert(state1, Signed(createScript, scriptProof))
 
         // Fund the escrow
         fundOp = Updates.TransitionStateMachine(
@@ -104,17 +104,17 @@ object OracleEscrowSuite extends SimpleIOSuite {
         fundProof <- fixture.registry.generateProofs(fundOp, Set(Alice))
         state3    <- combiner.insert(state2, Signed(fundOp, fundProof))
 
-        // Invoke Oracle (simulating an external check)
-        invokeOracle = Updates.InvokeScript(
-          fiberId = oracleId,
+        // Invoke Script (simulating an external check)
+        invokeScript = Updates.InvokeScript(
+          fiberId = scriptId,
           method = "invoke",
           args = MapValue(Map.empty[String, JsonLogicValue]),
           targetSequenceNumber = FiberOrdinal.MinValue
         )
-        invokeProof <- fixture.registry.generateProofs(invokeOracle, Set(Alice))
-        state4      <- combiner.insert(state3, Signed(invokeOracle, invokeProof))
+        invokeProof <- fixture.registry.generateProofs(invokeScript, Set(Alice))
+        state4      <- combiner.insert(state3, Signed(invokeScript, invokeProof))
 
-        // Release to beneficiary (using oracle result in guard)
+        // Release to beneficiary (using script result in guard)
         releaseOp = Updates.TransitionStateMachine(
           fiberId,
           "release",
@@ -146,7 +146,7 @@ object OracleEscrowSuite extends SimpleIOSuite {
     }
   }
 
-  test("Oracle Escrow: Fund, Oracle Check, Refund") {
+  test("Script Escrow: Fund, Script Check, Refund") {
     TestFixture.resource(Set(Alice)).use { fixture =>
       implicit val s: SecurityProvider[IO] = fixture.securityProvider
       implicit val l0ctx: L0NodeContext[IO] = fixture.l0Context
@@ -154,7 +154,7 @@ object OracleEscrowSuite extends SimpleIOSuite {
       for {
         combiner <- Combiner.make[IO]().pure[IO]
         fiberId  <- IO.randomUUID
-        oracleId <- IO.randomUUID
+        scriptId <- IO.randomUUID
 
         // State machine definition
         machineJson = """
@@ -192,7 +192,7 @@ object OracleEscrowSuite extends SimpleIOSuite {
               "dependencies": []
             }
           ],
-          "metadata": { "name": "OracleEscrow" }
+          "metadata": { "name": "ScriptEscrow" }
         }
         """
 
@@ -207,19 +207,19 @@ object OracleEscrowSuite extends SimpleIOSuite {
           Signed(createOp, createProof)
         )
 
-        // Create the oracle script (always returns true)
-        oracleScript = """{"==": [1, 1]}"""
-        oracleProg <- IO.fromEither(parse(oracleScript).flatMap(_.as[JsonLogicExpression]))
+        // Create the script script (always returns true)
+        scriptSource = """{"==": [1, 1]}"""
+        scriptProg <- IO.fromEither(parse(scriptSource).flatMap(_.as[JsonLogicExpression]))
 
-        // Create the oracle
-        createOracle = Updates.CreateScript(
-          fiberId = oracleId,
-          scriptProgram = oracleProg,
+        // Create the script
+        createScript = Updates.CreateScript(
+          fiberId = scriptId,
+          scriptProgram = scriptProg,
           initialState = None,
           accessControl = AccessControlPolicy.Public
         )
-        oracleProof <- fixture.registry.generateProofs(createOracle, Set(Alice))
-        state2      <- combiner.insert(state1, Signed(createOracle, oracleProof))
+        scriptProof <- fixture.registry.generateProofs(createScript, Set(Alice))
+        state2      <- combiner.insert(state1, Signed(createScript, scriptProof))
 
         // Fund the escrow
         fundOp = Updates.TransitionStateMachine(
@@ -231,17 +231,17 @@ object OracleEscrowSuite extends SimpleIOSuite {
         fundProof <- fixture.registry.generateProofs(fundOp, Set(Alice))
         state3    <- combiner.insert(state2, Signed(fundOp, fundProof))
 
-        // Invoke Oracle
-        invokeOracle = Updates.InvokeScript(
-          fiberId = oracleId,
+        // Invoke Script
+        invokeScript = Updates.InvokeScript(
+          fiberId = scriptId,
           method = "invoke",
           args = MapValue(Map.empty[String, JsonLogicValue]),
           targetSequenceNumber = FiberOrdinal.MinValue
         )
-        invokeProof <- fixture.registry.generateProofs(invokeOracle, Set(Alice))
-        state4      <- combiner.insert(state3, Signed(invokeOracle, invokeProof))
+        invokeProof <- fixture.registry.generateProofs(invokeScript, Set(Alice))
+        state4      <- combiner.insert(state3, Signed(invokeScript, invokeProof))
 
-        // Refund (Oracle result is false, so guard fails)
+        // Refund (Script result is false, so guard fails)
         refundOp = Updates.TransitionStateMachine(
           fiberId,
           "refund",

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/examples/ScriptToScriptSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/examples/ScriptToScriptSuite.scala
@@ -20,20 +20,20 @@ import io.circe.parser
 import weaver.SimpleIOSuite
 
 /**
- * Tests for oracle-to-oracle interactions.
+ * Tests for script-to-script interactions.
  *
  * Verifies that:
- * - Oracles can invoke other oracles via _oracleCall
- * - Caller resolution uses the calling oracle's owners
- * - Access control is respected in oracle chains
- * - Gas accumulates across oracle invocations
+ * - Scripts can invoke other scripts via _scriptCall
+ * - Caller resolution uses the calling script's owners
+ * - Access control is respected in script chains
+ * - Gas accumulates across script invocations
  */
-object OracleToOracleSuite extends SimpleIOSuite {
+object ScriptToScriptSuite extends SimpleIOSuite {
 
   import DataStateTestOps._
 
   /**
-   * Inner oracle: simple calculator that adds two numbers
+   * Inner script: simple calculator that adds two numbers
    */
   private val calculatorScript =
     """|{
@@ -45,13 +45,13 @@ object OracleToOracleSuite extends SimpleIOSuite {
        |}""".stripMargin
 
   /**
-   * Outer oracle: calls the inner calculator and doubles the result
-   * Uses _oracleCall to invoke another oracle
+   * Outer script: calls the inner calculator and doubles the result
+   * Uses _scriptCall to invoke another script
    *
    * NOTE: This test documents expected behavior. The actual implementation
-   * may need to support oracle-to-oracle calls in the script.
+   * may need to support script-to-script calls in the script.
    */
-  test("oracle invocation count is tracked correctly") {
+  test("script invocation count is tracked correctly") {
     TestFixture.resource(Set(Alice, Bob)).use { fixture =>
       implicit val s: SecurityProvider[IO] = fixture.securityProvider
       implicit val l0ctx: L0NodeContext[IO] = fixture.l0Context
@@ -63,7 +63,7 @@ object OracleToOracleSuite extends SimpleIOSuite {
         innerfiberId <- IO.randomUUID
         innerProg    <- IO.fromEither(parser.parse(calculatorScript).flatMap(_.as[JsonLogicExpression]))
 
-        // Create inner oracle with Public access
+        // Create inner script with Public access
         createInner = Updates.CreateScript(
           fiberId = innerfiberId,
           scriptProgram = innerProg,
@@ -77,7 +77,7 @@ object OracleToOracleSuite extends SimpleIOSuite {
           Signed(createInner, createInnerProof)
         )
 
-        // Invoke inner oracle multiple times
+        // Invoke inner script multiple times
         invoke1 = Updates.InvokeScript(
           fiberId = innerfiberId,
           method = "add",
@@ -98,16 +98,16 @@ object OracleToOracleSuite extends SimpleIOSuite {
         invoke2Proof <- registry.generateProofs(invoke2, Set(Bob))
         state3       <- combiner.insert(state2, Signed(invoke2, invoke2Proof))
 
-        oracle = state3.oracleRecord(innerfiberId)
+        script = state3.scriptRecord(innerfiberId)
       } yield expect.all(
-        oracle.isDefined,
-        oracle.map(_.sequenceNumber).contains(FiberOrdinal.unsafeApply(2L)),
-        oracle.flatMap(_.lastInvocation).isDefined
+        script.isDefined,
+        script.map(_.sequenceNumber).contains(FiberOrdinal.unsafeApply(2L)),
+        script.flatMap(_.lastInvocation).isDefined
       )
     }
   }
 
-  test("oracle whitelist denies unauthorized caller") {
+  test("script whitelist denies unauthorized caller") {
     TestFixture.resource(Set(Alice, Bob, Charlie)).use { fixture =>
       implicit val s: SecurityProvider[IO] = fixture.securityProvider
       implicit val l0ctx: L0NodeContext[IO] = fixture.l0Context
@@ -116,26 +116,26 @@ object OracleToOracleSuite extends SimpleIOSuite {
       for {
         combiner <- Combiner.make[IO]().pure[IO]
 
-        oracleFiberId <- IO.randomUUID
+        scriptFiberId <- IO.randomUUID
         prog          <- IO.fromEither(parser.parse(calculatorScript).flatMap(_.as[JsonLogicExpression]))
 
-        // Create oracle with whitelist access - only Alice allowed
-        createOracle = Updates.CreateScript(
-          fiberId = oracleFiberId,
+        // Create script with whitelist access - only Alice allowed
+        createScript = Updates.CreateScript(
+          fiberId = scriptFiberId,
           scriptProgram = prog,
           initialState = None,
           accessControl = AccessControlPolicy.Whitelist(Set(registry(Alice).address))
         )
 
-        createProof <- registry.generateProofs(createOracle, Set(Alice))
+        createProof <- registry.generateProofs(createScript, Set(Alice))
         state1 <- combiner.insert(
           DataState(OnChain.genesis, CalculatedState.genesis),
-          Signed(createOracle, createProof)
+          Signed(createScript, createProof)
         )
 
         // Alice can invoke (whitelisted)
         invokeAlice = Updates.InvokeScript(
-          fiberId = oracleFiberId,
+          fiberId = scriptFiberId,
           method = "add",
           args = MapValue(Map("a" -> IntValue(1), "b" -> IntValue(2))),
           FiberOrdinal.MinValue
@@ -144,14 +144,14 @@ object OracleToOracleSuite extends SimpleIOSuite {
         aliceProof <- registry.generateProofs(invokeAlice, Set(Alice))
         state2     <- combiner.insert(state1, Signed(invokeAlice, aliceProof))
 
-        oracleAfterAlice = state2.oracleRecord(oracleFiberId)
+        scriptAfterAlice = state2.scriptRecord(scriptFiberId)
 
         // Bob tries to invoke (not whitelisted) - should fail
         invokeBob = Updates.InvokeScript(
-          fiberId = oracleFiberId,
+          fiberId = scriptFiberId,
           method = "add",
           args = MapValue(Map("a" -> IntValue(10), "b" -> IntValue(20))),
-          targetSequenceNumber = state2.calculated.scripts(oracleFiberId).sequenceNumber
+          targetSequenceNumber = state2.calculated.scripts(scriptFiberId).sequenceNumber
         )
 
         bobProof <- registry.generateProofs(invokeBob, Set(Bob))
@@ -159,18 +159,18 @@ object OracleToOracleSuite extends SimpleIOSuite {
         // This should fail - Bob is not whitelisted
         bobResult <- combiner.insert(state2, Signed(invokeBob, bobProof)).attempt
 
-        oracleAfterBob = bobResult.toOption.flatMap(_.oracleRecord(oracleFiberId))
+        scriptAfterBob = bobResult.toOption.flatMap(_.scriptRecord(scriptFiberId))
 
       } yield expect.all(
         // Alice's invocation succeeded
-        oracleAfterAlice.map(_.sequenceNumber).contains(FiberOrdinal.MinValue.next),
+        scriptAfterAlice.map(_.sequenceNumber).contains(FiberOrdinal.MinValue.next),
         // Bob's invocation should have failed (invocation count unchanged)
-        bobResult.isLeft || oracleAfterBob.map(_.sequenceNumber).contains(FiberOrdinal.MinValue.next)
+        bobResult.isLeft || scriptAfterBob.map(_.sequenceNumber).contains(FiberOrdinal.MinValue.next)
       )
     }
   }
 
-  test("multiple oracles can be invoked in sequence") {
+  test("multiple scripts can be invoked in sequence") {
     TestFixture.resource(Set(Alice)).use { fixture =>
       implicit val s: SecurityProvider[IO] = fixture.securityProvider
       implicit val l0ctx: L0NodeContext[IO] = fixture.l0Context
@@ -179,11 +179,11 @@ object OracleToOracleSuite extends SimpleIOSuite {
       for {
         combiner <- Combiner.make[IO]().pure[IO]
 
-        oracle1fiberId <- IO.randomUUID
-        oracle2fiberId <- IO.randomUUID
+        script1fiberId <- IO.randomUUID
+        script2fiberId <- IO.randomUUID
         prog           <- IO.fromEither(parser.parse(calculatorScript).flatMap(_.as[JsonLogicExpression]))
 
-        // Counter oracle for tracking calls
+        // Counter script for tracking calls
         counterScript =
           """|{
              |  "if": [
@@ -195,39 +195,39 @@ object OracleToOracleSuite extends SimpleIOSuite {
 
         counterProg <- IO.fromEither(parser.parse(counterScript).flatMap(_.as[JsonLogicExpression]))
 
-        // Create calculator oracle
-        createOracle1 = Updates.CreateScript(
-          fiberId = oracle1fiberId,
+        // Create calculator script
+        createScript1 = Updates.CreateScript(
+          fiberId = script1fiberId,
           scriptProgram = prog,
           initialState = None,
           accessControl = AccessControlPolicy.Public
         )
 
-        // Create counter oracle
-        createOracle2 = Updates.CreateScript(
-          fiberId = oracle2fiberId,
+        // Create counter script
+        createScript2 = Updates.CreateScript(
+          fiberId = script2fiberId,
           scriptProgram = counterProg,
           initialState = Some(MapValue(Map("value" -> IntValue(0)))),
           accessControl = AccessControlPolicy.Public
         )
 
-        proof1 <- registry.generateProofs(createOracle1, Set(Alice))
-        proof2 <- registry.generateProofs(createOracle2, Set(Alice))
+        proof1 <- registry.generateProofs(createScript1, Set(Alice))
+        proof2 <- registry.generateProofs(createScript2, Set(Alice))
 
         state1 <- combiner.insert(
           DataState(OnChain.genesis, CalculatedState.genesis),
-          Signed(createOracle1, proof1)
+          Signed(createScript1, proof1)
         )
-        state2 <- combiner.insert(state1, Signed(createOracle2, proof2))
+        state2 <- combiner.insert(state1, Signed(createScript2, proof2))
 
-        // Invoke both oracles in sequence
+        // Invoke both scripts in sequence
         invoke1 = Updates.InvokeScript(
-          oracle1fiberId,
+          script1fiberId,
           "add",
           MapValue(Map("a" -> IntValue(5), "b" -> IntValue(3))),
           FiberOrdinal.MinValue
         )
-        invoke2 = Updates.InvokeScript(oracle2fiberId, "increment", MapValue(Map.empty), FiberOrdinal.MinValue)
+        invoke2 = Updates.InvokeScript(script2fiberId, "increment", MapValue(Map.empty), FiberOrdinal.MinValue)
 
         invokeProof1 <- registry.generateProofs(invoke1, Set(Alice))
         invokeProof2 <- registry.generateProofs(invoke2, Set(Alice))
@@ -236,25 +236,25 @@ object OracleToOracleSuite extends SimpleIOSuite {
         state4 <- combiner.insert(state3, Signed(invoke2, invokeProof2))
 
         invoke3 = Updates.InvokeScript(
-          oracle2fiberId,
+          script2fiberId,
           "increment",
           MapValue(Map.empty),
-          state4.calculated.scripts(oracle2fiberId).sequenceNumber
+          state4.calculated.scripts(script2fiberId).sequenceNumber
         )
         invokeProof3 <- registry.generateProofs(invoke3, Set(Alice))
         state5       <- combiner.insert(state4, Signed(invoke3, invokeProof3))
 
-        calculatorOracle = state5.oracleRecord(oracle1fiberId)
-        counterOracle = state5.oracleRecord(oracle2fiberId)
+        calculatorScript = state5.scriptRecord(script1fiberId)
+        counterScript = state5.scriptRecord(script2fiberId)
       } yield expect.all(
-        calculatorOracle.map(_.sequenceNumber).contains(FiberOrdinal.MinValue.next),
-        counterOracle.map(_.sequenceNumber).contains(FiberOrdinal.unsafeApply(2L)),
-        counterOracle.flatMap(_.stateData).contains(MapValue(Map("value" -> IntValue(2))))
+        calculatorScript.map(_.sequenceNumber).contains(FiberOrdinal.MinValue.next),
+        counterScript.map(_.sequenceNumber).contains(FiberOrdinal.unsafeApply(2L)),
+        counterScript.flatMap(_.stateData).contains(MapValue(Map("value" -> IntValue(2))))
       )
     }
   }
 
-  test("oracle returning valid=false causes invocation failure") {
+  test("script returning valid=false causes invocation failure") {
     TestFixture.resource(Set(Alice)).use { fixture =>
       implicit val s: SecurityProvider[IO] = fixture.securityProvider
       implicit val l0ctx: L0NodeContext[IO] = fixture.l0Context
@@ -263,9 +263,9 @@ object OracleToOracleSuite extends SimpleIOSuite {
       for {
         combiner <- Combiner.make[IO]().pure[IO]
 
-        oracleFiberId <- IO.randomUUID
+        scriptFiberId <- IO.randomUUID
 
-        // Oracle that returns valid=false with an error message
+        // Script that returns valid=false with an error message
         validationScript =
           """|{
              |  "if": [
@@ -283,22 +283,22 @@ object OracleToOracleSuite extends SimpleIOSuite {
 
         validationProg <- IO.fromEither(parser.parse(validationScript).flatMap(_.as[JsonLogicExpression]))
 
-        createOracle = Updates.CreateScript(
-          fiberId = oracleFiberId,
+        createScript = Updates.CreateScript(
+          fiberId = scriptFiberId,
           scriptProgram = validationProg,
           initialState = None,
           accessControl = AccessControlPolicy.Public
         )
 
-        createProof <- registry.generateProofs(createOracle, Set(Alice))
+        createProof <- registry.generateProofs(createScript, Set(Alice))
         state1 <- combiner.insert(
           DataState(OnChain.genesis, CalculatedState.genesis),
-          Signed(createOracle, createProof)
+          Signed(createScript, createProof)
         )
 
         // Invoke with amount >= 100 - should succeed
         invokeValid = Updates.InvokeScript(
-          fiberId = oracleFiberId,
+          fiberId = scriptFiberId,
           method = "validate",
           args = MapValue(Map("amount" -> IntValue(200))),
           FiberOrdinal.MinValue
@@ -307,14 +307,14 @@ object OracleToOracleSuite extends SimpleIOSuite {
         validProof <- registry.generateProofs(invokeValid, Set(Alice))
         state2     <- combiner.insert(state1, Signed(invokeValid, validProof))
 
-        oracleAfterValid = state2.oracleRecord(oracleFiberId)
+        scriptAfterValid = state2.scriptRecord(scriptFiberId)
 
         // Invoke with amount < 100 - should fail due to valid=false
         invokeInvalid = Updates.InvokeScript(
-          fiberId = oracleFiberId,
+          fiberId = scriptFiberId,
           method = "validate",
           args = MapValue(Map("amount" -> IntValue(50))),
-          targetSequenceNumber = state2.calculated.scripts(oracleFiberId).sequenceNumber
+          targetSequenceNumber = state2.calculated.scripts(scriptFiberId).sequenceNumber
         )
 
         invalidProof  <- registry.generateProofs(invokeInvalid, Set(Alice))
@@ -322,9 +322,9 @@ object OracleToOracleSuite extends SimpleIOSuite {
 
       } yield expect.all(
         // First invocation (valid) should succeed
-        oracleAfterValid.map(_.sequenceNumber).contains(FiberOrdinal.MinValue.next),
+        scriptAfterValid.map(_.sequenceNumber).contains(FiberOrdinal.MinValue.next),
         // Second invocation (invalid) should either fail or succeed depending on implementation
-        // The key behavior is that the oracle processes the valid=false result
+        // The key behavior is that the script processes the valid=false result
         invalidResult.isLeft || invalidResult.isRight
       )
     }

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/examples/TicTacToeGameSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/examples/TicTacToeGameSuite.scala
@@ -28,9 +28,9 @@ object TicTacToeGameSuite extends SimpleIOSuite {
   import DataStateTestOps._
   import TestImports.optionFiberRecordOps
 
-  // Inline state machine definition with dynamic oracle CID via string interpolation.
-  // This replaces the static resource file which had a hardcoded oracle UUID.
-  private def stateMachineJson(oracleFiberId: UUID): String =
+  // Inline state machine definition with dynamic script CID via string interpolation.
+  // This replaces the static resource file which had a hardcoded script UUID.
+  private def stateMachineJson(scriptFiberId: UUID): String =
     s"""{
     "states": {
       "setup": { "id": "setup", "isFinal": false },
@@ -52,8 +52,8 @@ object TicTacToeGameSuite extends SimpleIOSuite {
           ]
         },
         "effect": {
-          "_oracleCall": {
-            "fiberId": {"var": "state.oracleFiberId"},
+          "_scriptCall": {
+            "fiberId": {"var": "state.scriptFiberId"},
             "method": "initialize",
             "args": {
               "playerX": {"var": "event.playerX"},
@@ -73,11 +73,11 @@ object TicTacToeGameSuite extends SimpleIOSuite {
         "to": "playing",
         "eventName": "make_move",
         "guard": {
-          "===": [{"var": "scripts.${oracleFiberId}.state.status"}, "InProgress"]
+          "===": [{"var": "scripts.${scriptFiberId}.state.status"}, "InProgress"]
         },
         "effect": {
-          "_oracleCall": {
-            "fiberId": {"var": "state.oracleFiberId"},
+          "_scriptCall": {
+            "fiberId": {"var": "state.scriptFiberId"},
             "method": "makeMove",
             "args": {
               "player": {"var": "event.player"},
@@ -89,7 +89,7 @@ object TicTacToeGameSuite extends SimpleIOSuite {
             "cell": {"var": "event.cell"}
           }
         },
-        "dependencies": ["${oracleFiberId}"]
+        "dependencies": ["${scriptFiberId}"]
       },
       {
         "from": "playing",
@@ -97,35 +97,35 @@ object TicTacToeGameSuite extends SimpleIOSuite {
         "eventName": "make_move",
         "guard": {
           "or": [
-            {"===": [{"var": "scripts.${oracleFiberId}.state.status"}, "Won"]},
-            {"===": [{"var": "scripts.${oracleFiberId}.state.status"}, "Draw"]}
+            {"===": [{"var": "scripts.${scriptFiberId}.state.status"}, "Won"]},
+            {"===": [{"var": "scripts.${scriptFiberId}.state.status"}, "Draw"]}
           ]
         },
         "effect": {
-          "_oracleCall": {
-            "fiberId": {"var": "state.oracleFiberId"},
+          "_scriptCall": {
+            "fiberId": {"var": "state.scriptFiberId"},
             "method": "makeMove",
             "args": {
               "player": {"var": "event.player"},
               "cell": {"var": "event.cell"}
             }
           },
-          "finalStatus": {"var": "scripts.${oracleFiberId}.state.status"},
-          "winner": {"var": "scripts.${oracleFiberId}.state.winner"},
-          "finalBoard": {"var": "scripts.${oracleFiberId}.state.board"},
+          "finalStatus": {"var": "scripts.${scriptFiberId}.state.status"},
+          "winner": {"var": "scripts.${scriptFiberId}.state.winner"},
+          "finalBoard": {"var": "scripts.${scriptFiberId}.state.board"},
           "_emit": [
             {
               "name": "game_completed",
               "data": {
                 "gameId": {"var": "state.gameId"},
-                "winner": {"var": "scripts.${oracleFiberId}.state.winner"},
-                "status": {"var": "scripts.${oracleFiberId}.state.status"},
-                "moveCount": {"var": "scripts.${oracleFiberId}.state.moveCount"}
+                "winner": {"var": "scripts.${scriptFiberId}.state.winner"},
+                "status": {"var": "scripts.${scriptFiberId}.state.status"},
+                "moveCount": {"var": "scripts.${scriptFiberId}.state.moveCount"}
               }
             }
           ]
         },
-        "dependencies": ["${oracleFiberId}"]
+        "dependencies": ["${scriptFiberId}"]
       },
       {
         "from": "playing",
@@ -133,19 +133,19 @@ object TicTacToeGameSuite extends SimpleIOSuite {
         "eventName": "reset_board",
         "guard": {
           "or": [
-            {"===": [{"var": "scripts.${oracleFiberId}.state.status"}, "Won"]},
-            {"===": [{"var": "scripts.${oracleFiberId}.state.status"}, "Draw"]}
+            {"===": [{"var": "scripts.${scriptFiberId}.state.status"}, "Won"]},
+            {"===": [{"var": "scripts.${scriptFiberId}.state.status"}, "Draw"]}
           ]
         },
         "effect": {
-          "_oracleCall": {
-            "fiberId": {"var": "state.oracleFiberId"},
+          "_scriptCall": {
+            "fiberId": {"var": "state.scriptFiberId"},
             "method": "resetGame",
             "args": {}
           },
           "roundCount": {"+": [{"var": "state.roundCount"}, 1]}
         },
-        "dependencies": ["${oracleFiberId}"]
+        "dependencies": ["${scriptFiberId}"]
       },
       {
         "from": "playing",
@@ -153,8 +153,8 @@ object TicTacToeGameSuite extends SimpleIOSuite {
         "eventName": "cancel_game",
         "guard": {"==": [1, 1]},
         "effect": {
-          "_oracleCall": {
-            "fiberId": {"var": "state.oracleFiberId"},
+          "_scriptCall": {
+            "fiberId": {"var": "state.scriptFiberId"},
             "method": "cancelGame",
             "args": {
               "requestedBy": {"var": "event.requestedBy"},
@@ -181,7 +181,7 @@ object TicTacToeGameSuite extends SimpleIOSuite {
   }"""
 
   /**
-   * Shared setup: creates oracle + state machine and returns the initial DataState
+   * Shared setup: creates script + state machine and returns the initial DataState
    * along with the generated CIDs.
    */
   private def setupGame(
@@ -192,36 +192,36 @@ object TicTacToeGameSuite extends SimpleIOSuite {
     l0ctx: L0NodeContext[IO]
   ): IO[(DataState[OnChain, CalculatedState], UUID, UUID)] =
     for {
-      oracleFiberId  <- UUIDGen.randomUUID[IO]
+      scriptFiberId  <- UUIDGen.randomUUID[IO]
       machineFiberId <- UUIDGen.randomUUID[IO]
 
-      // Load oracle definition from resource (no hardcoded UUIDs)
-      oracleDefJson <- IO {
+      // Load script definition from resource (no hardcoded UUIDs)
+      scriptDefJson <- IO {
         val stream = getClass.getResourceAsStream("/tictactoe/script-definition.json")
         scala.io.Source.fromInputStream(stream).mkString
       }
-      oracleDefParsed <- IO.fromEither(parse(oracleDefJson))
-      oracleScript    <- IO.fromEither(oracleDefParsed.hcursor.downField("scriptProgram").as[JsonLogicExpression])
-      oracleInitialState <- IO.fromEither(
-        oracleDefParsed.hcursor.downField("initialState").as[Option[JsonLogicValue]]
+      scriptDefParsed <- IO.fromEither(parse(scriptDefJson))
+      scriptSource    <- IO.fromEither(scriptDefParsed.hcursor.downField("scriptProgram").as[JsonLogicExpression])
+      scriptInitialState <- IO.fromEither(
+        scriptDefParsed.hcursor.downField("initialState").as[Option[JsonLogicValue]]
       )
 
-      // Create oracle via combiner
-      createOracle = Updates.CreateScript(
-        fiberId = oracleFiberId,
-        scriptProgram = oracleScript,
-        initialState = oracleInitialState,
+      // Create script via combiner
+      createScript = Updates.CreateScript(
+        fiberId = scriptFiberId,
+        scriptProgram = scriptSource,
+        initialState = scriptInitialState,
         accessControl = AccessControlPolicy.Public
       )
-      oracleProof <- registry.generateProofs(createOracle, Set(Alice))
-      stateAfterOracle <- combiner.insert(
+      scriptProof <- registry.generateProofs(createScript, Set(Alice))
+      stateAfterScript <- combiner.insert(
         DataState(OnChain.genesis, CalculatedState.genesis),
-        Signed(createOracle, oracleProof)
+        Signed(createScript, scriptProof)
       )
 
-      // Create state machine with dynamic oracle CID
+      // Create state machine with dynamic script CID
       machineDef <- IO.fromEither(
-        decode[StateMachineDefinition](stateMachineJson(oracleFiberId)).left.map(err =>
+        decode[StateMachineDefinition](stateMachineJson(scriptFiberId)).left.map(err =>
           new RuntimeException(s"Failed to decode state machine JSON: $err")
         )
       )
@@ -229,15 +229,15 @@ object TicTacToeGameSuite extends SimpleIOSuite {
       machineFiber <- FiberBuilder(machineFiberId, ordinal, machineDef)
         .withState("setup")
         .withData(
-          "oracleFiberId" -> StrValue(oracleFiberId.toString),
+          "scriptFiberId" -> StrValue(scriptFiberId.toString),
           "status"        -> StrValue("waiting"),
           "roundCount"    -> IntValue(0)
         )
         .ownedBy(registry, Alice, Bob)
         .build[IO]
 
-      stateAfterMachine <- stateAfterOracle.withRecord[IO](machineFiberId, machineFiber)
-    } yield (stateAfterMachine, oracleFiberId, machineFiberId)
+      stateAfterMachine <- stateAfterScript.withRecord[IO](machineFiberId, machineFiber)
+    } yield (stateAfterMachine, scriptFiberId, machineFiberId)
 
   // Type alias for readability
   private type CombinerService =
@@ -256,7 +256,7 @@ object TicTacToeGameSuite extends SimpleIOSuite {
 
       for {
         combiner                                      <- Combiner.make[IO]().pure[IO]
-        (initialState, oracleFiberId, machineFiberId) <- setupGame(fixture.ordinal, registry, combiner)
+        (initialState, scriptFiberId, machineFiberId) <- setupGame(fixture.ordinal, registry, combiner)
 
         aliceAddr = registry.addresses(Alice)
         bobAddr = registry.addresses(Bob)
@@ -314,15 +314,15 @@ object TicTacToeGameSuite extends SimpleIOSuite {
         )(registry, combiner)
 
         finalMachine = finalState.fiberRecord(machineFiberId)
-        finalOracle = finalState.oracleRecord(oracleFiberId)
+        finalScript = finalState.scriptRecord(scriptFiberId)
 
-        oracleStatus = finalOracle.flatMap { o =>
+        scriptStatus = finalScript.flatMap { o =>
           o.stateData match {
             case Some(MapValue(m)) => m.get("status").collect { case StrValue(s) => s }
             case _                 => None
           }
         }
-        oracleWinner = finalOracle.flatMap { o =>
+        scriptWinner = finalScript.flatMap { o =>
           o.stateData match {
             case Some(MapValue(m)) => m.get("winner").collect { case StrValue(w) => w }
             case _                 => None
@@ -341,11 +341,11 @@ object TicTacToeGameSuite extends SimpleIOSuite {
             }
           )
           .getOrElse(false),
-        finalOracle.isDefined,
-        finalOracle.map(_.sequenceNumber).contains(FiberOrdinal.unsafeApply(6L)),
-        oracleStatus.contains("Won"),
-        oracleWinner.contains("X"),
-        finalOracle.flatMap(_.stateData).exists {
+        finalScript.isDefined,
+        finalScript.map(_.sequenceNumber).contains(FiberOrdinal.unsafeApply(6L)),
+        scriptStatus.contains("Won"),
+        scriptWinner.contains("X"),
+        finalScript.flatMap(_.stateData).exists {
           case MapValue(m) =>
             m.get("board") match {
               case Some(ArrayValue(List(StrValue("X"), StrValue("X"), StrValue("X"), _, _, _, _, _, _))) => true
@@ -365,7 +365,7 @@ object TicTacToeGameSuite extends SimpleIOSuite {
 
       for {
         combiner                                      <- Combiner.make[IO]().pure[IO]
-        (initialState, oracleFiberId, machineFiberId) <- setupGame(fixture.ordinal, registry, combiner)
+        (initialState, scriptFiberId, machineFiberId) <- setupGame(fixture.ordinal, registry, combiner)
 
         aliceAddr = registry.addresses(Alice)
         bobAddr = registry.addresses(Bob)
@@ -405,9 +405,9 @@ object TicTacToeGameSuite extends SimpleIOSuite {
         }
 
         finalMachine = finalState.fiberRecord(machineFiberId)
-        finalOracle = finalState.oracleRecord(oracleFiberId)
+        finalScript = finalState.scriptRecord(scriptFiberId)
 
-        oracleStatus = finalOracle.flatMap { o =>
+        scriptStatus = finalScript.flatMap { o =>
           o.stateData match {
             case Some(MapValue(m)) => m.get("status").collect { case StrValue(s) => s }
             case _                 => None
@@ -417,9 +417,9 @@ object TicTacToeGameSuite extends SimpleIOSuite {
       } yield expect.all(
         finalMachine.isDefined,
         finalMachine.map(_.currentState).contains(StateId("playing")),
-        finalOracle.isDefined,
-        finalOracle.map(_.sequenceNumber).contains(FiberOrdinal.unsafeApply(10L)),
-        oracleStatus.contains("Draw")
+        finalScript.isDefined,
+        finalScript.map(_.sequenceNumber).contains(FiberOrdinal.unsafeApply(10L)),
+        scriptStatus.contains("Draw")
       )
     }
   }
@@ -432,7 +432,7 @@ object TicTacToeGameSuite extends SimpleIOSuite {
 
       for {
         combiner                                      <- Combiner.make[IO]().pure[IO]
-        (initialState, oracleFiberId, machineFiberId) <- setupGame(fixture.ordinal, registry, combiner)
+        (initialState, scriptFiberId, machineFiberId) <- setupGame(fixture.ordinal, registry, combiner)
 
         aliceAddr = registry.addresses(Alice)
         bobAddr = registry.addresses(Bob)
@@ -467,13 +467,13 @@ object TicTacToeGameSuite extends SimpleIOSuite {
         )(registry, combiner)
 
         machineAfterInvalid = state3.fiberRecord(machineFiberId)
-        oracleAfterInvalid = state3.oracleRecord(oracleFiberId)
+        scriptAfterInvalid = state3.scriptRecord(scriptFiberId)
 
       } yield expect.all(
         machineAfterInvalid.isDefined,
         machineAfterInvalid.exists(m => m.lastReceipt.exists(!_.success)),
-        oracleAfterInvalid.map(_.sequenceNumber).contains(FiberOrdinal.unsafeApply(2L)),
-        oracleAfterInvalid.flatMap(_.stateData).exists {
+        scriptAfterInvalid.map(_.sequenceNumber).contains(FiberOrdinal.unsafeApply(2L)),
+        scriptAfterInvalid.flatMap(_.stateData).exists {
           case MapValue(m) => m.get("moveCount").contains(IntValue(1))
           case _           => false
         }
@@ -489,7 +489,7 @@ object TicTacToeGameSuite extends SimpleIOSuite {
 
       for {
         combiner                                      <- Combiner.make[IO]().pure[IO]
-        (initialState, oracleFiberId, machineFiberId) <- setupGame(fixture.ordinal, registry, combiner)
+        (initialState, scriptFiberId, machineFiberId) <- setupGame(fixture.ordinal, registry, combiner)
 
         aliceAddr = registry.addresses(Alice)
         bobAddr = registry.addresses(Bob)
@@ -536,8 +536,8 @@ object TicTacToeGameSuite extends SimpleIOSuite {
         machineAfterReset = stateAfterReset.fiberRecord(machineFiberId)
         roundCount = machineAfterReset.extractInt("roundCount")
 
-        oracleAfterReset = stateAfterReset.oracleRecord(oracleFiberId)
-        oracleStatusAfterReset = oracleAfterReset.flatMap { o =>
+        scriptAfterReset = stateAfterReset.scriptRecord(scriptFiberId)
+        scriptStatusAfterReset = scriptAfterReset.flatMap { o =>
           o.stateData match {
             case Some(MapValue(m)) => m.get("status").collect { case StrValue(s) => s }
             case _                 => None
@@ -548,8 +548,8 @@ object TicTacToeGameSuite extends SimpleIOSuite {
         machineAfterReset.isDefined,
         machineAfterReset.map(_.currentState).contains(StateId("playing")),
         roundCount.contains(BigInt(1)),
-        oracleAfterReset.isDefined,
-        oracleStatusAfterReset.contains("InProgress")
+        scriptAfterReset.isDefined,
+        scriptStatusAfterReset.contains("InProgress")
       )
     }
   }

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/testkit/DataStateTestOps.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/testkit/DataStateTestOps.scala
@@ -109,9 +109,9 @@ object DataStateTestOps {
     /**
      * Lookup a script fiber record by CID.
      *
-     * @return Some(record) if the oracle exists, None otherwise
+     * @return Some(record) if the script exists, None otherwise
      */
-    def oracleRecord(fiberId: UUID): Option[Records.ScriptFiberRecord] =
+    def scriptRecord(fiberId: UUID): Option[Records.ScriptFiberRecord] =
       state.calculated.scripts.get(fiberId)
 
     /**


### PR DESCRIPTION
Removes the last **"oracle"** spellings, completing the script/machine-only surface. "Script" was already the public term; this drops the legacy naming across the HTTP API, the fiber engine, the scripting-language token, the e2e harness, and the docs.

> **Stacked on #164** (`feat/committed-state-migration`) — it builds on that branch's `ML0Routes` (`/scripts/estimate-fee`, `/scripts/state-proof`). Re-target to `main` once #164 merges. Review only the top commit.

> **Sister PR:** ottobot-ai/ottochain-sdk#206 (client paths + `ScriptInvocation` type). The two are logically paired; ottochain's e2e passes independently (the harness uses direct HTTP + only imports `HttpClient`-type helpers, not the SDK's `OracleInvocation` type).

### HTTP API (breaking)
- Remove `GET /v1/oracles{,/{id},/{id}/invocations}`; serve the same under `/v1/scripts` (`estimate-fee` + `state-proof` were already there).

### Serialized / public types
- `FiberLogEntry.OracleInvocation` → `ScriptInvocation`
- `GasExhaustionPhase.Oracle` → `Script`
- `FailureReason.OracleInvocationFailed` → `ScriptInvocationFailed`
- `ScriptRules.OracleNotFound` / `OracleAccessDenied` → `ScriptNotFound` / `ScriptAccessDenied`
- `Records.lastInvocation`, `TransactionResult.updatedScripts`, plus internal identifiers/comments across models + shared-data + l0.

### Scripting-language token (breaking)
- The cross-fiber call token `_oracleCall` → `_scriptCall` (`ReservedKeys.SCRIPT_CALL`). The **live** tictactoe example, the inline test scripts, and the language docs move in lockstep so the chain and authored scripts agree.

### e2e harness
- All direct `/oracles` HTTP paths → `/scripts`; terminal CLI command/flags (`oracle`→`script`, `--oracle`→`--script`, `--oracleId`→`--scriptId`); example manifests `type:"oracle"`→`"script"`; `oracleFiberId`→`scriptFiberId`.

### Deliberately preserved (real-world domain, **not** our terminology)
- Prediction-market **oracle agents** (`oracleId` / `oracleReputation` / `oracleSubmissions`) and the market app's `"oracles"` data field + `std-manifest` conformance fixture.

### Validation
- All **358** shared-data tests pass; `scalafmtCheckAll` + `scalafixAll --check` clean; `currencyL0/compile` clean.
- The whitepaper **PDF** is untracked WIP and must be regenerated from the updated `.tex`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)