### PR TITLE
feat(asset): sigma-gated morphism guards (metakit rc.5)

### DIFF
--- a/docs/proposals/asset-model-zk-extension.md
+++ b/docs/proposals/asset-model-zk-extension.md
@@ -36,16 +36,19 @@ Companion: `docs/proposals/zk-coin-audit.md`, `docs/proposals/asset-model.md`,
 
 ## 1. The opcode reality (reconciled — one agent was wrong)
 
-metakit `1.8.0-rc.4` (pinned in `project/Dependencies.scala`) **does expose zk-verifier opcodes to the
+metakit `1.8.0-rc.5` (pinned in `project/Dependencies.scala`) **does expose zk-verifier opcodes to the
 JLVM, and they work in the combiner today.** This is not a claim — it is *demonstrated* by the shipped
 `ZkGatedMorphismSuite`, which builds a real `PoseidonMerkleTree` inclusion proof, gates a `Transfer`
 morphism on `{"pmt_verify": [...]}`, and asserts the on-chain opcode agrees with metakit's tree builder
 (valid proof accepted, tampered/absent rejected), plus a `groth16_verify` negative path.
 
-Reachable opcodes (verified against the resolved rc.4 jar via `javap` and by running them):
+Reachable opcodes (verified against the resolved jar via `javap` and by running them):
 `groth16_verify` (SP1-Groth16-BN254, 250k gas), `pmt_verify` (Poseidon-Merkle inclusion),
 `poseidon` (≤4 inputs), `bn254_add/mul/pairing`, `smt_verify`/`mpt_verify`, `bls_verify`,
-`schnorr_verify`, `ecvrf_verify`. They dispatch through the exact `JsonLogicEvaluator.evaluateWithGas`
+`schnorr_verify`, `ecvrf_verify` — **and, new in `1.8.0-rc.5`, the Σ-protocol family**:
+`prove_dlog_verify` (Schnorr / DLog leaf), `prove_dhtuple_verify` (DDH / Diffie–Hellman-tuple leaf),
+and `sigma_verify` (recursive CDS AND/OR/THRESHOLD over BN254 G1 — i.e. threshold + ring authorization,
+hiding which signer(s) participated). They dispatch through the exact `JsonLogicEvaluator.evaluateWithGas`
 path the `AssetCombiner` guard uses.
 
 > **Honesty note (a real cross-agent contradiction, resolved):** the lossy-compose investigation
