### PR TITLE
test(e2e): decouple confirm from wall-clock; right-size node JVMs

### DIFF
--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -16,7 +16,11 @@ services:
       - CL_PASSWORD=${CL_PASSWORD:-password}
       - CL_APP_ENV=dev
       - CL_EXTERNAL_IP=gl0
-      - JAVA_OPTS=-Xmx2g -Xms1g
+      # Right-sized for constrained CI (ubuntu-latest = 2 vCPU / 7 GB shared by ~5 JVMs):
+      # no -Xms pre-commit (heap grows on demand, killing the old 5×1g committed floor that
+      # forced swap → cats-effect "CPU starving"); SerialGC (one GC thread) beats G1's parallel
+      # threads for these small heaps on few cores. Override per-deployment if you need more.
+      - JAVA_OPTS=-Xmx1536m -XX:+UseSerialGC
     ports:
       - "9000:9000"
       - "9001:9001"
@@ -46,7 +50,11 @@ services:
       - CL_L0_PEER_ID=${GL0_PEER_ID}
       - CL_L0_PEER_HOST=gl0
       - CL_L0_PEER_PORT=9000
-      - JAVA_OPTS=-Xmx2g -Xms1g
+      # Right-sized for constrained CI (ubuntu-latest = 2 vCPU / 7 GB shared by ~5 JVMs):
+      # no -Xms pre-commit (heap grows on demand, killing the old 5×1g committed floor that
+      # forced swap → cats-effect "CPU starving"); SerialGC (one GC thread) beats G1's parallel
+      # threads for these small heaps on few cores. Override per-deployment if you need more.
+      - JAVA_OPTS=-Xmx1536m -XX:+UseSerialGC
     ports:
       - "9100:9100"
       - "9101:9101"
@@ -74,7 +82,11 @@ services:
       - CL_GLOBAL_L0_PEER_ID=${GL0_PEER_ID}
       - CL_GLOBAL_L0_PEER_HOST=gl0
       - CL_GLOBAL_L0_PEER_PORT=9000
-      - JAVA_OPTS=-Xmx2g -Xms1g
+      # Right-sized for constrained CI (ubuntu-latest = 2 vCPU / 7 GB shared by ~5 JVMs):
+      # no -Xms pre-commit (heap grows on demand, killing the old 5×1g committed floor that
+      # forced swap → cats-effect "CPU starving"); SerialGC (one GC thread) beats G1's parallel
+      # threads for these small heaps on few cores. Override per-deployment if you need more.
+      - JAVA_OPTS=-Xmx1536m -XX:+UseSerialGC
     ports:
       - "9200:9200"
       - "9201:9201"
@@ -106,7 +118,11 @@ services:
       - CL_L0_PEER_ID=${ML0_PEER_ID}
       - CL_L0_PEER_HOST=ml0
       - CL_L0_PEER_PORT=9200
-      - JAVA_OPTS=-Xmx2g -Xms1g
+      # Right-sized for constrained CI (ubuntu-latest = 2 vCPU / 7 GB shared by ~5 JVMs):
+      # no -Xms pre-commit (heap grows on demand, killing the old 5×1g committed floor that
+      # forced swap → cats-effect "CPU starving"); SerialGC (one GC thread) beats G1's parallel
+      # threads for these small heaps on few cores. Override per-deployment if you need more.
+      - JAVA_OPTS=-Xmx1536m -XX:+UseSerialGC
     ports:
       - "9300:9300"
       - "9301:9301"
@@ -136,7 +152,11 @@ services:
       - CL_L0_PEER_ID=${ML0_PEER_ID}
       - CL_L0_PEER_HOST=ml0
       - CL_L0_PEER_PORT=9200
