### PR TITLE
feat(fiber): runtime-updatable (dynamic) dependencies (#24)

### DIFF
--- a/modules/models/src/main/scala/xyz/kd5ujc/schema/Records.scala
+++ b/modules/models/src/main/scala/xyz/kd5ujc/schema/Records.scala
@@ -44,7 +44,8 @@ object Records {
     parentFiberId:         Option[UUID] = None,
     childFiberIds:         Set[UUID] = Set.empty,
     schemaBinding:         Option[SchemaBinding] = None,
-    authorizedSigners:     Set[Address] = Set.empty
+    authorizedSigners:     Set[Address] = Set.empty,
+    dynamicDependencies:   List[DynamicDependency] = List.empty
   ) extends FiberRecord
 
   @derive(customizableEncoder, customizableDecoder)

--- a/modules/models/src/main/scala/xyz/kd5ujc/schema/fiber/DynamicDependency.scala
+++ b/modules/models/src/main/scala/xyz/kd5ujc/schema/fiber/DynamicDependency.scala
@@ -1,0 +1,33 @@
+package xyz.kd5ujc.schema.fiber
+
+import java.util.UUID
+
+import io.constellationnetwork.schema.SnapshotOrdinal
+
+import xyz.kd5ujc.schema.CodecConfiguration._
+
+import derevo.circe.magnolia.{customizableDecoder, customizableEncoder}
+import derevo.derive
+
+/**
+ * A single entry in a fiber's append-only dynamic-dependency ledger.
+ *
+ * Dynamic dependencies extend the STATIC, per-transition `Transition.dependencies` with a per-FIBER,
+ * runtime-mutable set of fibers whose state is injected into `machines.<fiberId>.state` for EVERY
+ * transition of this fiber. They are mutated only via the reserved `_addDependency` /
+ * `_setDependencyActive` effect directives (guard-authorized, deterministic), enabling patterns like a
+ * fiber binding to an identity-registry instance it learns about at runtime (per-actor cross-fiber
+ * reads) without re-deploying its definition.
+ *
+ * The ledger is APPEND-ONLY with at most one entry per `fiberId`: a dependency is NEVER removed —
+ * deactivation flips `active` to false while preserving the original `addedAt` — so the history is a
+ * deterministic, auditable record and an inactive dep can be cheaply re-activated. The `machines`
+ * context is built from the ACTIVE subset only; ExecutionLimits bounds both the active count and the
+ * total ledger size for DoS safety.
+ */
+@derive(customizableEncoder, customizableDecoder)
+final case class DynamicDependency(
+  fiberId: UUID,
+  active:  Boolean,
+  addedAt: SnapshotOrdinal
+)

--- a/modules/models/src/main/scala/xyz/kd5ujc/schema/fiber/ExecutionLimits.scala
+++ b/modules/models/src/main/scala/xyz/kd5ujc/schema/fiber/ExecutionLimits.scala
@@ -11,10 +11,18 @@ package xyz.kd5ujc.schema.fiber
  *                          `maxDepth`: cascade cycle-detection keys on `(fiberId, eventName)`, so re-entering
  *                          the same asset-holding fiber with a different event is not a cycle and `maxDepth`
  *                          alone would permit ~10 mutations; this cap is the explicit bound.
+ * @param maxActiveDependencies Maximum number of ACTIVE dynamic dependencies a fiber may hold. Bounds the
+ *                          size of the `machines` context built each transition (each active dep is an
+ *                          O(state-size) summary lookup), so it is the primary anti-DoS cap.
+ * @param maxDependencyLedger Maximum number of DISTINCT fibers in the append-only dynamic-dependency ledger
+ *                          (active + inactive). Because the ledger is never pruned (deactivation only flips a
+ *                          flag), this bounds its growth; once full, no NEW dependency may be added.
  */
 final case class ExecutionLimits(
-  maxDepth:          Int = 10,
-  maxGas:            Long = 10_000_000L,
-  maxStateSizeBytes: Int = 1_048_576, // 1MB
-  maxAssetMutations: Int = 32
+  maxDepth:              Int = 10,
+  maxGas:                Long = 10_000_000L,
+  maxStateSizeBytes:     Int = 1_048_576, // 1MB
+  maxAssetMutations:     Int = 32,
+  maxActiveDependencies: Int = 64,
+  maxDependencyLedger:   Int = 256
 )

--- a/modules/models/src/main/scala/xyz/kd5ujc/schema/fiber/FailureReason.scala
+++ b/modules/models/src/main/scala/xyz/kd5ujc/schema/fiber/FailureReason.scala
@@ -59,6 +59,8 @@ sealed trait FailureReason {
       s"Failed to evaluate child ID expression: $error"
     case FailureReason.OwnersEvaluationFailed(error) =>
       s"Failed to evaluate owners expression: $error"
+    case FailureReason.DependencyLimitExceeded(kind, current, max) =>
+      s"Dynamic dependency $kind limit exceeded: $current (max: $max)"
   }
 }
 
@@ -89,4 +91,7 @@ object FailureReason {
   case class InvalidOwnerAddress(address: String, error: String) extends FailureReason
   case class ChildIdEvaluationFailed(error: String) extends FailureReason
   case class OwnersEvaluationFailed(error: String) extends FailureReason
+
+  /** A dynamic-dependency mutation would breach an ExecutionLimits cap (`kind` = "active" | "ledger"). */
+  case class DependencyLimitExceeded(kind: String, current: Int, max: Int) extends FailureReason
 }