@@ -72,10 +75,23 @@ Unlocks today: a **proof-gated `mintPolicy`** for bridges ("mint iff this SP1 pr
 verifies" — directly serves `asset-interop-functor.md` Open-Q3), **zk compliance/age gates**, and
 **Merkle-airdrop / allowlist** claims via `pmt_verify`.
 
-> **CAVEAT (load-bearing):** metakit's Groth16 / Poseidon-Merkle verifier has **no public security
-> audit**. A ZkVerify guard is sound only up to that verifier; it **must not protect real value until
-> the verifier is audited**. (We lean on *one reused deterministic verifier* — far better than
-> hand-rolling per use — but "audited" is struck from the pitch.)
+**New in `1.8.0-rc.5` — Σ-protocol guards (threshold / ring authorization).** The same witness →
+`evalGuardOrReject` path now also serves `sigma_verify` / `prove_dlog_verify` / `prove_dhtuple_verify`,
+so a guard can express **k-of-n / ring authorization without revealing which signer(s) participated** —
+e.g. a `mintPolicy` "any 2-of-3 issuers may mint, hidden which" (`sigma_verify` over a
+`threshold(2,[dlog A, dlog B, dlog C])` proposition), or a `Governed` `Compose` authorized by a ring
+`or([dlog A, dlog B])`. This was the **motivating use case** for adding the Σ opcodes to metakit, and it
+is the SAME zero-new-ottochain-crypto win as the Groth16 / Merkle guards (one reused deterministic
+verifier, witness on the tx, graceful `CombineRejected` on failure). It is authorization, **not**
+confidential amounts — orthogonal to the 5-bit behavior model and to the shielded-mode subsystem (§4).
+Policy JSON in `asset-model.md` §8.3; exercised end-to-end by `SigmaGatedMorphismSuite`.
+
+> **CAVEAT (load-bearing):** none of metakit's verifier opcodes — Groth16 / Poseidon-Merkle, nor the
+> Σ-protocol family (`prove_dlog` / `prove_dhtuple` / `sigma_verify`, whose strong-FS + CDS surface is
+> implemented + live but **not yet externally audited**, metakit `docs/sigma-verify.md` §0) — has a
+> public security audit. A ZkVerify guard is sound only up to that verifier; it **must not protect real
+> value until the verifier is audited**. (We lean on *one reused deterministic verifier* — far better
+> than hand-rolling per use — but "audited" is struck from the pitch.)
 
 ---
 

--- a/docs/proposals/asset-model.md
+++ b/docs/proposals/asset-model.md
@@ -826,7 +826,8 @@ A `Governed` morphism's `guard` — and a `mintPolicy` guard — may REQUIRE a z
 Merkle-membership proof carried on the transaction. The signed `ApplyMorphism` / `MintAsset` carries an
 optional `witness: Option[JsonLogicValue]`, which the combiner exposes to the guard under the reserved
 `witness` context key. The guard then calls one of metakit's already-wired, gas-metered verifier opcodes
-(`groth16_verify`, `pmt_verify`, `poseidon`) over that witness:
+(`groth16_verify`, `pmt_verify`, `poseidon`, and — since metakit `1.8.0-rc.5` — the Σ-protocol family
+`prove_dlog_verify` / `prove_dhtuple_verify` / `sigma_verify`) over that witness:
 
 ```json
 { "morphisms": {
@@ -845,6 +846,33 @@ or, for a proof-gated mint ("mint iff this membership/inclusion proof verifies")
                                       {"var": "witness.proof"} ] } }
 ```
 
+Since metakit `1.8.0-rc.5` the **Σ-protocol** verifier opcodes are available too, so a guard can require
+**threshold / ring authorization without revealing which signer(s) participated** — the use case the Σ
+opcodes were built for. A `mintPolicy` "any 2 of these 3 issuer keys may mint, hidden which":
+
+```json
+{ "mintPolicy": { "sigma_verify": [ { "type": "threshold", "k": 2, "children": [
+                                        {"type":"dlog","pk":"<issuerA-64B>"},
+                                        {"type":"dlog","pk":"<issuerB-64B>"},
+                                        {"type":"dlog","pk":"<issuerC-64B>"} ] },
+                                    {"var": "witness.proof"},
+                                    {"var": "witness.message"} ] } }
+```
+
+or a `Governed` morphism authorized by **any one of a ring** of holders (hidden which):
+
+```json
+{ "morphisms": { "Compose": { "visibility": "Governed",
+    "guard": { "sigma_verify": [ {"type":"or","children":[ {"type":"dlog","pk":"<A-64B>"},
+                                                            {"type":"dlog","pk":"<B-64B>"} ]},
+                                 {"var":"witness.proof"}, {"var":"witness.message"} ] } } } }
+```
+
+The proposition (the issuer / holder set) is FIXED in the policy; the prover's per-use `proof` + bound
+`message` ride on the `witness`. Same combiner path, same determinism — `sigma_verify` is just another
+JLVM opcode through `evalGuardOrReject`. (Authorization, not confidential amounts: this is orthogonal to
+the 5-bit behavior model and to the shielded-mode subsystem of `asset-shielded-mode.md`.)
+
 This is **pure wiring, no new cryptography**: the verifier opcodes already exist in metakit and run
 DETERMINISTICALLY in the combiner through the same `JsonLogicEvaluator.evaluateWithGas` path every guard
 uses (`AssetCombiner.evalGuardOrReject`) — one reused verifier, not a hand-rolled per-use check. A false
@@ -852,9 +880,61 @@ or failed verification is a graceful `CombineRejected`, never a snapshot abort (
 combiner-only, stateful gate). Out of scope (intentionally): confidential amounts, homomorphic
 commitments, shielded pools, nullifier sets, range proofs — any new crypto.
 
-**CAVEAT (honest):** metakit's Groth16 / Poseidon-Merkle verifier has **no public security audit**. A
-`ZkVerify`-gated guard is sound only up to the correctness of that verifier, so it **must not protect real
-value** until metakit's verifier is independently audited.
+**CAVEAT (honest):** none of metakit's verifier opcodes — the Groth16 / Poseidon-Merkle verifier, nor the
+Σ-protocol family (`prove_dlog` / `prove_dhtuple` / `sigma_verify`) — has a public security audit yet. The
+Σ family is implemented and live but its strong-Fiat-Shamir + CDS surface is **not yet externally audited**
+(metakit `docs/sigma-verify.md` §0). A `ZkVerify`-gated guard is sound only up to the correctness of the
+underlying verifier, so it **must not protect real value** until that verifier is independently audited.
+
+### Richer dynamics — computed propositions & boolean composition (the Ergo `SigmaProp` / CDS map)
+
+The Σ-gated guard above is the *floor*, not the ceiling. Two composition layers give the guard the same
+expressive range as Ergo's `SigmaProp` and the CDS algebra of Damgård's Σ-protocol theory:
+
+**Layer 1 — the Σ-composition algebra, INSIDE `sigma_verify` (hiding).** The proposition tree IS Ergo's
+`SigmaProp`: `dlog` (≡ `proveDlog`) and `dhtuple` (≡ `proveDHTuple`) leaves under `and` (CAND), `or`
+(COR), `threshold(k)` (CTHRESHOLD ≡ `atLeast`), arbitrarily nested. Ring signatures (a wide `or`), m-of-n,
+and mixed access trees (`and` of `or`s of `threshold`s) verify in one shot with CDS hiding — *which*
+leaf/branch satisfied stays hidden.
+
+**Layer 2 — computed propositions & boolean composition, via JLVM (the "script" layer).** The guard is a
+full JSON-Logic expression and `sigma_verify`'s three arguments are sub-expressions, so:
+
+- the **proposition need not be a literal** — it can be *computed* from the guard context
+  (`amount` / `holder` / `assetId` / `ordinal` / `witness`, plus any committed-state the combiner injects)
+  with `var` / `if` / `get` / `map` / `merge` + object/array construction. E.g. choose the threshold by
+  size — `"k": {"if":[{">":[{"var":"amount"},1000]}, 3, 2]}` ("large mints need 3-of-n, small 2-of-n") —
+  or pull the issuer set from policy state. This is OttoChain's analogue of Ergo computing a `SigmaProp`
+  in ErgoScript: the predicate is *data*, assembled at evaluation time.
+- `sigma_verify` **composes with non-Σ predicates** through boolean `and` / `or` / `if`: e.g.
+  `{"and":[{">":[{"var":"ordinal"},<unlock>]}, {"sigma_verify":[…2-of-3…]}]}` — a time-lock AND a hidden
+  2-of-3. Amount caps, state checks, even `pmt_verify` / `groth16_verify` membership gate *alongside* the
+  Σ proof. (`SigmaGatedMorphismSuite` exercises exactly this `and`(amount-cap, threshold) shape.)
+
+**The one rule (CDS / metakit RFC §1):** hiding-composition lives *inside one* `sigma_verify`
+proposition. Do **not** JSON-Logic-`or` two `sigma_verify` calls to get an OR — that reveals which call
+verified, defeating CDS hiding. So: *which-signer / m-of-n privacy* → inside the tree; *plain boolean
+conditions* → JLVM around it. (Ergo enforces the identical `SigmaProp`-vs-`Boolean` split.)
+
+**Anti-replay:** the `message` a leaf binds should commit to op-specific data (e.g. `assetId` ‖ `amount`
+‖ a snapshot anchor), not a fixed constant, so a valid proof cannot be replayed across mints — the same
+linearity the commit-reveal nonce gives `AuthorizeCompose` (§8.5 below).
+
+**Ergo `SigmaProp` ↔ OttoChain JLVM:**
+
+- `proveDlog(pk)` / `proveDHTuple` ↔ a `sigma_verify` leaf `{"type":"dlog" | "dhtuple", …}`
+- `&&` / `||` / `atLeast(k,…)` ↔ proposition `and` / `or` / `threshold(k)` (CDS hiding, inside one proof)
+- ErgoScript *computes* the SigmaProp ↔ JLVM *computes* the proposition (`var` / `if` / `map` + objects)
+- `sigmaProp(cond) && proveDlog(pk)` ↔ `{"and":[<JLVM predicate>, {"sigma_verify":[…]}]}`
+
+**Boundary (needs a circuit, not a Σ-leaf):** relations beyond dlog/dhtuple — range proofs, Pedersen
+openings, **confidential amounts** — are Groth16 / Bulletproof territory (the shielded-mode subsystem,
+`asset-shielded-mode.md`), not `sigma_verify`. Hiding the signer *set itself* (vs. *which* signer) needs a
+zk accumulator. Weighted / non-k-of-n access structures would need a new metakit connective. The Σ layer
+covers *authorization* richness; *amount privacy* is the orthogonal axis.
+
+> References: I. Damgård, *On Σ-protocols* (the CDS partial-knowledge composition); Ergo `SigmaProp` /
+> `atLeast` (`docs.ergoplatform.com/dev/scs/sigma`); metakit `docs/sigma-verify.md`.
 
 ### Symmetric composition (two holders) — commit-reveal nonce
 

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/SigmaGatedMorphismSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/SigmaGatedMorphismSuite.scala
@@ -1,0 +1,214 @@
+package xyz.kd5ujc.shared_data
+
+import java.util.UUID
+
+import cats.effect.IO
+
+import scala.collection.immutable.SortedMap
+
+import io.constellationnetwork.currency.dataApplication.{DataState, L0NodeContext}
+import io.constellationnetwork.metagraph_sdk.json_logic._
+import io.constellationnetwork.metagraph_sdk.json_logic.core.JsonLogicOp
+import io.constellationnetwork.security.SecurityProvider
+import io.constellationnetwork.security.signature.Signed
+
+import xyz.kd5ujc.schema.Records.AssetRecord
+import xyz.kd5ujc.schema.Updates._
+import xyz.kd5ujc.schema.asset._
+import xyz.kd5ujc.schema.fiber.FiberLogEntry
+import xyz.kd5ujc.schema.registry._
+import xyz.kd5ujc.schema.{CalculatedState, OnChain}
+import xyz.kd5ujc.shared_data.lifecycle.Combiner
+import xyz.kd5ujc.shared_test.Participant._
+import xyz.kd5ujc.shared_test.TestFixture
+
+import io.circe.parser.decode
+import weaver.SimpleIOSuite
+
+/**
+ * Σ-protocol (`sigma_verify`)-gated `mintPolicy` — the "richer dynamics" companion to
+ * [[ZkGatedMorphismSuite]]. Where the sibling suite gates on a Poseidon-Merkle membership proof
+ * (`pmt_verify`) or a Groth16 SNARK (`groth16_verify`), this one gates a proof-gated mint on a
+ * recursive CDS Σ-threshold proof (`sigma_verify`) AND a dynamic context predicate, demonstrating
+ * boolean COMPOSITION of an on-chain threshold proof with a guard-context check:
+ *
+ * {{{
+ *   { "and": [ { "<=": [ {"var":"amount"}, CAP ] },
+ *              { "sigma_verify": [ <proposition>, {"var":"witness.proof"}, {"var":"witness.message"} ] } ] }
+ * }}}
+ *
+ * The Σ vector (proposition / proof / message) is LIFTED VERBATIM from metakit's conformance
+ * corpus (`zk_opcode_test_vectors.json`, `"sigma"` category, the
+ * "THRESHOLD 2-of-3 (exactly k witnesses) -> true" case, whose `expected == "true"`), so we never
+ * hand-roll a Σ prover. The proposition is FIXED in the policy guard; the proof tree and message
+ * ride on the reserved `witness` key the combiner injects into `mintContext`.
+ *
+ * Three cases prove both gates are live and that they compose:
+ *   1. amount ≤ CAP + the valid (proof, message) witness   → mint SUCCEEDS,
+ *   2. amount > CAP + the valid witness                     → CombineRejected (predicate gates, even
+ *                                                             though the Σ proof is valid),
+ *   3. amount ≤ CAP + a tampered witness (wrong message)    → CombineRejected (`sigma_verify` → false).
+ *
+ * CAVEAT (carried from §8 / `AssetCombiner.morphismContext`): metakit's Σ verifier has no public
+ * security audit — a `sigma_verify` guard must not protect real value until that verifier is audited.
+ */
+object SigmaGatedMorphismSuite extends SimpleIOSuite {
+
+  private def asset(n: String): RegistryName = RegistryName.unsafe(s"$n.asset")
+
+  private val stateShape: MessageShape =
+    MessageShape("Asset.State", List(FieldShape("amount", 1, "int64", repeated = false, optional = false)))
+
+  private val genesis = DataState(OnChain.genesis, CalculatedState.genesis)
+
+  private def wasRejected(state: DataState[OnChain, CalculatedState]): Boolean =
+    state.onChain.latestLogs.values.flatten.exists {
+      case _: FiberLogEntry.RejectionReceipt => true
+      case _                                 => false
+    }
+
+  private def assetOf(state: DataState[OnChain, CalculatedState], id: UUID): Option[AssetRecord] =
+    state.calculated.assets.get(id)
+
+  // Deterministic asset ids.
+  private val a1 = UUID.fromString("dddddddd-0000-4000-8000-000000000001")
+  private val a2 = UUID.fromString("dddddddd-0000-4000-8000-000000000002")
+  private val a3 = UUID.fromString("dddddddd-0000-4000-8000-000000000003")
+
+  // ── Known-good Σ vector, lifted VERBATIM from metakit's conformance corpus ──────────────────────
+  // metakit `src/test/resources/conformance/zk_opcode_test_vectors.json`, `"sigma"` category, the
+  // case noted "THRESHOLD 2-of-3 (exactly k witnesses) -> true" (`expected == "true"`). Its `expr`
+  // is `{"sigma_verify":[<proposition>,<proof>,<message>]}`; we split out the three args. Because the
+  // whole vector evaluates to `true`, `sigma_verify(proposition, proof, message)` verifies.
+
+  /** arg0 — the threshold PROPOSITION (2-of-3 over three dlog public keys). FIXED in the guard. */
+  private val sigmaPropositionJson: String =
+    """{"type":"threshold","k":2,"children":[""" +
+    """{"type":"dlog","pk":"0x20418c4b55f7576f6c62f9d0e1e0e52cf09a179566d72c2c8f2c301f54e4a536064573dfb6d9d4f1870737375e39282e99ae8b403c2b7f4ff57add81d9532a51"},""" +
+    """{"type":"dlog","pk":"0x19f5b932805050d67ac80bb61305891dc27068a18b9c4589addfbd520ac1e1cf0f45f70a06ed93bc4888508d91263fecc172fcfc8ec1f6dd91310d0c73cc09d1"},""" +
+    """{"type":"dlog","pk":"0x2d7566e6e023fe09ff134db395c315cd2ccf3a991e1540eac153180b2fb97ace1301357a95587073a2181744f47c66b62d1406997ee2f05327e5fd777110b850"}]}"""
+
+  /** arg1 — the PROOF tree (per-node `e`/`z`). Carried on the witness under `proof`. */
+  private val sigmaProofJson: String =
+    """{"type":"threshold","e":"0xce420da67e40248441b4c4146bc16da56a3e2929d7f5e5ff62640e2bd877dc","k":2,"children":[""" +
+    """{"type":"dlog","e":"0x15f2ae21031ba7b77cf9769d3e37104c31f11ab90ebcd5c50ac9165a616e59","z":"0x2d93c770d287eb098e1300bd307339648ff1431149a2fd8117f1a89cedbb1e08"},""" +
+    """{"type":"dlog","e":"0x633950b384f639e23b2ebb1dc136976cdcbb4f127e67858bb2253ec9b145cd","z":"0x21fc6fb5c553a654f8f3258061797a26f569506c704916fbe4de86b16502eb46"},""" +
+    """{"type":"dlog","e":"0xb889f334f9adbad10663099494c0ea8587747c82a72eb5b1da8826b8085c48","z":"0x2da853b72c74b1d9a09ccd066474e11df57eb55fe1234dd16e723e11960e283e"}]}"""
+
+  /** arg2 — the MESSAGE (hex of ascii "authorize sigma"). Carried on the witness under `message`. */
+  private val sigmaMessageHex: String = "0x617574686f72697a65207369676d61"
+
+  /**
+   * A wrong message — the valid message with its last byte flipped (`...6d61` → `...6d62`), i.e.
+   * same length/shape but a different transcript → the Σ challenges no longer reconstruct →
+   * `sigma_verify` returns false.
+   */
+  private val sigmaMessageHexWrong: String = "0x617574686f72697a65207369676d62"
+
+  private def parseJlv(json: String): JsonLogicValue =
+    decode[JsonLogicValue](json).fold(throw _, identity)
+
+  private val proposition: JsonLogicValue = parseJlv(sigmaPropositionJson)
+  private val proofValue: JsonLogicValue = parseJlv(sigmaProofJson)
+
+  /** Witness = `{proof: <arg1>, message: <arg2>}` (the proof tree + the message the guard hashes). */
+  private val validWitness: JsonLogicValue =
+    MapValue(Map("proof" -> proofValue, "message" -> StrValue(sigmaMessageHex)))
+
+  /** Tampered witness: same valid proof, but the WRONG message → `sigma_verify` → false. */
+  private val tamperedWitness: JsonLogicValue =
+    MapValue(Map("proof" -> proofValue, "message" -> StrValue(sigmaMessageHexWrong)))
+
+  // ── The guard: boolean composition of a context predicate AND a Σ-threshold proof ───────────────
+
+  private val Cap: BigInt = 100
+
+  /**
+   * `{ "and": [ { "<=": [ {"var":"amount"}, CAP ] },
+   *             { "sigma_verify": [ <proposition literal>, {"var":"witness.proof"}, {"var":"witness.message"} ] } ] }`
+   *
+   * The proposition is a literal baked into the policy; the proof tree and message are read from the
+   * injected `witness` context. This is the §8 ZkVerify-gated-mint shape, enriched with a dynamic
+   * `amount <= CAP` predicate so the two gates compose.
+   */
+  private val sigmaGuard: JsonLogicExpression =
+    ApplyExpression(
+      JsonLogicOp.AndOp,
+      List(
+        ApplyExpression(
+          JsonLogicOp.Leq,
+          List(VarExpression(Left("amount")), ConstExpression(IntValue(Cap)))
+        ),
+        ApplyExpression(
+          JsonLogicOp.SigmaVerifyOp,
+          List(
+            ConstExpression(proposition),
+            VarExpression(Left("witness.proof")),
+            VarExpression(Left("witness.message"))
+          )
+        )
+      )
+    )
+
+  // ── Policy builders (mirrors ZkGatedMorphismSuite) ──────────────────────────────────────────────
+
+  private def openSupply(mintGuard: Option[JsonLogicExpression]): SupplyPolicy =
+    SupplyPolicy(maxSupply = None, mintPolicy = mintGuard, burnPolicy = None, decimals = Some(0))
+
+  /** A policy whose `mintPolicy` is the Σ-gate (proof-gated mint). */
+  private def mintGovernedBy(name: String, guard: JsonLogicExpression): CreateAssetPolicy =
+    CreateAssetPolicy(
+      asset(name),
+      SemVer(1, 0, 0),
+      TokenBehavior.Fungible,
+      openSupply(mintGuard = Some(guard)),
+      SortedMap(MorphismKind.Transfer -> MorphismSpec(MorphismVisibility.Public, None, None, None)),
+      stateShape
+    )
+
+  // ════════════════════════════════════════════════════════════════════════════════════════════════
+  // sigma_verify-gated mint with a composed dynamic predicate — the headline test
+  // ════════════════════════════════════════════════════════════════════════════════════════════════
+
+  test(
+    "a sigma_verify mintPolicy composed with a dynamic predicate: ≤CAP+valid mints, >CAP rejects, tampered rejects"
+  ) {
+    TestFixture.resource(Set(Alice)).use { fixture =>
+      implicit val sp: SecurityProvider[IO] = fixture.securityProvider
+      implicit val l0: L0NodeContext[IO] = fixture.l0Context
+      val combiner = Combiner.make[IO]()
+      val aliceHolder = AssetHolder.Wallet(fixture.registry.addresses(Alice))
+      val policy = mintGovernedBy("sigmabridge", sigmaGuard)
+      val ref = SchemaRef(asset("sigmabridge"), VersionReq.Latest)
+
+      // (1) amount ≤ CAP (50) + the valid (proof, message) witness → both gates pass → mints.
+      val mintOk = MintAsset(a1, ref, aliceHolder, 50L, witness = Some(validWitness))
+      // (2) amount > CAP (150) + the SAME valid witness → `<=` predicate fails → CombineRejected,
+      //     even though the Σ proof is valid (proves the boolean composition gates).
+      val mintOverCap = MintAsset(a2, ref, aliceHolder, 150L, witness = Some(validWitness))
+      // (3) amount ≤ CAP (50) + a TAMPERED witness (wrong message) → `sigma_verify` false → rejected.
+      val mintTampered = MintAsset(a3, ref, aliceHolder, 50L, witness = Some(tamperedWitness))
+
+      for {
+        prP <- fixture.registry.generateProofs(policy, Set(Alice))
+        s1  <- combiner.insert(genesis, Signed(policy, prP))
+        // (1) below cap + valid Σ proof → mints
+        prOk <- fixture.registry.generateProofs(mintOk, Set(Alice))
+        sOk  <- combiner.insert(s1, Signed(mintOk, prOk))
+        // (2) above cap + valid Σ proof → rejected, asset not created
+        prCap <- fixture.registry.generateProofs(mintOverCap, Set(Alice))
+        sCap  <- combiner.insert(s1, Signed(mintOverCap, prCap))
+        // (3) below cap + tampered Σ proof → rejected, asset not created
+        prTmp <- fixture.registry.generateProofs(mintTampered, Set(Alice))
+        sTmp  <- combiner.insert(s1, Signed(mintTampered, prTmp))
+      } yield
+      // (1) both gates satisfied → mint applied
+      expect(!wasRejected(sOk)) and expect(assetOf(sOk, a1).map(_.amount).contains(50L)) and
+      expect(assetOf(sOk, a1).map(_.holder).contains(aliceHolder)) and
+      // (2) dynamic predicate gate fires despite a valid Σ proof → rejected, not created
+      expect(wasRejected(sCap)) and expect(assetOf(sCap, a2).isEmpty) and
+      // (3) Σ gate fires (tampered proof) → rejected, not created
+      expect(wasRejected(sTmp)) and expect(assetOf(sTmp, a3).isEmpty)
+    }
+  }
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
     val catsMtl = "1.3.1"
     val enumeratum = "1.7.5"
     val decline = "2.5.0"
-    val metakit = "1.8.0-rc.4"
+    val metakit = "1.8.0-rc.5"
     val pureConfig = "0.17.5"
     val weaver = "0.10.1"
 


### PR DESCRIPTION
## Summary

metakit `1.8.0-rc.5` ships the Σ-protocol verifier opcodes (`prove_dlog_verify` / `prove_dhtuple_verify` / `sigma_verify`). Because the asset guard path (`AssetCombiner.evalGuardOrReject` → `JsonLogicEvaluator.evaluateWithGas`) is opcode-generic, these work as `mintPolicy` / `MorphismSpec.guard` predicates with **zero new ottochain crypto** — through the existing ZkVerify-gated-morphism wiring (witness on the tx → guard context).

This enriches the **authorization** layer only — orthogonal to the 5-bit behavior model. It unlocks:

- **Threshold mint policies** — "any k-of-n issuers may mint, without revealing which."
- **Ring / m-of-n morphism authorization** — hidden which holder authorized.
- **Richer dynamics** (Ergo `SigmaProp` / Damgård CDS ↔ JLVM): the proposition can be *computed* in JLVM and boolean-composed with non-Σ predicates around `sigma_verify` — hiding-composition stays inside one proof, per CDS.

## Changes

- `project/Dependencies.scala`: metakit `rc.4 → rc.5` (additive — Σ opcodes + behavior-identical totality hardening; compiles clean).
- `docs/proposals/asset-model.md` §8.3: Σ opcodes + threshold/ring examples + a **richer-dynamics** subsection (Ergo SigmaProp / CDS ↔ JLVM map, the hiding rule, anti-replay, the circuit boundary) + honest unaudited caveat.
- `docs/proposals/asset-model-zk-extension.md`: opcode reality (rc.5 Σ) + roadmap entry.
- `modules/shared-data/.../SigmaGatedMorphismSuite.scala` (new): end-to-end demo — `mintPolicy = and(amount ≤ cap, sigma_verify(2-of-3 threshold))`; below-cap + valid → mints, above-cap → rejected (the dynamic predicate gates), tampered proof → rejected (the Σ gate). The 2-of-3 vector is lifted verbatim from metakit's conformance set.

## Verification

Asset suites green against rc.5: `SigmaGatedMorphismSuite` + `ZkGatedMorphismSuite` + `AssetMorphismLawSuite` — **25 tests, 0 failures**.

## Caveat

metakit's verifiers (Groth16 + Σ) are **not yet externally audited** — a ZkVerify-gated guard must not protect real value until they are (metakit `docs/sigma-verify.md` §0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
