### PR TITLE
chore: regenerate stale docs/openapi.json

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -978,6 +978,28 @@
           }
         }
       },
+      "DynamicDependency" : {
+        "title" : "DynamicDependency",
+        "type" : "object",
+        "required" : [
+          "fiberId",
+          "active",
+          "addedAt"
+        ],
+        "properties" : {
+          "fiberId" : {
+            "type" : "string",
+            "format" : "uuid"
+          },
+          "active" : {
+            "type" : "boolean"
+          },
+          "addedAt" : {
+            "type" : "integer",
+            "format" : "int64"
+          }
+        }
+      },
       "EmittedEvent" : {
         "title" : "EmittedEvent",
         "type" : "object",
@@ -1398,6 +1420,12 @@
             "uniqueItems" : true,
             "items" : {
               "type" : "string"
+            }
+          },
+          "dynamicDependencies" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/DynamicDependency"
             }
           }
         }


### PR DESCRIPTION
The committed OpenAPI contract (`docs/openapi.json`) drifted out of sync with the generator output, so the Code Quality "Check OpenAPI contract is up to date" check fails on every open PR. This regenerates it via `currencyL0 GenerateOpenApi` (adds the missing `DynamicDependency` schema + `dynamicDependencies` field), with no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)