### PR TITLE
test(e2e): raise DL1-sync retry budget from 20 to 40 attempts

### DIFF
--- a/e2e-test/runner.ts
+++ b/e2e-test/runner.ts
@@ -36,7 +36,12 @@ function parseArgs() {
     wallets: 'alice',
     waitTime: '5',
     retryDelay: '5',
-    maxRetries: '20',
+    // 40 × retryDelay(5s) ≈ 200s budget per ML0-confirmation / DL1-sync / validation wait.
+    // Sized for COLD START: a CI runner's first run fetches the metakit jar (cold cache) and
+    // pays JVM warmup, slowing first-block production past the old 20-attempt (~100s) window —
+    // an intermittent `DL1 sync timed out ... after N attempts (seqNum=…)` flake (see PR #167).
+    // Returns as soon as the condition holds, so the larger budget only affects worst-case waits.
+    maxRetries: '40',
     parallel: 'true',
   };
 


### PR DESCRIPTION
## Summary

Raises the e2e runner's poll budget `maxRetries` default **20 → 40** (`runner.ts`), so each ML0-confirmation / DL1-sync / validation wait gets ~200s instead of ~100s (`maxRetries × retryDelay(5s)`). The e2e workflow uses these defaults as-is.

## Why

On a cold CI runner the **first** run fetches the metakit jar (cold cache) + pays JVM warmup, which slows first-block production past the old ~100s window — an intermittent `DL1 sync timed out … after 20 attempts (seqNum=6)` flake. Observed on **#167**: 3/14 game flows (which touch no sigma/asset code) timed out at step 8, then the *identical* commit passed 14/14 on re-run. Bumping the budget absorbs the cold start; the poll returns as soon as the condition holds, so the larger budget only lengthens worst-case (genuinely-failing) waits.

## Pattern note

The bump is the low-risk fix. The genuinely-better structural fix is a **one-time cluster-warmup / readiness gate before the timed flows** (amortize cold-start once instead of charging each early flow's per-flow budget) — left as a follow-up if the flake recurs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
