### PR TITLE
chore(deps): bump metakit to 1.8.0-rc.7 for SDK opcode parity

### DIFF
--- a/docs/proposals/asset-model-zk-extension.md
+++ b/docs/proposals/asset-model-zk-extension.md
@@ -36,7 +36,7 @@ Companion: `docs/proposals/zk-coin-audit.md`, `docs/proposals/asset-model.md`,
 
 ## 1. The opcode reality (reconciled — one agent was wrong)
 
-metakit `1.8.0-rc.5` (pinned in `project/Dependencies.scala`) **does expose zk-verifier opcodes to the
+metakit `1.8.0-rc.7` (pinned in `project/Dependencies.scala`) **does expose zk-verifier opcodes to the
 JLVM, and they work in the combiner today.** This is not a claim — it is *demonstrated* by the shipped
 `ZkGatedMorphismSuite`, which builds a real `PoseidonMerkleTree` inclusion proof, gates a `Transfer`
 morphism on `{"pmt_verify": [...]}`, and asserts the on-chain opcode agrees with metakit's tree builder

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
     val catsMtl = "1.3.1"
     val enumeratum = "1.7.5"
     val decline = "2.5.0"
-    val metakit = "1.8.0-rc.5"
+    val metakit = "1.8.0-rc.7"
     val pureConfig = "0.17.5"
     val weaver = "0.10.1"
     val tapir = "1.11.10"


### PR DESCRIPTION
## Summary

Bumps the `metakit` (Scala JLVM evaluator) pin **`1.8.0-rc.5` → `1.8.0-rc.7`** to restore opcode parity with the SDK's JLVM evaluator (`@ottochain/sdk` → `@constellation-network/metagraph-sdk-jlvm@1.8.0-rc.5`).

## Why

`metakit` (Scala) and `metagraph-sdk-jlvm` (TS) are **independently-tagged ports of the same JLVM evaluator**, coordinated only by the shared `1.8.0-rc.x` version line. Their `rc.5` tags **diverged** — the TS `rc.5` (cut later) folded in extra opcode PRs:

| Opcode | chain `metakit` rc.5 | SDK `metagraph-sdk-jlvm` rc.5 | chain `metakit` **rc.7** |
|---|---|---|---|
| `set` | ❌ | ✅ | ✅ |
| `unset` | ❌ | ✅ | ✅ |
| `hex_to_int` | ❌ | ✅ | ✅ |

Verified directly against the published jars (`JsonLogicOp$*Op$` class set):
- `metakit_2.13-1.8.0-rc.5.jar` → **no** `SetOp` / `UnsetOp` / `HexToIntOp` (77 ops).
- `metakit_2.13-1.8.0-rc.7.jar` → adds all three (81 ops); superset of the SDK's rc.5.

**Failure mode this fixes:** the chain decodes an unknown single-key object (e.g. `{"set":[...]}`) as a *literal map*, so a `set`/`unset` effect silently writes a junk top-level key into state — no error, just corruption. rc.7 makes the chain a superset of what the SDK can emit.

## Blast radius

- 5 SDK std-app definitions emit `set`/`unset` and would mis-execute pre-rc.7: `dao-token`, `governance-simple`, `dao-multisig`, `dao-reputation`, `identity-registry`.
- 🟢 The 3 genesis-manifest apps (`identity-universal`, `governance-universal`, `market-universal`) use **zero** `set`/`unset`, so genesis boot was already safe — this unblocks the rest.

## Version note

`rc.7` is the **latest on Maven Central**; `rc.6` and `rc.8` are not published in the `1.8.0` line (it goes rc.5 → rc.7).

## Verification

- Maven Central resolution + opcode-class presence confirmed (above).
- ⚠️ **Needs CI green** — this is a two-RC bump; beyond the additive opcodes, CI (compile + test) is the gate for any other `rc.5 → rc.7` API change. I did not run the Scala build locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018mM9FbyJLFn5WjkzxZ4K2U