-      - JAVA_OPTS=-Xmx2g -Xms1g
+      # Right-sized for constrained CI (ubuntu-latest = 2 vCPU / 7 GB shared by ~5 JVMs):
+      # no -Xms pre-commit (heap grows on demand, killing the old 5×1g committed floor that
+      # forced swap → cats-effect "CPU starving"); SerialGC (one GC thread) beats G1's parallel
+      # threads for these small heaps on few cores. Override per-deployment if you need more.
+      - JAVA_OPTS=-Xmx1536m -XX:+UseSerialGC
     ports:
       - "9400:9400"
       - "9401:9401"

--- a/e2e-test/lib/ordinalConfirmation.ts
+++ b/e2e-test/lib/ordinalConfirmation.ts
@@ -24,7 +24,18 @@ export interface OrdinalConfirmationOptions {
   maxResubmits?: number;
   /** Polling interval in ms (default: 2000) */
   pollIntervalMs?: number;
-  /** Maximum total time to wait in ms (default: 300000 = 5 min) */
+  /**
+   * Liveness gate: if the ML0 ordinal does not advance AT ALL for this long, the chain is
+   * considered stalled (consensus not live) and we fail fast. This is the ONLY wall-clock gate
+   * — a chain that keeps producing snapshots is given its full ordinal budget no matter how slow
+   * each ordinal is. Decouples "slow chain" (keep waiting) from "dead chain" (fail). (default: 120000 = 2 min)
+   */
+  stallTimeoutMs?: number;
+  /**
+   * Optional absolute wall-clock ceiling, purely as a runaway backstop. Undefined (the default)
+   * means no absolute cap: termination is guaranteed by the ordinal budget
+   * (`ordinalThreshold` × (`maxResubmits` + 1) ordinals) and the stall gate.
+   */
   maxTotalTimeMs?: number;
   /** Label for logging */
   label: string;
@@ -79,15 +90,26 @@ async function checkEntity(
 /**
  * Wait for ML0 confirmation using ordinal-based tracking with auto-resubmit.
  *
+ * The budget is measured in ML0 *ordinals*, not wall-clock: a chain that keeps producing
+ * snapshots — however slowly — is given its full ordinal budget. Wall-clock only ever fails the
+ * wait through the stall gate, which fires when the ordinal stops advancing entirely (consensus
+ * dead). This decouples "slow chain" (keep waiting) from "dead chain" (fail fast) — the metagraph's
+ * idle snapshot cadence can be tens of seconds per ordinal, so a fixed wall-clock cap used to kill
+ * confirmations that were merely slow, not stuck.
+ *
  * Algorithm:
- * 1. Record start ordinal
- * 2. Poll entity state every pollIntervalMs
- * 3. If predicate satisfied → success
- * 4. If (currentOrdinal - startOrdinal) >= ordinalThreshold:
- *    - Resubmit the transaction
- *    - Reset startOrdinal to currentOrdinal
- *    - Increment resubmit counter
- * 5. If resubmits exhausted or maxTotalTime exceeded → fail
+ * 1. Record start ordinal; remember the last time the ordinal advanced.
+ * 2. Poll entity state every pollIntervalMs.
+ * 3. If predicate satisfied → success.
+ * 4. If the ordinal has not advanced for `stallTimeoutMs` → fail (consensus not live). This also
+ *    covers ML0 being unreachable (ordinal reads return null → no advance).
+ * 5. If (currentOrdinal - startOrdinal) >= ordinalThreshold → resubmit, reset the window, bump the
+ *    resubmit counter.
+ * 6. If resubmits are exhausted and another full threshold passes → fail (ordinal budget spent).
+ * 7. `maxTotalTimeMs`, if set, is an absolute runaway backstop only.
+ *
+ * Termination is guaranteed: while the chain advances, the ordinal budget is consumed; if it stops
+ * advancing, the stall gate fires.
  */
 export async function waitForOrdinalConfirmation(
   opts: OrdinalConfirmationOptions
@@ -100,7 +122,8 @@ export async function waitForOrdinalConfirmation(
     ordinalThreshold = 5,
     maxResubmits = 3,
     pollIntervalMs = 2000,
-    maxTotalTimeMs = 300000,
+    stallTimeoutMs = 120000,
+    maxTotalTimeMs,
     label,
     log,
   } = opts;
@@ -127,13 +150,28 @@ export async function waitForOrdinalConfirmation(
 
   w(`\n      ⏳ ML0 confirm ${label} (ord=${startSnapshot.ordinal})`);
 
+  // Liveness tracking: the highest ordinal we've seen and when we last saw it advance.
+  // The stall gate keys off lack-of-progress, NOT total elapsed time, so a slow-but-live
+  // chain is never killed mid-flight.
+  let lastObservedOrdinal = startSnapshot.ordinal;
+  let lastAdvanceTime = Date.now();
+
   while (true) {
-    // Check timeout
-    if (Date.now() - startTime > maxTotalTimeMs) {
-      w(' ✗ (timeout)\n');
+    // Stall gate (also covers ML0 unreachable: ordinal never advances → fires here).
+    if (Date.now() - lastAdvanceTime > stallTimeoutMs) {
+      w(' ✗ (stalled)\n');
       throw new Error(
-        `${TAG} Confirmation timed out for ${label} after ${maxTotalTimeMs}ms ` +
-          `(${resubmitCount} resubmits)`
+        `${TAG} ML0 ordinal stuck at ${lastObservedOrdinal} for ${stallTimeoutMs}ms for ${label} ` +
+          `— consensus not live (${resubmitCount} resubmits)`
+      );
+    }
+
+    // Absolute runaway backstop (opt-in).
+    if (maxTotalTimeMs !== undefined && Date.now() - startTime > maxTotalTimeMs) {
+      w(' ✗ (abs-timeout)\n');
+      throw new Error(
+        `${TAG} Confirmation hit absolute ceiling for ${label} after ${maxTotalTimeMs}ms ` +
+          `(${resubmitCount} resubmits, ordinal ${lastObservedOrdinal})`
       );
     }
 
@@ -147,12 +185,18 @@ export async function waitForOrdinalConfirmation(
     // Check current ordinal
     const currentSnapshot = await getCurrentOrdinal(ml0BaseUrl);
     if (currentSnapshot) {
+      // Liveness: reset the stall clock whenever the chain makes progress.
+      if (currentSnapshot.ordinal > lastObservedOrdinal) {
+        lastObservedOrdinal = currentSnapshot.ordinal;
+        lastAdvanceTime = Date.now();
+      }
+
       const ordinalDelta = currentSnapshot.ordinal - startSnapshot.ordinal;
 
       if (ordinalDelta >= ordinalThreshold) {
         // Ordinals passed without our tx appearing — resubmit
         if (resubmitCount >= maxResubmits) {
-          w(' ✗ (resubmits exhausted)\n');
+          w(' ✗ (ordinal budget exhausted)\n');
           throw new Error(
             `${TAG} Confirmation failed for ${label}: transaction not included after ` +
               `${ordinalThreshold} ordinals × ${maxResubmits + 1} attempts ` +

--- a/e2e-test/runner.ts
+++ b/e2e-test/runner.ts
@@ -745,7 +745,10 @@ async function runFlow(
         ordinalThreshold: 5,
         maxResubmits: 3,
         pollIntervalMs: 2000,
-        maxTotalTimeMs: 300000,
+        // No fixed wall-clock cap: a slow-but-advancing chain gets its full ordinal budget
+        // (5 × 4 = 20 ordinals). The stall gate fails fast (120s) only if ML0 stops producing
+        // snapshots entirely — i.e. genuine consensus death, not mere slowness under CI load.
+        stallTimeoutMs: 120000,
         label: `${step.action} on ${activeCid}`,
         log: log ? { write: (s: string) => log.write(s) } : undefined,
       });

--- a/modules/data_l1/src/main/resources/dag-l1.conf
+++ b/modules/data_l1/src/main/resources/dag-l1.conf
@@ -32,7 +32,12 @@ token-lock {
 
 transaction-limit {
   base-balance = 100000000
+  # Cadence at which the L1 fires a TimeTrigger block when below the event-trigger threshold.
+  # Drives the metagraph's idle snapshot cadence (one empty block → one empty ML0 snapshot per
+  # interval). Overridable via env so CI can trade a busier chain for faster confirmations — but
+  # note a lower value means MORE empty-block consensus rounds, i.e. more CPU on constrained infra.
   time-trigger-interval = 43 seconds
+  time-trigger-interval = ${?DATA_L1_TIME_TRIGGER_INTERVAL}
   time-to-wait-for-base-balance = 20 hours
   min-fee-without-limit = 200000
 }


### PR DESCRIPTION
## Summary

Hardening for the intermittent **tictactoe step-9 `ordinalConfirm` timeouts** (e.g. [run 27672444458](https://github.com/scasplte2/ottochain/actions/runs/27672444458) — failed 2/14, went green on re-run with no code change).

**Root cause** (from the captured node logs, not a guess): the chain never stalled — ML0 kept producing snapshots on its ~43s idle cadence — but the CI runner was CPU-/RAM-starved, so the data-L1 block carrying the final move wasn't formed within budget. The two events were re-validated `VALID` hundreds of times but never landed in a snapshot, and the e2e's **fixed 300s wall-clock cap killed a confirmation that was merely slow, not stuck**. The cats-effect "CPU is probably starving" warnings appear **only on the DL1 JVMs**.

This is the same flake class as #168 / #169.

## Changes

### 1. Decouple confirmation from wall-clock
`e2e-test/lib/ordinalConfirmation.ts`, `runner.ts`

Budget is now measured in **ML0 ordinals**, not seconds. A chain that keeps producing snapshots — however slowly — gets its full ordinal budget (`ordinalThreshold × (maxResubmits+1)` = 20 ordinals). A new **`stallTimeoutMs`** gate (120s) fails fast **only** when the ordinal stops advancing entirely (genuine consensus death, or ML0 unreachable — covered because null reads never advance the ordinal). `maxTotalTimeMs` becomes an opt-in runaway backstop. Termination stays guaranteed: advancing → budget spent; not advancing → stall gate.

> On the failing run, the chain *was* advancing (47→54 at 43s each). Old logic killed it at 300s after ~1 resubmit; new logic rides out the full ordinal budget while still catching a true stall in 2 min.

### 2. Make the L1 time-trigger cadence overridable
`modules/data_l1/src/main/resources/dag-l1.conf` — matches the existing `${?DATA_PEERS_COUNT}` pattern:
```hocon
time-trigger-interval = ${?DATA_L1_TIME_TRIGGER_INTERVAL}
```
Default **43s unchanged**. Set `DATA_L1_TIME_TRIGGER_INTERVAL` (e.g. in the e2e `dl1-extra.env`) to trade a busier chain for faster confirms. ⚠️ A lower value means more empty-block consensus rounds = more CPU, so pair with #3 / a bigger runner.

### 3. Right-size node JVMs for constrained CI
`docker-compose.local.yml`

`ubuntu-latest` = **2 vCPU / 7 GB** shared by ~5 JVMs, each previously `-Xmx2g -Xms1g` → **10 GB ceiling, 5 GB pre-committed floor → swap → "CPU starving"**. Now `-Xmx1536m`, **no `-Xms` pre-commit** (heap grows on demand), and **SerialGC** (one GC thread, better than G1's parallel threads for small heaps on few cores). Override per-deployment for larger hosts.

## Notes
- Doc-PR #170 and the `feat/semi-private-guard` work are **not** included — this branch is the 4 hardening files only, off `main`.
- `tsc` is clean for the two changed TS files; the pre-existing 15 `tsc` errors are unrelated SDK-shape drift in `lib/registry`/`lib/state-machine` (e2e runs via `tsx`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)