--- a/modules/models/src/main/scala/xyz/kd5ujc/schema/fiber/FiberEffect.scala
+++ b/modules/models/src/main/scala/xyz/kd5ujc/schema/fiber/FiberEffect.scala
@@ -43,4 +43,17 @@ object FiberEffect {
    */
   @derive(customizableEncoder, customizableDecoder)
   final case class AssetTransferred(assetId: UUID, recipient: AssetHolder) extends FiberEffect
+
+  /**
+   * A mutation to the SOURCE fiber's append-only dynamic-dependency ledger (`_addDependency` /
+   * `_setDependencyActive`). Carries a RESOLVED `fiberId` (the directive's `fiberId` expression is
+   * evaluated against the transition context DURING extraction, like `Triggered`/`AssetTransferred`)
+   * and the desired `active` flag (`_addDependency` ⇒ true). Applied to
+   * `StateMachineFiberRecord.dynamicDependencies` by the engine as a bounded upsert — it carries NO
+   * authorization on its own; the only gate is that the transition's guard ran. Unknown target ids are
+   * permitted (they simply resolve to nothing in `machines` until/unless the fiber exists), matching the
+   * silently-excluded behaviour of static `Transition.dependencies`.
+   */
+  @derive(customizableEncoder, customizableDecoder)
+  final case class DependencyMutated(fiberId: UUID, active: Boolean) extends FiberEffect
 }

--- a/modules/models/src/main/scala/xyz/kd5ujc/schema/fiber/FiberGasConfig.scala
+++ b/modules/models/src/main/scala/xyz/kd5ujc/schema/fiber/FiberGasConfig.scala
@@ -12,11 +12,13 @@ import io.constellationnetwork.metagraph_sdk.json_logic.gas.GasCost
  * @param triggerEvent Cost to dispatch a trigger to another fiber
  * @param spawnDirective Cost to spawn a new child fiber
  * @param contextBuild Cost to build trigger/spawn context
