### PR TITLE
build: replace removed apt-key in Dockerfile sbt install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,9 +65,10 @@ FROM eclipse-temurin:21-jdk AS otto-builder
 ARG OTTOCHAIN_VERSION
 
 RUN apt-get update && apt-get install -y curl gnupg && \
-    echo "deb https://repo.scala-sbt.org/scalasbt/debian all main" > /etc/apt/sources.list.d/sbt.list && \
-    curl -sL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2EE0EA64E40A89B84B2DF73499E82A75642AC823" | apt-key add && \
-    apt-get update && apt-get install -y sbt
+    echo "deb [signed-by=/usr/share/keyrings/sbt.gpg] https://repo.scala-sbt.org/scalasbt/debian all main" > /etc/apt/sources.list.d/sbt.list && \
+    curl -sL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2EE0EA64E40A89B84B2DF73499E82A75642AC823" | gpg --dearmor -o /usr/share/keyrings/sbt.gpg && \
+    apt-get update && apt-get install -y sbt && \
+    rm -rf /var/lib/apt/lists/*
 
 WORKDIR /ottochain
 


### PR DESCRIPTION
## Problem
The `v0.7.16` release Docker build failed at `Dockerfile:67` ([run 27853363625](https://github.com/scasplte2/ottochain/actions/runs/27853363625)):
```
/bin/sh: 1: apt-key: not found   →  exit code 127
```
`apt-key` was removed from the base image (`eclipse-temurin:21-jdk` is now Ubuntu-based without it). Pre-existing rot — it would break any release built today. The JAR build (sbt on the runner) is unaffected and passed.

## Fix
Migrate the sbt-repo key from the deprecated `apt-key add` to the `signed-by=` keyring approach (dearmor into `/usr/share/keyrings/sbt.gpg`), plus apt-list cleanup. Only Stage 2 (`otto-builder`) is touched.

## Validation
Built the fixed sbt-install layer locally against `eclipse-temurin:21-jdk`: sbt installs and `sbt --version` runs (sbt runner 2.0.0). ✅

## Follow-up
Docker CI only runs on release/dispatch, not PRs — so once merged, `v0.7.16` is re-cut (tag moved onto this fix) to rebuild the release image from a fixed tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)