+ * @param dependencyMutation Cost per `_addDependency` / `_setDependencyActive` directive applied
  */
 final case class FiberGasConfig(
-  triggerEvent:   GasCost = GasCost(5),
-  spawnDirective: GasCost = GasCost(50),
-  contextBuild:   GasCost = GasCost(10)
+  triggerEvent:       GasCost = GasCost(5),
+  spawnDirective:     GasCost = GasCost(50),
+  contextBuild:       GasCost = GasCost(10),
+  dependencyMutation: GasCost = GasCost(20)
 )
 
 object FiberGasConfig {
@@ -28,13 +30,15 @@ object FiberGasConfig {
   val Mainnet: FiberGasConfig = FiberGasConfig(
     triggerEvent = GasCost(10),
     spawnDirective = GasCost(100),
-    contextBuild = GasCost(20)
+    contextBuild = GasCost(20),
+    dependencyMutation = GasCost(40)
   )
 
   /** Minimal costs for testing gas exhaustion scenarios */
   val Minimal: FiberGasConfig = FiberGasConfig(
     triggerEvent = GasCost(1),
     spawnDirective = GasCost(1),
-    contextBuild = GasCost(1)
+    contextBuild = GasCost(1),
+    dependencyMutation = GasCost(1)
   )
 }

--- a/modules/models/src/main/scala/xyz/kd5ujc/schema/fiber/FiberResult.scala
+++ b/modules/models/src/main/scala/xyz/kd5ujc/schema/fiber/FiberResult.scala
@@ -30,13 +30,14 @@ object FiberResult {
    *                       messages only). The combiner re-checks holder-ownership before applying any of these.
    */
   final case class Success(
-    newStateData:   JsonLogicValue,
-    newStateId:     Option[StateId],
-    triggers:       List[FiberTrigger],
-    spawns:         List[SpawnDirective],
-    returnValue:    Option[JsonLogicValue],
-    emittedEvents:  List[EmittedEvent] = List.empty,
-    assetTransfers: List[FiberEffect.AssetTransferred] = List.empty
+    newStateData:        JsonLogicValue,
+    newStateId:          Option[StateId],
+    triggers:            List[FiberTrigger],
+    spawns:              List[SpawnDirective],
+    returnValue:         Option[JsonLogicValue],
+    emittedEvents:       List[EmittedEvent] = List.empty,
+    assetTransfers:      List[FiberEffect.AssetTransferred] = List.empty,
+    dependencyMutations: List[FiberEffect.DependencyMutated] = List.empty
   ) extends FiberResult
 
   /**

--- a/modules/models/src/main/scala/xyz/kd5ujc/schema/fiber/GasExhaustionPhase.scala
+++ b/modules/models/src/main/scala/xyz/kd5ujc/schema/fiber/GasExhaustionPhase.scala
@@ -16,4 +16,5 @@ object GasExhaustionPhase extends Enum[GasExhaustionPhase] with CirceEnum[GasExh
   case object Spawn extends GasExhaustionPhase
   case object Migration extends GasExhaustionPhase
   case object Morphism extends GasExhaustionPhase // asset-model.md §10: _transferAsset directive evaluation
+  case object DependencyMutation extends GasExhaustionPhase // _addDependency / _setDependencyActive fiberId resolution
 }

--- a/modules/models/src/main/scala/xyz/kd5ujc/schema/fiber/ReservedKeys.scala
+++ b/modules/models/src/main/scala/xyz/kd5ujc/schema/fiber/ReservedKeys.scala
@@ -14,6 +14,8 @@ object ReservedKeys {
   val SCRIPT_CALL = "_scriptCall"
   val EMIT = "_emit"
   val TRANSFER_ASSET = "_transferAsset" // Fiber-held asset custody transfer (asset-model.md §10)
+  val ADD_DEPENDENCY = "_addDependency" // Runtime-add/re-activate a dynamic cross-fiber dependency (append-only ledger)
+  val SET_DEPENDENCY_ACTIVE = "_setDependencyActive" // Toggle a dynamic dependency's active flag (never removed)
 
   // Script Return Convention Keys - Used in extractStateAndResult for script results
   val SCRIPT_STATE = "_state"
@@ -34,6 +36,10 @@ object ReservedKeys {
   val DEFINITION = "definition"
   val INITIAL_DATA = "initialData"
   val OWNERS = "owners"
+
+  // Dynamic Dependency Directive Keys - Used in extractDependencyMutations
+  // (the target fiber reuses FIBER_ID above; ACTIVE is the on/off flag for _setDependencyActive)
+  val ACTIVE = "active"
 
   // State Machine Definition Keys - Used in parseStateMachineDefinition(FromExpression)
   val STATES = "states"

--- a/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/fiber/FiberEngine.scala
+++ b/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/fiber/FiberEngine.scala
@@ -353,7 +353,8 @@ object FiberEngine {
                   spawns,
                   returnValue,
                   emittedEvents,
-                  assetTransfers
+                  assetTransfers,
+                  dependencyMutations
                 ) =>
               fiber match {
                 case sm: Records.StateMachineFiberRecord =>
@@ -365,7 +366,8 @@ object FiberEngine {
                     fiberTriggers,
                     spawns,
                     emittedEvents,
-                    assetTransfers
+                    assetTransfers,
+                    dependencyMutations
                   )
 
                 case script: Records.ScriptFiberRecord =>
@@ -406,14 +408,15 @@ object FiberEngine {
         }
 
       private def processStateMachineSuccess(
-        sm:             Records.StateMachineFiberRecord,
-        input:          FiberInput,
-        newStateData:   JsonLogicValue,
-        newStateId:     Option[StateId],
-        triggers:       List[FiberTrigger],
-        spawns:         List[SpawnDirective],
-        emittedEvents:  List[EmittedEvent],
-        assetTransfers: List[FiberEffect.AssetTransferred]
+        sm:                  Records.StateMachineFiberRecord,
+        input:               FiberInput,
+        newStateData:        JsonLogicValue,
+        newStateId:          Option[StateId],
+        triggers:            List[FiberTrigger],
+        spawns:              List[SpawnDirective],
+        emittedEvents:       List[EmittedEvent],
+        assetTransfers:      List[FiberEffect.AssetTransferred],
+        dependencyMutations: List[FiberEffect.DependencyMutated]
       ): FiberT[F, TransactionResult] =
         // #33 runtime conformance gate: a strict-bound fiber's produced state must conform, else abort.
         ConformanceChecker.violationsFor(sm.schemaBinding, calculatedState, newStateData) match {
@@ -428,56 +431,75 @@ object FiberEngine {
               triggers,
               spawns,
               emittedEvents,
-              assetTransfers
+              assetTransfers,
+              dependencyMutations
             )
         }
 
       private def commitStateMachineSuccess(
-        sm:             Records.StateMachineFiberRecord,
-        input:          FiberInput,
-        newStateData:   JsonLogicValue,
-        newStateId:     Option[StateId],
-        triggers:       List[FiberTrigger],
-        spawns:         List[SpawnDirective],
-        emittedEvents:  List[EmittedEvent],
-        assetTransfers: List[FiberEffect.AssetTransferred]
+        sm:                  Records.StateMachineFiberRecord,
+        input:               FiberInput,
+        newStateData:        JsonLogicValue,
+        newStateId:          Option[StateId],
+        triggers:            List[FiberTrigger],
+        spawns:              List[SpawnDirective],
+        emittedEvents:       List[EmittedEvent],
+        assetTransfers:      List[FiberEffect.AssetTransferred],
+        dependencyMutations: List[FiberEffect.DependencyMutated]
       ): FiberT[F, TransactionResult] =
         for {
-          hash    <- newStateData.computeDigest.liftFiber
-          gasUsed <- ExecutionOps.getGasUsed[FiberT[F, *]]
+          limits <- ExecutionOps.askLimits[FiberT[F, *]]
+          // Apply the append-only dynamic-dependency ledger mutations FIRST: a bounds breach aborts the
+          // transition (fail-closed) before any state or log is committed.
+          result <- DependencyLedger.applyMutations(
+            sm.dynamicDependencies,
+            dependencyMutations,
+            ordinal,
+            limits
+          ) match {
+            case Left(reason) =>
+              ExecutionOps.getGasUsed[FiberT[F, *]].map(g => TransactionResult.Aborted(reason, g): TransactionResult)
 
-          receipt = EventReceipt.success(
-            sm = sm,
-            eventName = input.key,
-            ordinal = ordinal,
-            gasUsed = gasUsed,
-            newStateId = newStateId,
-            triggers = triggers,
-            emittedEvents = emittedEvents
-          )
-
-          _ <- ExecutionOps.appendLog[FiberT[F, *]](receipt)
-
-          updatedFiber = sm.copy(
-            previousUpdateOrdinal = sm.latestUpdateOrdinal,
-            latestUpdateOrdinal = ordinal,
-            currentState = newStateId.getOrElse(sm.currentState),
-            stateData = newStateData,
-            stateDataHash = hash,
-            sequenceNumber = sm.sequenceNumber.next,
-            lastReceipt = Some(receipt)
-          )
-
-          spawnResult <- processSpawnsValidated(spawns, updatedFiber, input)
-
-          result <- spawnResult match {
-            case Left(errors) =>
+            case Right(newLedger) =>
               for {
-                currentGas <- ExecutionOps.getGasUsed[FiberT[F, *]]
-              } yield TransactionResult.Aborted(errors.head, currentGas): TransactionResult
+                hash    <- newStateData.computeDigest.liftFiber
+                gasUsed <- ExecutionOps.getGasUsed[FiberT[F, *]]
 
-            case Right(spawnedFibers) =>
-              completeStateMachineTransaction(sm, updatedFiber, spawnedFibers, triggers, assetTransfers)
+                receipt = EventReceipt.success(
+                  sm = sm,
+                  eventName = input.key,
+                  ordinal = ordinal,
+                  gasUsed = gasUsed,
+                  newStateId = newStateId,
+                  triggers = triggers,
+                  emittedEvents = emittedEvents
+                )
+
+                _ <- ExecutionOps.appendLog[FiberT[F, *]](receipt)
+
+                updatedFiber = sm.copy(
+                  previousUpdateOrdinal = sm.latestUpdateOrdinal,
+                  latestUpdateOrdinal = ordinal,
+                  currentState = newStateId.getOrElse(sm.currentState),
+                  stateData = newStateData,
+                  stateDataHash = hash,
+                  sequenceNumber = sm.sequenceNumber.next,
+                  lastReceipt = Some(receipt),
+                  dynamicDependencies = newLedger
+                )
+
+                spawnResult <- processSpawnsValidated(spawns, updatedFiber, input)
+
+                r <- spawnResult match {
+                  case Left(errors) =>
+                    ExecutionOps
+                      .getGasUsed[FiberT[F, *]]
+                      .map(g => TransactionResult.Aborted(errors.head, g): TransactionResult)
+
+                  case Right(spawnedFibers) =>
+                    completeStateMachineTransaction(sm, updatedFiber, spawnedFibers, triggers, assetTransfers)
+                }
+              } yield r
           }
         } yield result
 

--- a/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/fiber/core/DependencyLedger.scala
+++ b/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/fiber/core/DependencyLedger.scala
@@ -1,0 +1,65 @@
+package xyz.kd5ujc.shared_data.fiber.core
+
+import io.constellationnetwork.schema.SnapshotOrdinal
+
+import xyz.kd5ujc.schema.fiber.{DynamicDependency, ExecutionLimits, FailureReason, FiberEffect}
+
+/**
+ * Pure application of `_addDependency` / `_setDependencyActive` mutations to a fiber's append-only
+ * dynamic-dependency ledger, with DoS bounds enforced. Kept pure (no effect type) so it is trivially
+ * unit-testable and deterministic across nodes.
+ *
+ * Semantics (see [[xyz.kd5ujc.schema.fiber.DynamicDependency]]):
+ *   - UPSERT by `fiberId`: a mutation targeting an existing entry flips its `active` flag and PRESERVES
+ *     the original `addedAt`; a mutation targeting a new `fiberId` APPENDS a fresh entry
+ *     (`addedAt = ordinal`). The ledger therefore holds at most one entry per fiber and is never pruned.
+ *   - Mutations apply left-to-right; the last mutation for a given `fiberId` wins.
+ *   - Bounds (fail-closed — abort the transition):
+ *       * a NEW fiberId pushing the ledger past `maxDependencyLedger` ⇒ DependencyLimitExceeded("ledger")
+ *       * a final ACTIVE count above `maxActiveDependencies`           ⇒ DependencyLimitExceeded("active")
+ *     The active cap is checked ONCE on the resulting ledger, so toggling a dep off-then-on within a
+ *     single transition nets out correctly.
+ */
+object DependencyLedger {
+
+  def applyMutations(
+    current:   List[DynamicDependency],
+    mutations: List[FiberEffect.DependencyMutated],
+    ordinal:   SnapshotOrdinal,
+    limits:    ExecutionLimits
+  ): Either[FailureReason, List[DynamicDependency]] = {
+
+    def step(
+      ledger: List[DynamicDependency],
+      m:      FiberEffect.DependencyMutated
+    ): Either[FailureReason, List[DynamicDependency]] =
+      ledger.indexWhere(_.fiberId == m.fiberId) match {
+        case -1 =>
+          // A new distinct fiber → the total-ledger bound applies (append-only, never pruned).
+          if (ledger.size >= limits.maxDependencyLedger)
+            Left(FailureReason.DependencyLimitExceeded("ledger", ledger.size + 1, limits.maxDependencyLedger))
+          else
+            Right(ledger :+ DynamicDependency(m.fiberId, m.active, ordinal))
+
+        case idx =>
+          // Existing entry → flip active, preserve the original addedAt (append-only history).
+          Right(ledger.updated(idx, ledger(idx).copy(active = m.active)))
+      }
+
+    mutations
+      .foldLeft[Either[FailureReason, List[DynamicDependency]]](Right(current)) { (acc, m) =>
+        acc.flatMap(step(_, m))
+      }
+      .flatMap { finalLedger =>
+        val activeCount = finalLedger.count(_.active)
+        if (activeCount > limits.maxActiveDependencies)
+          Left(FailureReason.DependencyLimitExceeded("active", activeCount, limits.maxActiveDependencies))
+        else
+          Right(finalLedger)
+      }
+  }
+
+  /** The ACTIVE dependency fiber ids — the subset injected into the `machines` context each transition. */
+  def activeIds(ledger: List[DynamicDependency]): Set[java.util.UUID] =
+    ledger.collect { case d if d.active => d.fiberId }.toSet
+}

--- a/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/fiber/evaluation/EffectExtractor.scala
+++ b/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/fiber/evaluation/EffectExtractor.scala
@@ -9,7 +9,7 @@ import cats.syntax.all._
 import cats.{Monad, ~>}
 
 import io.constellationnetwork.metagraph_sdk.json_logic._
-import io.constellationnetwork.metagraph_sdk.json_logic.core.StrValue
+import io.constellationnetwork.metagraph_sdk.json_logic.core.{BoolValue, StrValue}
 import io.constellationnetwork.schema.address.{Address, DAGAddressRefined}
 
 import xyz.kd5ujc.schema.asset.AssetHolder
@@ -77,13 +77,15 @@ object EffectExtractor {
       triggers       <- extractTriggerEvents[F, G](effectResult, contextData, sourceFiberId)
       scriptCall     <- extractScriptCall[F, G](effectResult, contextData, sourceFiberId)
       assetTransfers <- extractAssetTransfers[F, G](effectResult, contextData)
+      depMutations   <- extractDependencyMutations[F, G](effectResult, contextData)
     } yield {
       val spawns = extractSpawnDirectivesFromExpression(effectExpr)
       val emitted = extractEmittedEvents(effectResult)
       (triggers ++ scriptCall.toList).map(FiberEffect.Triggered) ++
       spawns.map(FiberEffect.Spawned) ++
       emitted.map(FiberEffect.Emitted) ++
-      assetTransfers
+      assetTransfers ++
+      depMutations
     }
 
   /**
@@ -239,6 +241,58 @@ object EffectExtractor {
     scala.util.Try(UUID.fromString(s)).toOption match {
       case Some(uuid) => Some(AssetHolder.Fiber(uuid))
       case None       => refineV[DAGAddressRefined](s).toOption.map(refined => AssetHolder.Wallet(Address(refined)))
+    }
+
+  /**
+   * Extract dynamic-dependency mutations (`_addDependency` / `_setDependencyActive`) with gas metering.
+   * Mirrors [[extractAssetTransfers]]: each directive's `fiberId` JSON-Logic expression is RESOLVED here
+   * against the transition context (gas charged under [[GasExhaustionPhase.DependencyMutation]]), so the
+   * resulting [[FiberEffect.DependencyMutated]] carries a value, not logic. `_addDependency` forces
+   * `active = true`; `_setDependencyActive` reads the directive's `active` boolean. A malformed directive
+   * (missing/non-UUID `fiberId`, or a `_setDependencyActive` lacking a boolean `active`) is DROPPED — the
+   * same fail-silent mode the other extractors use. The append-only ledger + DoS bounds are applied later,
+   * by the engine ([[xyz.kd5ujc.shared_data.fiber.core.DependencyLedger]]).
+   */
+  def extractDependencyMutations[F[_]: Async, G[_]: Monad](
+    effectResult: JsonLogicValue,
+    contextData:  JsonLogicValue
+  )(implicit
+    S:    Stateful[G, ExecutionState],
+    A:    Ask[G, FiberContext],
+    lift: F ~> G
+  ): G[List[FiberEffect.DependencyMutated]] =
+    for {
+      adds <- extractArrayByKey(effectResult, ReservedKeys.ADD_DEPENDENCY)
+        .flatTraverse(item => parseDependencyMutation[F, G](item, contextData, forcedActive = Some(true)).map(_.toList))
+      sets <- extractArrayByKey(effectResult, ReservedKeys.SET_DEPENDENCY_ACTIVE)
+        .flatTraverse(item => parseDependencyMutation[F, G](item, contextData, forcedActive = None).map(_.toList))
+    } yield adds ++ sets
+
+  private def parseDependencyMutation[F[_]: Async, G[_]: Monad](
+    value:        JsonLogicValue,
+    contextData:  JsonLogicValue,
+    forcedActive: Option[Boolean]
+  )(implicit
+    S:    Stateful[G, ExecutionState],
+    A:    Ask[G, FiberContext],
+    lift: F ~> G
+  ): G[Option[FiberEffect.DependencyMutated]] =
+    value match {
+      case MapValue(depMap) =>
+        (for {
+          fiberIdValue <- OptionT.fromOption[G](depMap.get(ReservedKeys.FIBER_ID))
+          fiberIdExpr = ExpressionParser.valueToExpression(fiberIdValue)
+          // Charge gas for fiberId resolution under the DependencyMutation phase.
+          evaluatedFiberId <- OptionT(
+            MeteredEvaluator.evalOpt[F, G](fiberIdExpr, contextData, GasExhaustionPhase.DependencyMutation)
+          )
+          fiberIdStr <- OptionT.fromOption[G](evaluatedFiberId match { case StrValue(s) => Some(s); case _ => None })
+          fiberId    <- OptionT.fromOption[G](scala.util.Try(UUID.fromString(fiberIdStr)).toOption)
+          active <- OptionT.fromOption[G](
+            forcedActive.orElse(depMap.get(ReservedKeys.ACTIVE).collect { case BoolValue(b) => b })
+          )
+        } yield FiberEffect.DependencyMutated(fiberId, active)).value
+      case _ => none[FiberEffect.DependencyMutated].pure[G]
     }
 
   def extractEmittedEvents(effectResult: JsonLogicValue): List[EmittedEvent] =

--- a/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/fiber/evaluation/FiberEvaluator.scala
+++ b/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/fiber/evaluation/FiberEvaluator.scala
@@ -120,7 +120,9 @@ object FiberEvaluator {
                   fiber,
                   input,
                   proofs,
-                  transition.dependencies
+                  // machines context = this transition's STATIC dependencies ∪ the fiber's ACTIVE
+                  // runtime (dynamic) dependencies. (#24)
+                  transition.dependencies ++ DependencyLedger.activeIds(fiber.dynamicDependencies)
                 )
                 .liftTo[G]
               result <- evaluateGuardAndApply(
@@ -245,11 +247,13 @@ object FiberEvaluator {
           spawnMachines = effects.collect { case FiberEffect.Spawned(d) => d }
           emittedEvents = effects.collect { case FiberEffect.Emitted(ev) => ev }
           assetTransfers = effects.collect { case t: FiberEffect.AssetTransferred => t }
+          depMutations = effects.collect { case d: FiberEffect.DependencyMutated => d }
 
           // Charge orchestration overhead
           _ <- ExecutionOps.chargeGas[G](fiberGasConfig.contextBuild.amount)
           _ <- ExecutionOps.chargeGas[G](allTriggers.size.toLong * fiberGasConfig.triggerEvent.amount)
           _ <- ExecutionOps.chargeGas[G](spawnMachines.size.toLong * fiberGasConfig.spawnDirective.amount)
+          _ <- ExecutionOps.chargeGas[G](depMutations.size.toLong * fiberGasConfig.dependencyMutation.amount)
 
           // Get total gas for result
           totalGasUsed <- ExecutionOps.getGasUsed[G]
@@ -270,7 +274,8 @@ object FiberEvaluator {
                     spawns = spawnMachines,
                     returnValue = None,
                     emittedEvents = emittedEvents,
-                    assetTransfers = assetTransfers
+                    assetTransfers = assetTransfers,
+                    dependencyMutations = depMutations
                   )
                 case Left(reason) => reason.asOutcome
               }

--- a/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/fiber/triggers/TriggerHandler.scala
+++ b/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/fiber/triggers/TriggerHandler.scala
@@ -85,7 +85,10 @@ class StateMachineTriggerHandler[F[_]: Async: SecurityProvider, G[_]: Monad](
       ordinal <- ExecutionOps.askOrdinal[G]
       outcome <- FiberEvaluator.make[F, G](calculatedState).evaluate(sm, trigger.input, List.empty)
       result <- outcome match {
-        case FiberResult.Success(newStateData, newStateId, triggers, _, _, emittedEvents, assetTransfers) =>
+        // Cascaded (triggered) transitions do not spawn or mutate dynamic dependencies — those directives
+        // (`spawns`, `dependencyMutations`) are honoured only on the PRIMARY transition (see FiberEngine),
+        // so both are ignored here, as `spawns` already is.
+        case FiberResult.Success(newStateData, newStateId, triggers, _, _, emittedEvents, assetTransfers, _) =>
           val receipt = EventReceipt.success(
             sm = sm,
             eventName = trigger.input.key,

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/DependencyLedgerSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/DependencyLedgerSuite.scala
@@ -1,0 +1,87 @@
+package xyz.kd5ujc.shared_data
+
+import java.util.UUID
+
+import io.constellationnetwork.ext.cats.syntax.next._
+import io.constellationnetwork.schema.SnapshotOrdinal
+
+import xyz.kd5ujc.schema.fiber.{DynamicDependency, ExecutionLimits, FailureReason, FiberEffect}
+import xyz.kd5ujc.shared_data.fiber.core.DependencyLedger
+
+import weaver.FunSuite
+
+/**
+ * Pure unit tests for the append-only dynamic-dependency ledger (#24): upsert semantics + DoS bounds.
+ */
+object DependencyLedgerSuite extends FunSuite {
+
+  private val ord0 = SnapshotOrdinal.MinValue
+  private val ord1 = ord0.next
+
+  private def uuid(n: Int): UUID = new UUID(0L, n.toLong)
+  private def add(id: UUID): FiberEffect.DependencyMutated = FiberEffect.DependencyMutated(id, active = true)
+  private def set(id: UUID, a: Boolean): FiberEffect.DependencyMutated = FiberEffect.DependencyMutated(id, a)
+
+  test("add appends a new active entry stamped with the current ordinal") {
+    expect(
+      DependencyLedger.applyMutations(Nil, List(add(uuid(1))), ord0, ExecutionLimits()) ==
+        Right(List(DynamicDependency(uuid(1), active = true, ord0)))
+    )
+  }
+
+  test("set upserts in place: flips active and PRESERVES the original addedAt") {
+    val start = List(DynamicDependency(uuid(1), active = true, ord0))
+    expect(
+      DependencyLedger.applyMutations(start, List(set(uuid(1), a = false)), ord1, ExecutionLimits()) ==
+        Right(List(DynamicDependency(uuid(1), active = false, ord0))) // addedAt stays ord0, not ord1
+    )
+  }
+
+  test("re-adding a deactivated dep reactivates the SAME entry (no duplicate, addedAt preserved)") {
+    val start = List(DynamicDependency(uuid(1), active = false, ord0))
+    expect(
+      DependencyLedger.applyMutations(start, List(add(uuid(1))), ord1, ExecutionLimits()) ==
+        Right(List(DynamicDependency(uuid(1), active = true, ord0)))
+    )
+  }
+
+  test("ledger cap blocks a NEW distinct fiber beyond maxDependencyLedger") {
+    val limits = ExecutionLimits(maxDependencyLedger = 2)
+    expect(
+      DependencyLedger.applyMutations(Nil, List(add(uuid(1)), add(uuid(2)), add(uuid(3))), ord0, limits) ==
+        Left(FailureReason.DependencyLimitExceeded("ledger", 3, 2))
+    )
+  }
+
+  test("inactive entries STILL count toward the ledger cap (append-only, never pruned)") {
+    val limits = ExecutionLimits(maxDependencyLedger = 2, maxActiveDependencies = 64)
+    val muts = List(add(uuid(1)), add(uuid(2)), set(uuid(2), a = false), add(uuid(3)))
+    expect(
+      DependencyLedger.applyMutations(Nil, muts, ord0, limits) ==
+        Left(FailureReason.DependencyLimitExceeded("ledger", 3, 2))
+    )
+  }
+
+  test("active cap blocks too many ACTIVE deps") {
+    val limits = ExecutionLimits(maxActiveDependencies = 2)
+    expect(
+      DependencyLedger.applyMutations(Nil, List(add(uuid(1)), add(uuid(2)), add(uuid(3))), ord0, limits) ==
+        Left(FailureReason.DependencyLimitExceeded("active", 3, 2))
+    )
+  }
+
+  test("toggling a dep off within the batch keeps the final active-count within cap") {
+    val limits = ExecutionLimits(maxActiveDependencies = 1)
+    val muts = List(add(uuid(1)), add(uuid(2)), set(uuid(2), a = false)) // net: only #1 active
+    expect(DependencyLedger.applyMutations(Nil, muts, ord0, limits).map(_.count(_.active)) == Right(1))
+  }
+
+  test("activeIds returns only the active subset") {
+    val ledger = List(
+      DynamicDependency(uuid(1), active = true, ord0),
+      DynamicDependency(uuid(2), active = false, ord0),
+      DynamicDependency(uuid(3), active = true, ord0)
+    )
+    expect(DependencyLedger.activeIds(ledger) == Set(uuid(1), uuid(3)))
+  }
+}

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/DynamicDependenciesSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/DynamicDependenciesSuite.scala
@@ -1,0 +1,116 @@
+package xyz.kd5ujc.shared_data
+
+import cats.effect.IO
+import cats.effect.std.UUIDGen
+import cats.syntax.all._
+
+import io.constellationnetwork.currency.dataApplication.{DataState, L0NodeContext}
+import io.constellationnetwork.ext.cats.syntax.next._
+import io.constellationnetwork.metagraph_sdk.json_logic._
+import io.constellationnetwork.security.SecurityProvider
+import io.constellationnetwork.security.signature.Signed
+
+import xyz.kd5ujc.schema.fiber.{FiberOrdinal, _}
+import xyz.kd5ujc.schema.{CalculatedState, OnChain, Records, Updates}
+import xyz.kd5ujc.shared_data.lifecycle.Combiner
+import xyz.kd5ujc.shared_test.Participant._
+import xyz.kd5ujc.shared_test.TestFixture
+
+import io.circe.parser._
+import weaver.SimpleIOSuite
+
+/**
+ * Integration test for runtime-updatable (dynamic) dependencies (#24): a fiber adds a dependency at
+ * runtime via `_addDependency`, and a SUBSEQUENT transition reads that dependency's state through the
+ * `machines.<dep>.state` context — proving the per-fiber ACTIVE dynamic deps are merged into the
+ * machines context alongside the static `Transition.dependencies`.
+ */
+object DynamicDependenciesSuite extends SimpleIOSuite {
+
+  test("_addDependency binds a fiber at runtime; a later transition reads machines.<dep>.state (#24)") {
+    TestFixture.resource(Set(Alice)).use { fixture =>
+      implicit val s: SecurityProvider[IO] = fixture.securityProvider
+      implicit val l0ctx: L0NodeContext[IO] = fixture.l0Context
+      for {
+        combiner <- Combiner.make[IO]().pure[IO]
+
+        depId      <- UUIDGen.randomUUID[IO]
+        consumerId <- UUIDGen.randomUUID[IO]
+
+        // --- dependency target fiber B: a static fiber holding { value: 42 } ---
+        depJson = """
+        {
+          "states": { "ACTIVE": { "id": "ACTIVE", "isFinal": false } },
+          "initialState": "ACTIVE",
+          "transitions": []
+        }
+        """
+        depDef <- IO.fromEither(decode[StateMachineDefinition](depJson))
+        depData = MapValue(Map("value" -> IntValue(42)))
+        createDep = Updates.CreateStateMachine(depId, depDef, depData)
+        depProof <- fixture.registry.generateProofs(createDep, Set(Alice))
+        s1       <- combiner.insert(DataState(OnChain.genesis, CalculatedState.genesis), Signed(createDep, depProof))
+
+        // --- consumer fiber A: `bind` adds B as a dynamic dep; `read` copies B.value into A.seen ---
+        consumerJson = s"""
+        {
+          "states": {
+            "init":  { "id": "init",  "isFinal": false },
+            "bound": { "id": "bound", "isFinal": false },
+            "read":  { "id": "read",  "isFinal": false }
+          },
+          "initialState": "init",
+          "transitions": [
+            {
+              "from": "init", "to": "bound", "eventName": "bind", "guard": true,
+              "effect": { "_addDependency": [ { "fiberId": "$depId" } ] },
+              "dependencies": []
+            },
+            {
+              "from": "bound", "to": "read", "eventName": "read", "guard": true,
+              "effect": {
+                "merge": [ { "var": "state" }, { "seen": { "var": "machines.$depId.state.value" } } ]
+              },
+              "dependencies": []
+            }
+          ]
+        }
+        """
+        consumerDef <- IO.fromEither(decode[StateMachineDefinition](consumerJson))
+        consumerData = MapValue(Map("seen" -> IntValue(0)))
+        createConsumer = Updates.CreateStateMachine(consumerId, consumerDef, consumerData)
+        consumerProof <- fixture.registry.generateProofs(createConsumer, Set(Alice))
+        s2            <- combiner.insert(s1, Signed(createConsumer, consumerProof))
+
+        // fire `bind` → A's dynamic-dependency ledger should now hold B (active)
+        bindEvent = Updates.TransitionStateMachine(consumerId, "bind", MapValue(Map.empty), FiberOrdinal.MinValue)
+        bindProof <- fixture.registry.generateProofs(bindEvent, Set(Alice))
+        s3        <- combiner.insert(s2, Signed(bindEvent, bindProof))
+
+        boundConsumer = s3.calculated.stateMachines
+          .get(consumerId)
+          .collect { case r: Records.StateMachineFiberRecord => r }
+
+        // fire `read` → A.seen should become B.value (42), proving machines.<dep> was injected from the
+        // ACTIVE dynamic dep added in the previous transition
+        readEvent = Updates.TransitionStateMachine(consumerId, "read", MapValue(Map.empty), FiberOrdinal.MinValue.next)
+        readProof <- fixture.registry.generateProofs(readEvent, Set(Alice))
+        s4        <- combiner.insert(s3, Signed(readEvent, readProof))
+
+        readConsumer = s4.calculated.stateMachines
+          .get(consumerId)
+          .collect { case r: Records.StateMachineFiberRecord => r }
+
+        seenValue = readConsumer.flatMap { c =>
+          c.stateData match {
+            case MapValue(m) => m.get("seen").collect { case IntValue(v) => v }
+            case _           => None
+          }
+        }
+      } yield expect(boundConsumer.exists(_.dynamicDependencies.exists(d => d.fiberId == depId && d.active))) and
+      expect(boundConsumer.map(_.currentState).contains(StateId("bound"))) and
+      expect(readConsumer.map(_.currentState).contains(StateId("read"))) and
+      expect(seenValue.contains(BigInt(42)))
+    }
+  }
+}


### PR DESCRIPTION
## What

Adds a per-fiber **append-only dynamic-dependency ledger** so a fiber can bind to another fiber's state at **runtime** — the chain primitive the std-app registry/resolution consumption (reputation/role reads, corporate resolution gating) was gated on. Until now `Transition.dependencies` was static per-transition; a std-app definition could not bind a specific registry/resolution **instance** (the `machines.<id>` key is static in the AST, the UUID is instance-specific).

## Model (`modules/models`)

- `DynamicDependency{fiberId, active, addedAt}` — append-only, at most one entry per fiberId, **never pruned** (deactivation flips `active`, preserving an auditable history).
- `StateMachineFiberRecord.dynamicDependencies` (defaulted, so existing constructors are unaffected).
- `FiberEffect.DependencyMutated`; `FiberResult.Success.dependencyMutations`.
- Reserved keys `_addDependency` / `_setDependencyActive` (+ `active`); `GasExhaustionPhase.DependencyMutation`; `FiberGasConfig.dependencyMutation`; `ExecutionLimits.maxActiveDependencies` (64) + `maxDependencyLedger` (256); `FailureReason.DependencyLimitExceeded`.

## Engine (`modules/shared-data`)

- `EffectExtractor.extractDependencyMutations` — resolves each directive's `fiberId` expression against context (gas-metered, fail-silent on malformed), mirroring `_transferAsset`.
- `DependencyLedger` — pure, deterministic upsert + DoS bounds (active cap + ledger cap), **fail-closed** (a breach aborts the transition).
- `FiberEvaluator` — `machines` context = `static transition.deps ∪ active dynamic deps`; charges gas per mutation; carries them in `Success`.
- `FiberEngine.commitStateMachineSuccess` — applies the bounded ledger **first** (breach aborts before any state/log commit), persists the new ledger in the record copy.
- `TriggerHandler` — cascaded (triggered) transitions do not mutate deps, at parity with how they already do not spawn.

## Reads

A consumer fiber `_addDependency`-binds a registry/resolution instance in one transition, then a later transition reads `machines[<id>].state…` (dynamic addressing via `get`). The SDK side ships the consumption helpers (`depInState`, `addDependency`/`setDependencyActive`, `signerHasReputationVia`/`signerHasRoleVia`) and uses them to close the corporate object-dependency gating two-phase.

## Tests

- `DependencyLedgerSuite` (8) — upsert semantics + bounds.
- `DynamicDependenciesSuite` (1) — end-to-end: runtime `_addDependency` bind → cross-fiber `machines.<dep>.state` read.
- Full `shared-data` suite green (496, +9), 0 regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)