### PR TITLE
refactor(fiber): rework FiberPolicy into a named ADT

### DIFF
--- a/modules/models/src/main/scala/xyz/kd5ujc/schema/fiber/FiberPolicy.scala
+++ b/modules/models/src/main/scala/xyz/kd5ujc/schema/fiber/FiberPolicy.scala
@@ -11,12 +11,12 @@ import derevo.circe.magnolia.{customizableDecoder, customizableEncoder}
 import derevo.derive
 import enumeratum.EnumEntry.Uppercase
 import enumeratum.{CirceEnum, Enum, EnumEntry}
-import io.circe.{Decoder, Encoder}
+import io.circe.{Decoder, Encoder, Json}
 
 /**
  * The 5 directive families [[xyz.kd5ujc.shared_data.fiber.evaluation.EffectExtractor]] scrapes from a
- * transition's effect result. A fiber's [[FiberPolicy.allowedEffects]] (when set) restricts which of these
- * its transitions may produce. Entry names are UPPERCASE on the wire (`"TRIGGER"`, `"SPAWN"`, …) — the
+ * transition's effect result. A fiber's [[FiberPolicy.Constrained.allowedEffects]] (when set) restricts which of
+ * these its transitions may produce. Entry names are UPPERCASE on the wire (`"TRIGGER"`, `"SPAWN"`, …) — the
  * cross-language string contract with the SDK builder.
  */
 sealed trait EffectKind extends EnumEntry with Uppercase
@@ -121,7 +121,7 @@ object MigrationAuthority {
 /**
  * The upgrade-path constitution: how (if at all) the fiber's hash-pinned definition may change. Ordered by
  * `rank` so the tighten-only lattice may only move UP (Immutable > Governed > AppendOnly > Arbitrary); a
- * migration can never launder a stricter tier down to a looser one. `None` on [[FiberPolicy.upgradePolicy]]
+ * migration can never launder a stricter tier down to a looser one. `None` on [[FiberPolicy.Constrained.upgradePolicy]]
  * is exactly [[Arbitrary]] (rank 0, today's behaviour) at every site.
  *
  * Prior art: Aptos `upgrade_policy` (immutable / compatible / arbitrary); Sui `UpgradeCap`; CosmWasm cw2
@@ -186,14 +186,21 @@ final case class VersionRange(
 }
 
 /**
- * The fiber's hash-pinned, opt-in constitution (fiber-policy.md, `fiberpolicy-dials` stream).
+ * The fiber's hash-pinned constitution (fiber-policy.md, `fiberpolicy-dials` stream), as a REQUIRED, NAMED
+ * ADT. Every definition has exactly one of two constitutions:
  *
- * A fiber voluntarily surrenders a capability in return for a guarantee any external observer can verify by
- * resolving ONE `logicHash`-anchored field. Every dial is `Option`/defaulted so a partial policy survives
- * `dropNulls` byte-stably and an all-default [[FiberPolicy]] is canonically identical to an absent one
- * (`Some(empty) ⇒ None`, see [[FiberPolicy.normalize]]). Default `policy = None` on
- * [[StateMachineDefinition]] is exactly today's unconstrained behaviour, hash-identical to a pre-policy
- * definition.
+ *   - [[FiberPolicy.Unconstrained]] — the named default: NO surrendered capability, today's legacy behaviour.
+ *     Replaces the old `None`/`Some(empty)`. [[StateMachineDefinition.policy]] defaults to it, so a pre-policy
+ *     definition is hash-identical to one that explicitly declares `Unconstrained`.
+ *   - [[FiberPolicy.Constrained]] — at least one of the 14 dials is set. A fiber voluntarily surrenders a capability
+ *     in return for a guarantee any external observer can verify by resolving ONE `logicHash`-anchored field.
+ *
+ * Every dial of [[Constrained]] is `Option`/defaulted so a partial policy survives `dropNulls` byte-stably. A
+ * `Constrained` with ALL 14 dials empty is SEMANTICALLY identical to `Unconstrained`; the smart constructor
+ * [[FiberPolicy.constrained]] (and the decoder) collapse it to `Unconstrained` so there is exactly ONE canonical
+ * representation of "unconstrained". This is the internal-determinism rule the verified re-bind
+ * (`definition.computeDigest === logicHash`) relies on: an absent policy key, `Unconstrained`, and an
+ * all-empty `Constrained` ALL encode to the same canonical bytes (field default + smart constructor + dropNulls).
  *
  * Enforcement is FAIL-CLOSED everywhere: a dial breach aborts the whole transition (total discard) or rejects
  * the update via [[FailureReason.PolicyViolation]] / `CombineRejected` — no dial ever silently strips a
@@ -203,51 +210,142 @@ final case class VersionRange(
  * `migrationAuthority`) is enforced at the migrate boundary by [[xyz.kd5ujc.shared_data.fiber.UpgradeGate]].
  * The pause/freeze runtime ops remain DEFERRED to a later wave and are intentionally absent here.
  */
-@derive(customizableEncoder, customizableDecoder)
-final case class FiberPolicy(
-  selfReproducing:  Option[Boolean] = None, // Dial #1: a _spawn child's definition must hash-equal the parent's
-  allowedEffects:   Option[Set[EffectKind]] = None, // None ⇒ all families (legacy)
-  spawnOwnerPolicy: Option[SpawnOwnerPolicy] = None,
-  maxGenerations:   Option[Int] = None, // same-definition-hash spawn-lineage depth cap
-  maxSpawnFanout:   Option[Int] = None, // children per single transition (tighter than ExecutionLimits cap)
-  acceptedCallers:  Option[Set[UUID]] = None, // fiber-origin ($caller) allowlist; user/wallet origin unaffected
-  sealedStates:     Option[Set[StateId]] = None, // states from which NO transition may fire (terminal/halted)
-  transferPolicy:   Option[TransferPolicy] = None,
-  dependencyPolicy: Option[DependencyPolicy] = None,
-  // ── version & compatibility family ──
-  upgradePolicy:      Option[UpgradePolicy] = None, // None ⇒ Arbitrary (legacy); gates migrate at UpgradeGate
-  version:            Option[SemVer] = None, // self-declared semantic version (TRUST-LAYER; gate uses schemaBinding)
-  compatibleWith:     Option[VersionRange] = None, // bridge window: which successor versions migrate may target
-  interfaces:         Option[Set[String]] = None, // ERC-165 interface ids the fiber advertises (self-declared)
-  migrationAuthority: Option[MigrationAuthority] = None // who may authorize a Governed migration
-) {
+sealed trait FiberPolicy {
 
-  /** An all-default policy is semantically equivalent to no policy at all. */
-  def isEmpty: Boolean =
-    selfReproducing.isEmpty && allowedEffects.isEmpty && spawnOwnerPolicy.isEmpty &&
-    maxGenerations.isEmpty && maxSpawnFanout.isEmpty && acceptedCallers.isEmpty &&
-    sealedStates.isEmpty && transferPolicy.isEmpty && dependencyPolicy.isEmpty &&
-    upgradePolicy.isEmpty && version.isEmpty && compatibleWith.isEmpty &&
-    interfaces.isEmpty && migrationAuthority.isEmpty
+  /** Convenience: this dial is ON only when explicitly set to `true`. `Unconstrained` is never reproducing. */
+  def isSelfReproducing: Boolean = this match {
+    case FiberPolicy.Unconstrained  => false
+    case c: FiberPolicy.Constrained => c.selfReproducing.contains(true)
+  }
 
-  /** Convenience: this dial is ON only when explicitly set to `true`. */
-  def isSelfReproducing: Boolean = selfReproducing.contains(true)
+  /** The effective upgrade tier — an absent dial (or `Unconstrained`) is [[UpgradePolicy.Arbitrary]] (legacy). */
+  def effectiveUpgradePolicy: UpgradePolicy =
+    dials.flatMap(_.upgradePolicy).getOrElse(UpgradePolicy.default)
 
-  /** The effective upgrade tier — an absent dial is [[UpgradePolicy.Arbitrary]] (legacy/unconstrained). */
-  def effectiveUpgradePolicy: UpgradePolicy = upgradePolicy.getOrElse(UpgradePolicy.default)
+  /**
+   * The dial bundle when this is a [[FiberPolicy.Constrained]], else `None` (an `Unconstrained` policy has NO dials
+   * set). Keeps consumer call sites that read a single dial readable: `policy.dials.flatMap(_.sealedStates)`
+   * replaces the old `policy.flatMap(_.sealedStates)` over an `Option[FiberPolicy]`, with the identical shape.
+   */
+  def dials: Option[FiberPolicy.Constrained] = this match {
+    case FiberPolicy.Unconstrained  => None
+    case c: FiberPolicy.Constrained => Some(c)
+  }
 }
 
 object FiberPolicy {
 
-  val empty: FiberPolicy = FiberPolicy()
+  /**
+   * The named default: NO surrendered capability — today's unconstrained/legacy behaviour. Replaces the old
+   * `None` / `Some(empty)`. Encodes as the magnolia variant wrapper `{"Unconstrained":{}}`.
+   */
+  case object Unconstrained extends FiberPolicy
 
   /**
-   * Normalize `Some(empty) ⇒ None` so an all-default policy hashes identically to an absent one. This is the
-   * internal-determinism rule the verified re-bind (`definition.computeDigest === logicHash`) relies on,
-   * independent of any back-compat concern: two definitions that mean the same thing MUST hash the same,
+   * A constitution that sets at least one of the 14 dials. Constructed ONLY via the smart constructor
+   * [[FiberPolicy.constrained]] (or the decoder), which collapses an all-empty `Constrained` to [[Unconstrained]] so
+   * there is exactly ONE canonical "unconstrained" form. Encodes as `{"Constrained":{<set dials only, after
+   * dropNulls>}}`.
+   */
+  @derive(customizableEncoder, customizableDecoder)
+  final case class Constrained(
+    selfReproducing:  Option[Boolean] = None, // Dial #1: a _spawn child's definition must hash-equal the parent's
+    allowedEffects:   Option[Set[EffectKind]] = None, // None ⇒ all families (legacy)
+    spawnOwnerPolicy: Option[SpawnOwnerPolicy] = None,
+    maxGenerations:   Option[Int] = None, // same-definition-hash spawn-lineage depth cap
+    maxSpawnFanout:   Option[Int] = None, // children per single transition (tighter than ExecutionLimits cap)
+    acceptedCallers:  Option[Set[UUID]] = None, // fiber-origin ($caller) allowlist; user/wallet origin unaffected
+    sealedStates:     Option[Set[StateId]] = None, // states from which NO transition may fire (terminal/halted)
+    transferPolicy:   Option[TransferPolicy] = None,
+    dependencyPolicy: Option[DependencyPolicy] = None,
+    // ── version & compatibility family ──
+    upgradePolicy:      Option[UpgradePolicy] = None, // None ⇒ Arbitrary (legacy); gates migrate at UpgradeGate
+    version:            Option[SemVer] = None, // self-declared semantic version (TRUST-LAYER; gate uses schemaBinding)
+    compatibleWith:     Option[VersionRange] = None, // bridge window: which successor versions migrate may target
+    interfaces:         Option[Set[String]] = None, // ERC-165 interface ids the fiber advertises (self-declared)
+    migrationAuthority: Option[MigrationAuthority] = None // who may authorize a Governed migration
+  ) extends FiberPolicy {
+
+    /** An all-default `Constrained` is semantically equivalent to `Unconstrained`. */
+    def isEmpty: Boolean =
+      selfReproducing.isEmpty && allowedEffects.isEmpty && spawnOwnerPolicy.isEmpty &&
+      maxGenerations.isEmpty && maxSpawnFanout.isEmpty && acceptedCallers.isEmpty &&
+      sealedStates.isEmpty && transferPolicy.isEmpty && dependencyPolicy.isEmpty &&
+      upgradePolicy.isEmpty && version.isEmpty && compatibleWith.isEmpty &&
+      interfaces.isEmpty && migrationAuthority.isEmpty
+  }
+
+  /**
+   * SMART CONSTRUCTOR (the determinism rule — load-bearing). Returns [[Unconstrained]] when every dial is
+   * empty, otherwise the given [[Constrained]]. This is the ONLY way a `Constrained` should be built, and the codec
+   * routes through it on decode, so an all-empty `Constrained` (typed OR on the wire as `{"Constrained":{}}`) is
+   * indistinguishable from `Unconstrained`. Two definitions that mean the same thing MUST hash the same,
    * regardless of which client (chain, SDK, third-party) wrote them.
    */
-  def normalize(p: Option[FiberPolicy]): Option[FiberPolicy] = p.filterNot(_.isEmpty)
+  def constrained(c: Constrained): FiberPolicy = if (c.isEmpty) Unconstrained else c
+
+  /**
+   * Named, all-defaulted convenience for the common case — the same dials as [[Constrained]], collapsed through the
+   * smart constructor. Lets call sites write `FiberPolicy.constrained(allowedEffects = Some(...))`.
+   */
+  def constrained(
+    selfReproducing:    Option[Boolean] = None,
+    allowedEffects:     Option[Set[EffectKind]] = None,
+    spawnOwnerPolicy:   Option[SpawnOwnerPolicy] = None,
+    maxGenerations:     Option[Int] = None,
+    maxSpawnFanout:     Option[Int] = None,
+    acceptedCallers:    Option[Set[UUID]] = None,
+    sealedStates:       Option[Set[StateId]] = None,
+    transferPolicy:     Option[TransferPolicy] = None,
+    dependencyPolicy:   Option[DependencyPolicy] = None,
+    upgradePolicy:      Option[UpgradePolicy] = None,
+    version:            Option[SemVer] = None,
+    compatibleWith:     Option[VersionRange] = None,
+    interfaces:         Option[Set[String]] = None,
+    migrationAuthority: Option[MigrationAuthority] = None
+  ): FiberPolicy =
+    constrained(
+      Constrained(
+        selfReproducing,
+        allowedEffects,
+        spawnOwnerPolicy,
+        maxGenerations,
+        maxSpawnFanout,
+        acceptedCallers,
+        sealedStates,
+        transferPolicy,
+        dependencyPolicy,
+        upgradePolicy,
+        version,
+        compatibleWith,
+        interfaces,
+        migrationAuthority
+      )
+    )
+
+  // ── Codec ──────────────────────────────────────────────────────────────────────────────────────────
+  // The named variant lives in CODE, not the bytes. `Unconstrained` encodes to JSON null — which the
+  // canonical path's `dropNulls` strips, so the `policy` key is OMITTED on the wire. Absence == Unconstrained,
+  // which is exactly what every pre-policy definition and the e2e/SDK already produce → client↔chain byte
+  // parity for FREE, with no sentinel to coordinate. `Constrained` encodes as its bare dials object (its own
+  // derived codec; `dropNulls` then strips the unset dials). Mirrors the UpgradePolicy / MigrationAuthority
+  // constrained ADT codecs in this file. NOTE: the canonical/signing/hash paths all `dropNulls`, so a `policy:null`
+  // never reaches the wire; a non-dropNulls encode would carry `"policy":null`, which still decodes back to
+  // Unconstrained.
+  private val constrainedEncoder: Encoder[Constrained] = Encoder[Constrained] // derevo-derived dials-object encoder
+  private val constrainedDecoder: Decoder[Constrained] = Decoder[Constrained]
+
+  implicit val encoder: Encoder[FiberPolicy] = Encoder.instance {
+    case Unconstrained  => Json.Null
+    case c: Constrained => constrainedEncoder(c)
+  }
+
+  // null/absent ⇒ Unconstrained; an object ⇒ Constrained routed through the smart constructor, so an all-empty
+  // `{}` (or all-null dials) collapses to Unconstrained — ONE canonical form in BOTH directions.
+  implicit val decoder: Decoder[FiberPolicy] = Decoder.instance { c =>
+    if (c.value.isNull) Right(Unconstrained)
+    else constrainedDecoder(c).map(constrained)
+  }
 
   // ────────────────────────────────────────────────────────────────────────────────────────────────
   // TIGHTEN-ONLY partial order (the trust anchor)
@@ -255,9 +353,10 @@ object FiberPolicy {
 
   /**
    * `tightens(old, neu)` succeeds iff `neu` is at least as restrictive as `old` on EVERY dial — the only
-   * direction a policy may move across a migration. Both sides are normalized first, so `Some(empty)` is
-   * treated as `None`; an absent `old` is fully-unconstrained, hence ANY `neu` is a valid tightening from
-   * "anything goes". Returns `Left(dial)` naming the first dial that LOOSENS.
+   * direction a policy may move across a migration. [[Unconstrained]] is BOTTOM (loosest): an `Unconstrained`
+   * `old` is fully-unconstrained, hence ANY `neu` is a valid tightening from "anything goes". A `Constrained` `old`
+   * with a `Unconstrained` `neu` LOOSENS every set dial back to "anything goes" and is rejected (Left naming
+   * the first loosened dial). Returns `Left(dial)` naming the first dial that LOOSENS.
    *
    * Per-dial order (`neu` must be ≥ `old` in restrictiveness):
    *   - selfReproducing: one-way latch — once ON, may never turn OFF (a fiber cannot graduate out).
@@ -281,11 +380,17 @@ object FiberPolicy {
    * `migrationAuthority` is likewise consulted at the gate (rotation under the same Governed rank is allowed,
    * matching cw2 admin-rotation), so it is not constrained here either.
    */
-  def tightens(old: Option[FiberPolicy], neu: Option[FiberPolicy]): Either[String, Unit] =
-    normalize(old) match {
-      case None => Right(()) // unconstrained prior ⇒ any successor is a valid tightening
-      case Some(o) =>
-        val n = normalize(neu).getOrElse(empty)
+  def tightens(old: FiberPolicy, neu: FiberPolicy): Either[String, Unit] =
+    old match {
+      case Unconstrained  => Right(()) // unconstrained prior ⇒ any successor is a valid tightening
+      case o: Constrained =>
+        // `Unconstrained` (or an all-empty `Constrained`) as the successor clears EVERY dial back to "anything
+        // goes" ⇒ it loosens any set dial. Run the per-dial order against the all-None projection so the
+        // FIRST loosened dial is the one named, exactly as a Some→None loosening would be.
+        val n = neu match {
+          case Unconstrained  => Constrained()
+          case c: Constrained => c
+        }
         for {
           _ <- latchOn("selfReproducing", o.selfReproducing, n.selfReproducing)
           _ <- subset("allowedEffects", o.allowedEffects, n.allowedEffects)

--- a/modules/models/src/main/scala/xyz/kd5ujc/schema/fiber/StateMachineDefinition.scala
+++ b/modules/models/src/main/scala/xyz/kd5ujc/schema/fiber/StateMachineDefinition.scala
@@ -5,37 +5,28 @@ import io.constellationnetwork.metagraph_sdk.json_logic.JsonLogicValue
 import xyz.kd5ujc.schema.CodecConfiguration._
 
 import derevo.circe.magnolia.{customizableDecoder, customizableEncoder}
-import io.circe.{Decoder, Encoder}
+import derevo.derive
 
+// `policy` is a REQUIRED, NAMED ADT (fiber-policy.md): every definition has exactly one constitution. It
+// defaults to FiberPolicy.Unconstrained (today's legacy/unconstrained behaviour). The codec derives normally
+// (honouring useDefaults via CodecConfiguration), so an absent `policy` key decodes to Unconstrained. The
+// old hand-rolled `Some(empty) ≡ None` normalization is GONE: there is no Option to collapse. The single
+// canonical "unconstrained" form is now guaranteed by the FiberPolicy codec itself (its decoder routes an
+// all-empty `Custom` through the smart constructor to Unconstrained), so an absent key, an explicit
+// `Unconstrained`, and an all-empty `Custom` all encode to the SAME canonical bytes everywhere
+// `computeDigest` is taken (verified re-bind #37, spawn child-hash, etc.), regardless of which client wrote
+// the definition.
+@derive(customizableEncoder, customizableDecoder)
 case class StateMachineDefinition(
   states:       Map[StateId, State],
   initialState: StateId,
   transitions:  List[Transition],
   metadata:     Option[JsonLogicValue] = None,
-  policy: Option[FiberPolicy] = None // opt-in, hash-pinned constitution (fiber-policy.md); None = legacy/unconstrained
+  policy:       FiberPolicy = FiberPolicy.Unconstrained // opt-in, hash-pinned constitution (fiber-policy.md)
 ) {
 
   // Helper to get transitions by current state + event type
   // Returns list to support multiple transitions with guards (first-match-wins)
   lazy val transitionMap: Map[(StateId, String), List[Transition]] =
     transitions.groupBy(t => (t.from, t.eventName))
-}
-
-object StateMachineDefinition {
-
-  // We hand-roll the codecs (rather than @derive) so the `policy` field passes through FiberPolicy.normalize
-  // on BOTH encode and decode, making Some(FiberPolicy.empty) ≡ None at the byte level. This is the
-  // load-bearing B3 fix: computeDigest(def.copy(policy = Some(empty))) is byte-identical to
-  // computeDigest(def.copy(policy = None)) EVERYWHERE computeDigest is taken (verified re-bind #37, spawn
-  // child-hash, etc.), regardless of which client wrote the definition. The structural base reuses the SAME
-  // configured derevo derivation (honouring useDefaults = true via CodecConfiguration), so an absent `policy`
-  // key still decodes to None and `dropNulls` still drops a None policy on serialize.
-  private val derivedDecoder: Decoder[StateMachineDefinition] = customizableDecoder.instance
-  private val derivedEncoder: Encoder[StateMachineDefinition] = customizableEncoder.instance
-
-  implicit val decoder: Decoder[StateMachineDefinition] =
-    derivedDecoder.map(d => d.copy(policy = FiberPolicy.normalize(d.policy)))
-
-  implicit val encoder: Encoder[StateMachineDefinition] =
-    derivedEncoder.contramap(d => d.copy(policy = FiberPolicy.normalize(d.policy)))
 }

--- a/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/fiber/FiberEngine.scala
+++ b/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/fiber/FiberEngine.scala
@@ -254,10 +254,10 @@ object FiberEngine {
        * ASSERTED commute-law obligation; `Arbitrary`/absent imply none. Read from the OLD (hash-pinned)
        * policy of the migrating fiber.
        */
-      private def commuteObligationFor(policy: Option[FiberPolicy]): Boolean =
-        policy.map(_.effectiveUpgradePolicy) match {
-          case Some(UpgradePolicy.AppendOnly) | Some(UpgradePolicy.Governed(_)) => true
-          case _                                                                => false
+      private def commuteObligationFor(policy: FiberPolicy): Boolean =
+        policy.effectiveUpgradePolicy match {
+          case UpgradePolicy.AppendOnly | UpgradePolicy.Governed(_) => true
+          case _                                                    => false
         }
 
       private def migrateStateMachine(
@@ -573,7 +573,7 @@ object FiberEngine {
         sm:        Records.StateMachineFiberRecord,
         mutations: List[FiberEffect.DependencyMutated]
       ): Option[FailureReason] =
-        sm.definition.policy.flatMap(_.dependencyPolicy).flatMap { dp =>
+        sm.definition.policy.dials.flatMap(_.dependencyPolicy).flatMap { dp =>
           dp.mode match {
             case DependencyMode.Open => None
             case DependencyMode.Allowlist =>
@@ -652,7 +652,7 @@ object FiberEngine {
       private def checkMaxGenerations(
         fiber: Records.StateMachineFiberRecord
       ): FiberT[F, Either[FailureReason, Unit]] =
-        fiber.definition.policy.flatMap(_.maxGenerations) match {
+        fiber.definition.policy.dials.flatMap(_.maxGenerations) match {
           case None => ().asRight[FailureReason].pure[FiberT[F, *]]
           case Some(cap) =>
             fiber.definition.computeDigest.liftFiber.flatMap { selfDigest =>

--- a/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/fiber/UpgradeGate.scala
+++ b/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/fiber/UpgradeGate.scala
@@ -63,13 +63,13 @@ object UpgradeGate {
    * [[UpgradePolicy.Arbitrary]] (legacy) ⇒ always admit.
    */
   def gateByUpgradePolicy(
-    oldP:       Option[FiberPolicy],
+    oldP:       FiberPolicy,
     old:        Records.StateMachineFiberRecord,
     newBinding: SchemaBinding,
     state:      CalculatedState,
     addrs:      Set[Address]
   ): Option[FailureReason] =
-    oldP.map(_.effectiveUpgradePolicy).getOrElse(UpgradePolicy.default) match {
+    oldP.effectiveUpgradePolicy match {
       case UpgradePolicy.Arbitrary => None
 
       case UpgradePolicy.Immutable =>
@@ -220,8 +220,8 @@ object UpgradeGate {
    * If the OLD policy declares a `compatibleWith` bridge window, the NEW (verified) binding version must fall
    * inside it; otherwise unconstrained. The predecessor declares which successor versions it will bridge TO.
    */
-  private def compatBridge(oldP: Option[FiberPolicy], newBinding: SchemaBinding): Option[FailureReason] =
-    oldP.flatMap(_.compatibleWith).flatMap { window =>
+  private def compatBridge(oldP: FiberPolicy, newBinding: SchemaBinding): Option[FailureReason] =
+    oldP.dials.flatMap(_.compatibleWith).flatMap { window =>
       if (window.contains(newBinding.version)) None
       else
         Some(

--- a/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/fiber/core/ContextProvider.scala
+++ b/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/fiber/core/ContextProvider.scala
@@ -324,7 +324,7 @@ object ContextProvider {
             )
           }
         val interfaces: List[JsonLogicValue] =
-          fiber.definition.policy
+          fiber.definition.policy.dials
             .flatMap(_.interfaces)
             .getOrElse(Set.empty)
             .toList

--- a/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/fiber/evaluation/FiberEvaluator.scala
+++ b/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/fiber/evaluation/FiberEvaluator.scala
@@ -130,7 +130,7 @@ object FiberEvaluator {
         fiber:  Records.StateMachineFiberRecord,
         caller: Option[UUID]
       ): Option[FailureReason] = {
-        val policy = fiber.definition.policy
+        val policy = fiber.definition.policy.dials
         val sealedHit =
           policy.flatMap(_.sealedStates).filter(_.contains(fiber.currentState)).map { _ =>
             FailureReason.PolicyViolation("sealedStates", s"state '${fiber.currentState.value}' is sealed")
@@ -246,7 +246,7 @@ object FiberEvaluator {
                   transition,
                   effectResult,
                   contextData,
-                  fiber.definition.policy.flatMap(_.allowedEffects)
+                  fiber.definition.policy.dials.flatMap(_.allowedEffects)
                 )
             }
 

--- a/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/fiber/spawning/SpawnValidator.scala
+++ b/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/fiber/spawning/SpawnValidator.scala
@@ -109,7 +109,7 @@ object SpawnValidator {
 
       /** `Some(digest)` iff the parent has opted into self-reproduction; `None` otherwise (no hashing cost). */
       private def maybeSelfHash(parent: Records.StateMachineFiberRecord): G[Option[Hash]] =
-        if (parent.definition.policy.exists(_.isSelfReproducing))
+        if (parent.definition.policy.isSelfReproducing)
           parent.definition.computeDigest.liftTo[G].map(_.some)
         else none[Hash].pure[G]
 
@@ -211,7 +211,7 @@ object SpawnValidator {
         parent:   Records.StateMachineFiberRecord,
         resolved: ValidatedNel[FailureReason, Set[Address]]
       ): ValidatedNel[FailureReason, Set[Address]] =
-        parent.definition.policy.flatMap(_.spawnOwnerPolicy) match {
+        parent.definition.policy.dials.flatMap(_.spawnOwnerPolicy) match {
           case None | Some(SpawnOwnerPolicy.Explicit) => resolved
           case Some(SpawnOwnerPolicy.InheritParent)   => resolved.map(_ => parent.owners)
           case Some(SpawnOwnerPolicy.SubsetOfParent) =>
@@ -304,7 +304,7 @@ object SpawnValidator {
         // maxSpawnsPerTransition. Same fail-closed abort path. Distinct FailureReason (PolicyViolation) so an
         // observer/test can tell a policy breach from the engine bound.
         val fanoutErrors: List[FailureReason] =
-          parent.definition.policy.flatMap(_.maxSpawnFanout) match {
+          parent.definition.policy.dials.flatMap(_.maxSpawnFanout) match {
             case Some(cap) if spawns.size > cap =>
               List(
                 FailureReason.PolicyViolation("maxSpawnFanout", s"transition emitted ${spawns.size} spawns (max: $cap)")

--- a/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/combine/AssetCombiner.scala
+++ b/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/combine/AssetCombiner.scala
@@ -443,7 +443,7 @@ class AssetCombiner[F[_]: Async: SecurityProvider](
       // recipient class ⇒ that class is unconstrained; absent policy ⇒ legacy (any recipient).
       _ <- st.calculated.stateMachines
         .get(emittingFiberId)
-        .flatMap(_.definition.policy)
+        .flatMap(_.definition.policy.dials)
         .flatMap(_.transferPolicy)
         .fold(Async[F].unit) { tp =>
           val (permitted, who) = transfer.recipient match {

--- a/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/validate/rules/FiberRules.scala
+++ b/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/validate/rules/FiberRules.scala
@@ -416,7 +416,7 @@ object FiberRules {
         case None => ().validNec[DataApplicationValidationError].pure[F] // existence handled by cidIsFound
         case Some(sm) =>
           val oldPolicy = sm.definition.policy
-          val immutable = oldPolicy.map(_.effectiveUpgradePolicy).contains(UpgradePolicy.Immutable)
+          val immutable = oldPolicy.effectiveUpgradePolicy == UpgradePolicy.Immutable
           if (immutable)
             (Errors.UpgradePolicyViolation(cid, "immutable: migrations are forbidden"): DataApplicationValidationError)
               .invalidNec[Unit]

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/FiberPolicyEnforcementSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/FiberPolicyEnforcementSuite.scala
@@ -71,8 +71,8 @@ object FiberPolicyEnforcementSuite extends SimpleIOSuite {
           ]
         }"""
         base <- parseDef(json)
-        forbid = base.copy(policy = Some(FiberPolicy(allowedEffects = Some(Set(EffectKind.Trigger)))))
-        permit = base.copy(policy = Some(FiberPolicy(allowedEffects = Some(Set(EffectKind.Emit)))))
+        forbid = base.copy(policy = FiberPolicy.constrained(allowedEffects = Some(Set(EffectKind.Trigger))))
+        permit = base.copy(policy = FiberPolicy.constrained(allowedEffects = Some(Set(EffectKind.Emit))))
         data = MapValue(Map("x" -> IntValue(0)))
         h <- (data: JsonLogicValue).computeDigest
         input = FiberInput.Transition("go", MapValue(Map.empty))
@@ -101,7 +101,7 @@ object FiberPolicyEnforcementSuite extends SimpleIOSuite {
           ]
         }"""
         base <- parseDef(json)
-        fdef = base.copy(policy = Some(FiberPolicy(sealedStates = Some(Set(StateId("init"))))))
+        fdef = base.copy(policy = FiberPolicy.constrained(sealedStates = Some(Set(StateId("init")))))
         data = MapValue(Map("x" -> IntValue(0)))
         h <- (data: JsonLogicValue).computeDigest
         st = CalculatedState(SortedMap(fid -> fiber(fid, fdef, data, h, fixture.ordinal)), SortedMap.empty)
@@ -145,8 +145,8 @@ object FiberPolicyEnforcementSuite extends SimpleIOSuite {
         sh <- (srcData: JsonLogicValue).computeDigest
         th <- (tgtData: JsonLogicValue).computeDigest
 
-        denyDef = tgtBase.copy(policy = Some(FiberPolicy(acceptedCallers = Some(Set(UUID.randomUUID())))))
-        allowDef = tgtBase.copy(policy = Some(FiberPolicy(acceptedCallers = Some(Set(sourceId)))))
+        denyDef = tgtBase.copy(policy = FiberPolicy.constrained(acceptedCallers = Some(Set(UUID.randomUUID()))))
+        allowDef = tgtBase.copy(policy = FiberPolicy.constrained(acceptedCallers = Some(Set(sourceId))))
 
         denyState = CalculatedState(
           SortedMap(
@@ -201,7 +201,7 @@ object FiberPolicyEnforcementSuite extends SimpleIOSuite {
           ]
         }"""
         base <- parseDef(json)
-        parentDef = base.copy(policy = Some(FiberPolicy(selfReproducing = Some(true))))
+        parentDef = base.copy(policy = FiberPolicy.constrained(selfReproducing = Some(true)))
         data = MapValue(Map("x" -> IntValue(0)))
         h <- (data: JsonLogicValue).computeDigest
         input = FiberInput.Transition("divide", MapValue(Map.empty))
@@ -232,7 +232,7 @@ object FiberPolicyEnforcementSuite extends SimpleIOSuite {
               "dependencies": [] }
           ]
         }"""
-        base <- parseDef(json) // policy = None ⇒ opt-out
+        base <- parseDef(json) // policy = FiberPolicy.Unconstrained ⇒ opt-out
         data = MapValue(Map("x" -> IntValue(0)))
         h <- (data: JsonLogicValue).computeDigest
         st = CalculatedState(SortedMap(parentId -> fiber(parentId, base, data, h, fixture.ordinal)), SortedMap.empty)
@@ -265,7 +265,7 @@ object FiberPolicyEnforcementSuite extends SimpleIOSuite {
           ]
         }"""
         base <- parseDef(json)
-        fdef = base.copy(policy = Some(FiberPolicy(maxSpawnFanout = Some(1))))
+        fdef = base.copy(policy = FiberPolicy.constrained(maxSpawnFanout = Some(1)))
         data = MapValue(Map("x" -> IntValue(0)))
         h <- (data: JsonLogicValue).computeDigest
         st = CalculatedState(SortedMap(parentId -> fiber(parentId, fdef, data, h, fixture.ordinal)), SortedMap.empty)
@@ -299,7 +299,7 @@ object FiberPolicyEnforcementSuite extends SimpleIOSuite {
           ]
         }"""
         base <- parseDef(json)
-        fdef = base.copy(policy = Some(FiberPolicy(spawnOwnerPolicy = Some(SpawnOwnerPolicy.SubsetOfParent))))
+        fdef = base.copy(policy = FiberPolicy.constrained(spawnOwnerPolicy = Some(SpawnOwnerPolicy.SubsetOfParent)))
         data = MapValue(Map("x" -> IntValue(0)))
         h <- (data: JsonLogicValue).computeDigest
         st = CalculatedState(
@@ -334,7 +334,7 @@ object FiberPolicyEnforcementSuite extends SimpleIOSuite {
           ]
         }"""
         base <- parseDef(json)
-        fdef = base.copy(policy = Some(FiberPolicy(maxGenerations = Some(3))))
+        fdef = base.copy(policy = FiberPolicy.constrained(maxGenerations = Some(3)))
         data = MapValue(Map("x" -> IntValue(0)))
         h <- (data: JsonLogicValue).computeDigest
         // parent references a missing ancestor ⇒ chain unverifiable ⇒ fail-closed reject.
@@ -366,7 +366,7 @@ object FiberPolicyEnforcementSuite extends SimpleIOSuite {
           ]
         }"""
         base <- parseDef(json)
-        fdef = base.copy(policy = Some(FiberPolicy(maxGenerations = Some(1000))))
+        fdef = base.copy(policy = FiberPolicy.constrained(maxGenerations = Some(1000)))
         data = MapValue(Map("x" -> IntValue(0)))
         h <- (data: JsonLogicValue).computeDigest
         // A.parent = B, B.parent = A  ⇒  a 2-node cycle in parentFiberId.
@@ -398,14 +398,13 @@ object FiberPolicyEnforcementSuite extends SimpleIOSuite {
         }"""
         base <- parseDef(json)
         denyDef = base.copy(policy =
-          Some(
-            FiberPolicy(dependencyPolicy =
+          FiberPolicy
+            .constrained(dependencyPolicy =
               Some(DependencyPolicy(DependencyMode.Allowlist, Some(Set(UUID.randomUUID()))))
             )
-          )
         )
         allowDef = base.copy(policy =
-          Some(FiberPolicy(dependencyPolicy = Some(DependencyPolicy(DependencyMode.Allowlist, Some(Set(depId))))))
+          FiberPolicy.constrained(dependencyPolicy = Some(DependencyPolicy(DependencyMode.Allowlist, Some(Set(depId)))))
         )
         data = MapValue(Map("x" -> IntValue(0)))
         h <- (data: JsonLogicValue).computeDigest
@@ -432,8 +431,8 @@ object FiberPolicyEnforcementSuite extends SimpleIOSuite {
         }"""
         base <- parseDef(json)
         // OLD policy: selfReproducing ON (a one-way latch). NEW: cleared ⇒ a loosening ⇒ must abort.
-        oldDef = base.copy(policy = Some(FiberPolicy(selfReproducing = Some(true))))
-        newDef = base.copy(policy = None)
+        oldDef = base.copy(policy = FiberPolicy.constrained(selfReproducing = Some(true)))
+        newDef = base.copy(policy = FiberPolicy.Unconstrained)
         data = MapValue(Map.empty)
         h <- (data: JsonLogicValue).computeDigest
         // Unbound fiber (schemaBinding = None) so the conformance gate is a no-op; the tighten check fires first.
@@ -458,7 +457,7 @@ object FiberPolicyEnforcementSuite extends SimpleIOSuite {
       for {
         fid  <- UUIDGen.randomUUID[IO]
         base <- parseDef("""{"states":{"init":{"id":"init","isFinal":false}},"initialState":"init","transitions":[]}""")
-        pol = Some(FiberPolicy(upgradePolicy = Some(UpgradePolicy.Immutable)))
+        pol = FiberPolicy.constrained(upgradePolicy = Some(UpgradePolicy.Immutable))
         fdef = base.copy(policy = pol)
         data = MapValue(Map.empty)
         h <- (data: JsonLogicValue).computeDigest
@@ -477,7 +476,7 @@ object FiberPolicyEnforcementSuite extends SimpleIOSuite {
         base <- parseDef("""{"states":{"init":{"id":"init","isFinal":false}},"initialState":"init","transitions":[]}""")
         // Governed by `anyAddr`; the NEW policy keeps the SAME Governed tier (tighten-only same-rank rotation OK).
         gov = UpgradePolicy.Governed(MigrationAuthority.Signers(Set(anyAddr)))
-        pol = Some(FiberPolicy(upgradePolicy = Some(gov)))
+        pol = FiberPolicy.constrained(upgradePolicy = Some(gov))
         fdef = base.copy(policy = pol)
         data = MapValue(Map.empty)
         h <- (data: JsonLogicValue).computeDigest

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/FiberPolicyHashStabilitySuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/FiberPolicyHashStabilitySuite.scala
@@ -13,10 +13,12 @@ import io.circe.syntax._
 import weaver.SimpleIOSuite
 
 /**
- * Hash-stability + empty-policy normalization (B3). The `policy = None` default must be `dropNulls`-stable so
- * every pre-policy definition's `computeDigest` is byte-identical, AND an all-default policy must hash exactly
- * like an absent one — the internal-determinism rule the verified re-bind (`computeDigest === logicHash`)
- * relies on, so two definitions that mean the same thing hash the same regardless of which client wrote them.
+ * Canonical-determinism for the REQUIRED, NAMED FiberPolicy ADT. The internal-determinism rule the verified
+ * re-bind (`computeDigest === logicHash`) relies on: an ABSENT policy key, an explicit `Unconstrained`, and an
+ * all-empty `Constrained` must ALL encode to the SAME canonical bytes (the field default = `Unconstrained`, the
+ * smart constructor that collapses an empty `Constrained` to `Unconstrained`, and `dropNulls` together guarantee
+ * it), so two definitions that mean the same thing hash the same regardless of which client wrote them. A SET
+ * dial must hash-distinct from `Unconstrained` and round-trip.
  */
 object FiberPolicyHashStabilitySuite extends SimpleIOSuite {
 
@@ -24,16 +26,18 @@ object FiberPolicyHashStabilitySuite extends SimpleIOSuite {
     states = Map(StateId("init") -> State(StateId("init"), isFinal = false)),
     initialState = StateId("init"),
     transitions = List.empty
-  )
+  ) // policy defaults to FiberPolicy.Unconstrained
 
-  test("policy=None and policy=Some(empty) produce IDENTICAL digests (B3 normalization)") {
+  test("Unconstrained (default) and an all-empty Constrained produce IDENTICAL digests (canonical collapse)") {
     for {
-      none  <- baseDef.computeDigest
-      empty <- baseDef.copy(policy = Some(FiberPolicy.empty)).computeDigest
-    } yield expect(none === empty)
+      unconstrained <- baseDef.computeDigest
+      // FiberPolicy.constrained(Constrained()) collapses to Unconstrained, so this is the same canonical form
+      empty <- baseDef.copy(policy = FiberPolicy.constrained(FiberPolicy.Constrained())).computeDigest
+    } yield expect(unconstrained === empty) and
+    expect(FiberPolicy.constrained(FiberPolicy.Constrained()) == FiberPolicy.Unconstrained)
   }
 
-  test("a legacy JSON (no policy key) decodes to policy=None and hashes identically to the typed None") {
+  test("a legacy JSON (no policy key) decodes to Unconstrained and hashes identically to the typed default") {
     val legacyJson = """{
       "states": { "init": { "id": "init", "isFinal": false } },
       "initialState": "init",
@@ -43,66 +47,80 @@ object FiberPolicyHashStabilitySuite extends SimpleIOSuite {
       decoded    <- IO.fromEither(decode[StateMachineDefinition](legacyJson))
       legacyHash <- decoded.computeDigest
       typedHash  <- baseDef.computeDigest
-    } yield expect(decoded.policy.isEmpty) and expect(legacyHash === typedHash)
+    } yield expect(decoded.policy == FiberPolicy.Unconstrained) and expect(legacyHash === typedHash)
   }
 
-  test("a wire policy:{} (all-default object) decodes to policy=None") {
-    val emptyPolicyJson = """{
+  test("a wire bare empty object (policy:{}) collapses to Unconstrained and hashes identically") {
+    val emptyObjJson = """{
       "states": { "init": { "id": "init", "isFinal": false } },
       "initialState": "init",
       "transitions": [],
       "policy": {}
     }"""
     for {
-      decoded   <- IO.fromEither(decode[StateMachineDefinition](emptyPolicyJson))
+      decoded   <- IO.fromEither(decode[StateMachineDefinition](emptyObjJson))
       emptyHash <- decoded.computeDigest
       typedHash <- baseDef.computeDigest
-    } yield expect(decoded.policy.isEmpty) and expect(emptyHash === typedHash)
+    } yield expect(decoded.policy == FiberPolicy.Unconstrained) and expect(emptyHash === typedHash)
   }
 
-  test("a NON-empty policy produces a DIFFERENT digest (the constitution is hash-pinned) and round-trips") {
-    val withPolicy = baseDef.copy(policy = Some(FiberPolicy(selfReproducing = Some(true))))
+  test("a wire null policy (policy:null) decodes to Unconstrained and hashes identically") {
+    val nullPolicyJson = """{
+      "states": { "init": { "id": "init", "isFinal": false } },
+      "initialState": "init",
+      "transitions": [],
+      "policy": null
+    }"""
+    for {
+      decoded   <- IO.fromEither(decode[StateMachineDefinition](nullPolicyJson))
+      uHash     <- decoded.computeDigest
+      typedHash <- baseDef.computeDigest
+    } yield expect(decoded.policy == FiberPolicy.Unconstrained) and expect(uHash === typedHash)
+  }
+
+  test("a non-empty Constrained produces a DIFFERENT digest (the constitution is hash-pinned) and round-trips") {
+    val withPolicy = baseDef.copy(policy = FiberPolicy.constrained(selfReproducing = Some(true)))
     for {
       baseHash   <- baseDef.computeDigest
       policyHash <- withPolicy.computeDigest
       reDecoded  <- IO.fromEither(decode[StateMachineDefinition](withPolicy.asJson.noSpaces))
     } yield expect(baseHash =!= policyHash) and
-    expect(reDecoded.policy.flatMap(_.selfReproducing).contains(true))
+    expect(reDecoded.policy.dials.flatMap(_.selfReproducing).contains(true))
   }
 
   test("the version-compat family round-trips through circe (ADT codecs) and stays hash-distinct") {
-    val vcPolicy = FiberPolicy(
+    val vcPolicy = FiberPolicy.constrained(
       upgradePolicy = Some(UpgradePolicy.Governed(MigrationAuthority.Role(new java.util.UUID(0L, 7L), "admins"))),
       version = Some(SemVer(1, 2, 3)),
       compatibleWith = Some(VersionRange(min = Some(SemVer(2, 0, 0)), max = Some(SemVer(3, 0, 0)))),
       interfaces = Some(Set("ITransfer", "IPause"))
     )
-    val withVc = baseDef.copy(policy = Some(vcPolicy))
+    val withVc = baseDef.copy(policy = vcPolicy)
     for {
       baseHash  <- baseDef.computeDigest
       vcHash    <- withVc.computeDigest
       reDecoded <- IO.fromEither(decode[StateMachineDefinition](withVc.asJson.noSpaces))
     } yield expect(baseHash =!= vcHash) and
-    expect(reDecoded.policy.flatMap(_.version).contains(SemVer(1, 2, 3))) and
-    expect(reDecoded.policy.flatMap(_.upgradePolicy).contains(vcPolicy.upgradePolicy.get)) and
-    expect(reDecoded.policy.flatMap(_.interfaces).contains(Set("ITransfer", "IPause"))) and
-    expect(reDecoded.policy.flatMap(_.compatibleWith) == vcPolicy.compatibleWith)
+    expect(reDecoded.policy.dials.flatMap(_.version).contains(SemVer(1, 2, 3))) and
+    expect(reDecoded.policy.dials.flatMap(_.upgradePolicy) == vcPolicy.dials.flatMap(_.upgradePolicy)) and
+    expect(reDecoded.policy.dials.flatMap(_.interfaces).contains(Set("ITransfer", "IPause"))) and
+    expect(reDecoded.policy.dials.flatMap(_.compatibleWith) == vcPolicy.dials.flatMap(_.compatibleWith))
   }
 
   test("a bare-tag upgradePolicy (immutable/appendOnly/arbitrary) round-trips as a string") {
-    val immutable = baseDef.copy(policy = Some(FiberPolicy(upgradePolicy = Some(UpgradePolicy.Immutable))))
+    val immutable = baseDef.copy(policy = FiberPolicy.constrained(upgradePolicy = Some(UpgradePolicy.Immutable)))
     for {
       reDecoded <- IO.fromEither(decode[StateMachineDefinition](immutable.asJson.noSpaces))
-    } yield expect(reDecoded.policy.flatMap(_.upgradePolicy).contains(UpgradePolicy.Immutable))
+    } yield expect(reDecoded.policy.dials.flatMap(_.upgradePolicy).contains(UpgradePolicy.Immutable))
   }
 
-  test("encoder normalizes Some(empty) away: the policy field is absent-or-null ⇒ dropNulls-stable") {
-    val emptied = baseDef.copy(policy = Some(FiberPolicy.empty))
-    val json = emptied.asJson
-    // Under useDefaults a None Option may serialize as an explicit `null`; what matters for hash-stability is
-    // that it is null (which the serialize-time `dropNulls` removes), NOT a non-null `{}` object. So: the
-    // policy field is either absent or JSON-null — never a present object.
-    val policyField = json.hcursor.downField("policy").focus
+  test("the canonical unconstrained form OMITS the policy key (Unconstrained ⇒ null ⇒ dropNulls strips it)") {
+    // The named variant lives in CODE, not the bytes: `Unconstrained` encodes to JSON null, which the
+    // canonical/signing path's dropNulls removes — so an unconstrained definition carries NO policy key on
+    // the wire. Absence == Unconstrained, exactly what every pre-policy / e2e / SDK payload already produces,
+    // so client↔chain byte parity is free (no sentinel to coordinate). The policy field is therefore either
+    // absent or null in the raw encoding; either way it is gone after dropNulls.
+    val policyField = baseDef.asJson.hcursor.downField("policy").focus
     IO.pure(expect(policyField.forall(_.isNull)))
   }
 }

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/FiberPolicyTightensSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/FiberPolicyTightensSuite.scala
@@ -8,8 +8,9 @@ import xyz.kd5ujc.schema.registry.SemVer
 import weaver.FunSuite
 
 /**
- * Pure unit tests for the FiberPolicy TIGHTEN-ONLY partial order and the empty-policy normalization. One case
- * per dial per direction: tighten OK, loosen rejected, None→Some OK, Some→None rejected where applicable.
+ * Pure unit tests for the FiberPolicy TIGHTEN-ONLY partial order over the REQUIRED, NAMED ADT and the
+ * smart-constructor canonicalization (`Constrained`-all-empty ⇒ `Unconstrained`). One case per dial per direction:
+ * tighten OK, loosen rejected, None→Some OK, Some→None rejected where applicable.
  */
 object FiberPolicyTightensSuite extends FunSuite {
 
@@ -18,81 +19,86 @@ object FiberPolicyTightensSuite extends FunSuite {
   private val b = uuid(2)
 
   private def ok(old: FiberPolicy, neu: FiberPolicy) =
-    expect(FiberPolicy.tightens(Some(old), Some(neu)).isRight)
+    expect(FiberPolicy.tightens(old, neu).isRight)
 
   private def rejected(old: FiberPolicy, neu: FiberPolicy, dial: String) =
-    expect(FiberPolicy.tightens(Some(old), Some(neu)) == Left(dial))
+    expect(FiberPolicy.tightens(old, neu) == Left(dial))
 
-  // ── normalize ────────────────────────────────────────────────────────────────────────────────────
+  // ── smart constructor (canonical "unconstrained" form) ─────────────────────────────────────────────
 
-  test("normalize: Some(empty) ⇒ None; a partial policy is preserved") {
-    expect(FiberPolicy.normalize(Some(FiberPolicy.empty)).isEmpty) and
-    expect(FiberPolicy.normalize(Some(FiberPolicy(selfReproducing = Some(true)))).isDefined) and
-    expect(FiberPolicy.normalize(None).isEmpty)
+  test("constrained: an all-empty Constrained collapses to Unconstrained; a partial policy is preserved") {
+    expect(FiberPolicy.constrained(FiberPolicy.Constrained()) == FiberPolicy.Unconstrained) and
+    expect(FiberPolicy.constrained() == FiberPolicy.Unconstrained) and
+    expect(FiberPolicy.constrained(selfReproducing = Some(true)).isInstanceOf[FiberPolicy.Constrained])
   }
 
-  test("tightens: an absent (or empty) old policy ⇒ ANY successor is a valid tightening from unconstrained") {
-    val anything = FiberPolicy(
+  test("tightens: an Unconstrained old policy ⇒ ANY successor is a valid tightening from unconstrained") {
+    val anything = FiberPolicy.constrained(
       selfReproducing = Some(true),
       allowedEffects = Some(Set(EffectKind.Emit)),
       sealedStates = Some(Set(StateId("done"))),
       maxGenerations = Some(1)
     )
-    expect(FiberPolicy.tightens(None, Some(anything)).isRight) and
-    expect(FiberPolicy.tightens(Some(FiberPolicy.empty), Some(anything)).isRight) and
+    expect(FiberPolicy.tightens(FiberPolicy.Unconstrained, anything).isRight) and
+    // an all-empty Constrained is canonically Unconstrained, so it is also BOTTOM
+    expect(FiberPolicy.tightens(FiberPolicy.constrained(FiberPolicy.Constrained()), anything).isRight) and
     // identity tightening (same policy) is always OK
-    expect(FiberPolicy.tightens(Some(anything), Some(anything)).isRight)
+    expect(FiberPolicy.tightens(anything, anything).isRight)
   }
 
-  test("tightens: a non-empty old ⇒ None new is a LOOSENING (back to unconstrained) and is rejected") {
-    val old = FiberPolicy(allowedEffects = Some(Set(EffectKind.Emit)))
-    expect(FiberPolicy.tightens(Some(old), None).isLeft)
+  test("tightens: a Constrained old ⇒ Unconstrained new is a LOOSENING (back to unconstrained) and is rejected") {
+    val old = FiberPolicy.constrained(allowedEffects = Some(Set(EffectKind.Emit)))
+    expect(FiberPolicy.tightens(old, FiberPolicy.Unconstrained).isLeft)
   }
 
   // ── selfReproducing (one-way latch) ──────────────────────────────────────────────────────────────
 
   test("selfReproducing: OFF→ON OK; ON→OFF latched (rejected); ON→ON OK") {
-    ok(FiberPolicy(), FiberPolicy(selfReproducing = Some(true))) and
-    ok(FiberPolicy(selfReproducing = Some(true)), FiberPolicy(selfReproducing = Some(true))) and
+    ok(FiberPolicy.Unconstrained, FiberPolicy.constrained(selfReproducing = Some(true))) and
+    ok(FiberPolicy.constrained(selfReproducing = Some(true)), FiberPolicy.constrained(selfReproducing = Some(true))) and
     rejected(
-      FiberPolicy(selfReproducing = Some(true)),
-      FiberPolicy(selfReproducing = Some(false)),
+      FiberPolicy.constrained(selfReproducing = Some(true)),
+      FiberPolicy.constrained(selfReproducing = Some(false)),
       "selfReproducing"
     ) and
-    // dropping the field entirely also clears the latch ⇒ rejected
-    rejected(FiberPolicy(selfReproducing = Some(true)), FiberPolicy(), "selfReproducing")
+    // dropping the field entirely (⇒ Unconstrained) also clears the latch ⇒ rejected
+    rejected(FiberPolicy.constrained(selfReproducing = Some(true)), FiberPolicy.Unconstrained, "selfReproducing")
   }
 
   // ── allowedEffects (set shrinks) ─────────────────────────────────────────────────────────────────
 
   test("allowedEffects: None→Some OK; subset OK; superset rejected; Some→None rejected") {
-    ok(FiberPolicy(), FiberPolicy(allowedEffects = Some(Set(EffectKind.Emit)))) and
+    ok(FiberPolicy.Unconstrained, FiberPolicy.constrained(allowedEffects = Some(Set(EffectKind.Emit)))) and
     ok(
-      FiberPolicy(allowedEffects = Some(Set(EffectKind.Emit, EffectKind.Trigger))),
-      FiberPolicy(allowedEffects = Some(Set(EffectKind.Emit)))
+      FiberPolicy.constrained(allowedEffects = Some(Set(EffectKind.Emit, EffectKind.Trigger))),
+      FiberPolicy.constrained(allowedEffects = Some(Set(EffectKind.Emit)))
     ) and
     rejected(
-      FiberPolicy(allowedEffects = Some(Set(EffectKind.Emit))),
-      FiberPolicy(allowedEffects = Some(Set(EffectKind.Emit, EffectKind.Spawn))),
+      FiberPolicy.constrained(allowedEffects = Some(Set(EffectKind.Emit))),
+      FiberPolicy.constrained(allowedEffects = Some(Set(EffectKind.Emit, EffectKind.Spawn))),
       "allowedEffects"
     ) and
-    rejected(FiberPolicy(allowedEffects = Some(Set(EffectKind.Emit))), FiberPolicy(), "allowedEffects")
+    rejected(
+      FiberPolicy.constrained(allowedEffects = Some(Set(EffectKind.Emit))),
+      FiberPolicy.Unconstrained,
+      "allowedEffects"
+    )
   }
 
   // ── spawnOwnerPolicy (lattice rank up only) ──────────────────────────────────────────────────────
 
   test("spawnOwnerPolicy: Explicit→SubsetOfParent→InheritParent OK; reverse rejected") {
     ok(
-      FiberPolicy(spawnOwnerPolicy = Some(SpawnOwnerPolicy.Explicit)),
-      FiberPolicy(spawnOwnerPolicy = Some(SpawnOwnerPolicy.InheritParent))
+      FiberPolicy.constrained(spawnOwnerPolicy = Some(SpawnOwnerPolicy.Explicit)),
+      FiberPolicy.constrained(spawnOwnerPolicy = Some(SpawnOwnerPolicy.InheritParent))
     ) and
     ok(
-      FiberPolicy(spawnOwnerPolicy = Some(SpawnOwnerPolicy.SubsetOfParent)),
-      FiberPolicy(spawnOwnerPolicy = Some(SpawnOwnerPolicy.InheritParent))
+      FiberPolicy.constrained(spawnOwnerPolicy = Some(SpawnOwnerPolicy.SubsetOfParent)),
+      FiberPolicy.constrained(spawnOwnerPolicy = Some(SpawnOwnerPolicy.InheritParent))
     ) and
     rejected(
-      FiberPolicy(spawnOwnerPolicy = Some(SpawnOwnerPolicy.InheritParent)),
-      FiberPolicy(spawnOwnerPolicy = Some(SpawnOwnerPolicy.Explicit)),
+      FiberPolicy.constrained(spawnOwnerPolicy = Some(SpawnOwnerPolicy.InheritParent)),
+      FiberPolicy.constrained(spawnOwnerPolicy = Some(SpawnOwnerPolicy.Explicit)),
       "spawnOwnerPolicy"
     )
   }
@@ -100,21 +106,32 @@ object FiberPolicyTightensSuite extends FunSuite {
   // ── numeric caps (shrink only) ───────────────────────────────────────────────────────────────────
 
   test("maxGenerations / maxSpawnFanout: shrink OK; grow rejected; Some→None rejected") {
-    ok(FiberPolicy(maxGenerations = Some(5)), FiberPolicy(maxGenerations = Some(3))) and
-    rejected(FiberPolicy(maxGenerations = Some(3)), FiberPolicy(maxGenerations = Some(5)), "maxGenerations") and
-    rejected(FiberPolicy(maxGenerations = Some(3)), FiberPolicy(), "maxGenerations") and
-    ok(FiberPolicy(maxSpawnFanout = Some(4)), FiberPolicy(maxSpawnFanout = Some(2))) and
-    rejected(FiberPolicy(maxSpawnFanout = Some(2)), FiberPolicy(maxSpawnFanout = Some(4)), "maxSpawnFanout")
+    ok(FiberPolicy.constrained(maxGenerations = Some(5)), FiberPolicy.constrained(maxGenerations = Some(3))) and
+    rejected(
+      FiberPolicy.constrained(maxGenerations = Some(3)),
+      FiberPolicy.constrained(maxGenerations = Some(5)),
+      "maxGenerations"
+    ) and
+    rejected(FiberPolicy.constrained(maxGenerations = Some(3)), FiberPolicy.Unconstrained, "maxGenerations") and
+    ok(FiberPolicy.constrained(maxSpawnFanout = Some(4)), FiberPolicy.constrained(maxSpawnFanout = Some(2))) and
+    rejected(
+      FiberPolicy.constrained(maxSpawnFanout = Some(2)),
+      FiberPolicy.constrained(maxSpawnFanout = Some(4)),
+      "maxSpawnFanout"
+    )
   }
 
   // ── acceptedCallers (set shrinks) ────────────────────────────────────────────────────────────────
 
   test("acceptedCallers: None→Some OK; subset OK; superset rejected") {
-    ok(FiberPolicy(), FiberPolicy(acceptedCallers = Some(Set(a)))) and
-    ok(FiberPolicy(acceptedCallers = Some(Set(a, b))), FiberPolicy(acceptedCallers = Some(Set(a)))) and
+    ok(FiberPolicy.Unconstrained, FiberPolicy.constrained(acceptedCallers = Some(Set(a)))) and
+    ok(
+      FiberPolicy.constrained(acceptedCallers = Some(Set(a, b))),
+      FiberPolicy.constrained(acceptedCallers = Some(Set(a)))
+    ) and
     rejected(
-      FiberPolicy(acceptedCallers = Some(Set(a))),
-      FiberPolicy(acceptedCallers = Some(Set(a, b))),
+      FiberPolicy.constrained(acceptedCallers = Some(Set(a))),
+      FiberPolicy.constrained(acceptedCallers = Some(Set(a, b))),
       "acceptedCallers"
     )
   }
@@ -123,17 +140,17 @@ object FiberPolicyTightensSuite extends FunSuite {
 
   test("sealedStates: the sealed set may only GROW; shrinking is rejected") {
     ok(
-      FiberPolicy(sealedStates = Some(Set(StateId("a")))),
-      FiberPolicy(sealedStates = Some(Set(StateId("a"), StateId("b"))))
+      FiberPolicy.constrained(sealedStates = Some(Set(StateId("a")))),
+      FiberPolicy.constrained(sealedStates = Some(Set(StateId("a"), StateId("b"))))
     ) and
     rejected(
-      FiberPolicy(sealedStates = Some(Set(StateId("a"), StateId("b")))),
-      FiberPolicy(sealedStates = Some(Set(StateId("a")))),
+      FiberPolicy.constrained(sealedStates = Some(Set(StateId("a"), StateId("b")))),
+      FiberPolicy.constrained(sealedStates = Some(Set(StateId("a")))),
       "sealedStates"
     ) and
     rejected(
-      FiberPolicy(sealedStates = Some(Set(StateId("a")))),
-      FiberPolicy(),
+      FiberPolicy.constrained(sealedStates = Some(Set(StateId("a")))),
+      FiberPolicy.Unconstrained,
       "sealedStates"
     )
   }
@@ -142,12 +159,12 @@ object FiberPolicyTightensSuite extends FunSuite {
 
   test("transferPolicy: recipient allowlists may only shrink") {
     ok(
-      FiberPolicy(transferPolicy = Some(TransferPolicy(allowedRecipientFibers = Some(Set(a, b))))),
-      FiberPolicy(transferPolicy = Some(TransferPolicy(allowedRecipientFibers = Some(Set(a)))))
+      FiberPolicy.constrained(transferPolicy = Some(TransferPolicy(allowedRecipientFibers = Some(Set(a, b))))),
+      FiberPolicy.constrained(transferPolicy = Some(TransferPolicy(allowedRecipientFibers = Some(Set(a)))))
     ) and
     rejected(
-      FiberPolicy(transferPolicy = Some(TransferPolicy(allowedRecipientFibers = Some(Set(a))))),
-      FiberPolicy(transferPolicy = Some(TransferPolicy(allowedRecipientFibers = Some(Set(a, b))))),
+      FiberPolicy.constrained(transferPolicy = Some(TransferPolicy(allowedRecipientFibers = Some(Set(a))))),
+      FiberPolicy.constrained(transferPolicy = Some(TransferPolicy(allowedRecipientFibers = Some(Set(a, b))))),
       "transferPolicy.allowedRecipientFibers"
     )
   }
@@ -156,21 +173,21 @@ object FiberPolicyTightensSuite extends FunSuite {
 
   test("dependencyPolicy: Open→Allowlist→Frozen OK; reverse rejected; Allowlist shrinks") {
     ok(
-      FiberPolicy(dependencyPolicy = Some(DependencyPolicy(DependencyMode.Open))),
-      FiberPolicy(dependencyPolicy = Some(DependencyPolicy(DependencyMode.Frozen)))
+      FiberPolicy.constrained(dependencyPolicy = Some(DependencyPolicy(DependencyMode.Open))),
+      FiberPolicy.constrained(dependencyPolicy = Some(DependencyPolicy(DependencyMode.Frozen)))
     ) and
     rejected(
-      FiberPolicy(dependencyPolicy = Some(DependencyPolicy(DependencyMode.Frozen))),
-      FiberPolicy(dependencyPolicy = Some(DependencyPolicy(DependencyMode.Allowlist))),
+      FiberPolicy.constrained(dependencyPolicy = Some(DependencyPolicy(DependencyMode.Frozen))),
+      FiberPolicy.constrained(dependencyPolicy = Some(DependencyPolicy(DependencyMode.Allowlist))),
       "dependencyPolicy.mode"
     ) and
     ok(
-      FiberPolicy(dependencyPolicy = Some(DependencyPolicy(DependencyMode.Allowlist, Some(Set(a, b))))),
-      FiberPolicy(dependencyPolicy = Some(DependencyPolicy(DependencyMode.Allowlist, Some(Set(a)))))
+      FiberPolicy.constrained(dependencyPolicy = Some(DependencyPolicy(DependencyMode.Allowlist, Some(Set(a, b))))),
+      FiberPolicy.constrained(dependencyPolicy = Some(DependencyPolicy(DependencyMode.Allowlist, Some(Set(a)))))
     ) and
     rejected(
-      FiberPolicy(dependencyPolicy = Some(DependencyPolicy(DependencyMode.Allowlist, Some(Set(a))))),
-      FiberPolicy(dependencyPolicy = Some(DependencyPolicy(DependencyMode.Allowlist, Some(Set(a, b))))),
+      FiberPolicy.constrained(dependencyPolicy = Some(DependencyPolicy(DependencyMode.Allowlist, Some(Set(a))))),
+      FiberPolicy.constrained(dependencyPolicy = Some(DependencyPolicy(DependencyMode.Allowlist, Some(Set(a, b))))),
       "dependencyPolicy.allowed"
     )
   }
@@ -180,55 +197,69 @@ object FiberPolicyTightensSuite extends FunSuite {
   test("upgradePolicy: rank may only INCREASE; absent is Arbitrary (rank 0)") {
     // Arbitrary→AppendOnly→Governed→Immutable all tighten (rank up)
     ok(
-      FiberPolicy(upgradePolicy = Some(UpgradePolicy.Arbitrary)),
-      FiberPolicy(upgradePolicy = Some(UpgradePolicy.AppendOnly))
+      FiberPolicy.constrained(upgradePolicy = Some(UpgradePolicy.Arbitrary)),
+      FiberPolicy.constrained(upgradePolicy = Some(UpgradePolicy.AppendOnly))
     ) and
     ok(
-      FiberPolicy(upgradePolicy = Some(UpgradePolicy.AppendOnly)),
-      FiberPolicy(upgradePolicy = Some(UpgradePolicy.Immutable))
+      FiberPolicy.constrained(upgradePolicy = Some(UpgradePolicy.AppendOnly)),
+      FiberPolicy.constrained(upgradePolicy = Some(UpgradePolicy.Immutable))
     ) and
-    // None (≡ Arbitrary)→AppendOnly OK
-    ok(FiberPolicy(), FiberPolicy(upgradePolicy = Some(UpgradePolicy.AppendOnly))) and
+    // Unconstrained (≡ Arbitrary)→AppendOnly OK
+    ok(FiberPolicy.Unconstrained, FiberPolicy.constrained(upgradePolicy = Some(UpgradePolicy.AppendOnly))) and
     // Immutable→Governed LOOSENS (rank 3→2) ⇒ rejected. Authority is identified by a registry-fiber Role here
     // (no Address needed in this pure suite); contents are irrelevant to the rank lattice.
     rejected(
-      FiberPolicy(upgradePolicy = Some(UpgradePolicy.Immutable)),
-      FiberPolicy(upgradePolicy = Some(UpgradePolicy.Governed(MigrationAuthority.Role(a, "admins")))),
+      FiberPolicy.constrained(upgradePolicy = Some(UpgradePolicy.Immutable)),
+      FiberPolicy.constrained(upgradePolicy = Some(UpgradePolicy.Governed(MigrationAuthority.Role(a, "admins")))),
       "upgradePolicy"
     ) and
-    // AppendOnly→None (≡ Arbitrary, rank 1→0) LOOSENS ⇒ rejected
-    rejected(FiberPolicy(upgradePolicy = Some(UpgradePolicy.AppendOnly)), FiberPolicy(), "upgradePolicy") and
+    // AppendOnly→Unconstrained (≡ Arbitrary, rank 1→0) LOOSENS ⇒ rejected
+    rejected(
+      FiberPolicy.constrained(upgradePolicy = Some(UpgradePolicy.AppendOnly)),
+      FiberPolicy.Unconstrained,
+      "upgradePolicy"
+    ) and
     // Governed→Governed (same rank, different authority) is a valid same-rank move (rotation gated at UpgradeGate)
     ok(
-      FiberPolicy(upgradePolicy = Some(UpgradePolicy.Governed(MigrationAuthority.Role(a, "admins")))),
-      FiberPolicy(upgradePolicy = Some(UpgradePolicy.Governed(MigrationAuthority.Role(b, "admins"))))
+      FiberPolicy.constrained(upgradePolicy = Some(UpgradePolicy.Governed(MigrationAuthority.Role(a, "admins")))),
+      FiberPolicy.constrained(upgradePolicy = Some(UpgradePolicy.Governed(MigrationAuthority.Role(b, "admins"))))
     )
   }
 
   // ── version (must advance) ───────────────────────────────────────────────────────────────────────
 
   test("version: may only ADVANCE; None→Some OK; Some→None rejected; regress rejected") {
-    ok(FiberPolicy(version = Some(SemVer(1, 0, 0))), FiberPolicy(version = Some(SemVer(1, 0, 1)))) and
-    ok(FiberPolicy(version = Some(SemVer(1, 2, 3))), FiberPolicy(version = Some(SemVer(1, 2, 3)))) and
-    ok(FiberPolicy(), FiberPolicy(version = Some(SemVer(1, 0, 0)))) and
-    rejected(FiberPolicy(version = Some(SemVer(2, 0, 0))), FiberPolicy(version = Some(SemVer(1, 9, 9))), "version") and
-    rejected(FiberPolicy(version = Some(SemVer(1, 0, 0))), FiberPolicy(), "version")
+    ok(
+      FiberPolicy.constrained(version = Some(SemVer(1, 0, 0))),
+      FiberPolicy.constrained(version = Some(SemVer(1, 0, 1)))
+    ) and
+    ok(
+      FiberPolicy.constrained(version = Some(SemVer(1, 2, 3))),
+      FiberPolicy.constrained(version = Some(SemVer(1, 2, 3)))
+    ) and
+    ok(FiberPolicy.Unconstrained, FiberPolicy.constrained(version = Some(SemVer(1, 0, 0)))) and
+    rejected(
+      FiberPolicy.constrained(version = Some(SemVer(2, 0, 0))),
+      FiberPolicy.constrained(version = Some(SemVer(1, 9, 9))),
+      "version"
+    ) and
+    rejected(FiberPolicy.constrained(version = Some(SemVer(1, 0, 0))), FiberPolicy.Unconstrained, "version")
   }
 
   // ── interfaces (set GROWS — a consumer must not lose an advertised capability) ───────────────────
 
   test("interfaces: the advertised set may only GROW; shrinking/dropping is rejected") {
     ok(
-      FiberPolicy(interfaces = Some(Set("ITransfer"))),
-      FiberPolicy(interfaces = Some(Set("ITransfer", "IPause")))
+      FiberPolicy.constrained(interfaces = Some(Set("ITransfer"))),
+      FiberPolicy.constrained(interfaces = Some(Set("ITransfer", "IPause")))
     ) and
-    ok(FiberPolicy(), FiberPolicy(interfaces = Some(Set("ITransfer")))) and
+    ok(FiberPolicy.Unconstrained, FiberPolicy.constrained(interfaces = Some(Set("ITransfer")))) and
     rejected(
-      FiberPolicy(interfaces = Some(Set("ITransfer", "IPause"))),
-      FiberPolicy(interfaces = Some(Set("ITransfer"))),
+      FiberPolicy.constrained(interfaces = Some(Set("ITransfer", "IPause"))),
+      FiberPolicy.constrained(interfaces = Some(Set("ITransfer"))),
       "interfaces"
     ) and
-    rejected(FiberPolicy(interfaces = Some(Set("ITransfer"))), FiberPolicy(), "interfaces")
+    rejected(FiberPolicy.constrained(interfaces = Some(Set("ITransfer"))), FiberPolicy.Unconstrained, "interfaces")
   }
 
   // ── enum wire strings (cross-language contract with the SDK builder) ─────────────────────────────

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/UpgradeGateSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/UpgradeGateSuite.scala
@@ -53,7 +53,7 @@ object UpgradeGateSuite extends FunSuite {
     SchemaBinding(pkg, v, Hash("schemaHash"), Hash("logicHash"))
 
   private def smRecord(
-    policy:  Option[FiberPolicy],
+    policy:  FiberPolicy,
     state:   JsonLogicValue = MapValue(Map.empty),
     binding: Option[SchemaBinding] = None,
     id:      UUID = uuid(1)
@@ -86,37 +86,36 @@ object UpgradeGateSuite extends FunSuite {
   // ── Arbitrary / absent ───────────────────────────────────────────────────────────────────────────
 
   test("absent upgradePolicy (≡ Arbitrary) admits any migration") {
-    val old = smRecord(None)
+    val old = smRecord(FiberPolicy.Unconstrained)
     expect(UpgradeGate.check(old, baseDef, binding(SemVer(2, 0, 0)), stateOf(old), Set(alice)).isEmpty)
   }
 
   test("explicit Arbitrary admits any migration") {
-    val old = smRecord(Some(FiberPolicy(upgradePolicy = Some(UpgradePolicy.Arbitrary))))
+    val old = smRecord(FiberPolicy.constrained(upgradePolicy = Some(UpgradePolicy.Arbitrary)))
     expect(UpgradeGate.check(old, baseDef, binding(SemVer(2, 0, 0)), stateOf(old), Set(alice)).isEmpty)
   }
 
   // ── Immutable ────────────────────────────────────────────────────────────────────────────────────
 
   test("Immutable denies ALL migrations (even an identity re-bind with verified signers)") {
-    val pol = Some(FiberPolicy(upgradePolicy = Some(UpgradePolicy.Immutable)))
+    val pol = FiberPolicy.constrained(upgradePolicy = Some(UpgradePolicy.Immutable))
     val old = smRecord(pol)
     val r = UpgradeGate.check(old, baseDef.copy(policy = pol), binding(SemVer(2, 0, 0)), stateOf(old), Set(alice))
     expect(isPolicyViolation(r, "upgradePolicy"))
   }
 
   test("Immutable cannot be escaped by a migration that drops the dial (tighten-only also denies)") {
-    val old = smRecord(Some(FiberPolicy(upgradePolicy = Some(UpgradePolicy.Immutable))))
+    val old = smRecord(FiberPolicy.constrained(upgradePolicy = Some(UpgradePolicy.Immutable)))
     // newDefinition tries to loosen to Arbitrary; gateByUpgradePolicy denies first regardless.
-    val newDef = baseDef.copy(policy = None)
+    val newDef = baseDef.copy(policy = FiberPolicy.Unconstrained)
     expect(UpgradeGate.check(old, newDef, binding(SemVer(2, 0, 0)), stateOf(old), Set(alice)).isDefined)
   }
 
   // ── Governed.Signers ─────────────────────────────────────────────────────────────────────────────
 
   test("Governed.Signers admits when a verified signer is in the authority set; denies otherwise") {
-    val pol = Some(
-      FiberPolicy(upgradePolicy = Some(UpgradePolicy.Governed(MigrationAuthority.Signers(Set(alice)))))
-    )
+    val pol =
+      FiberPolicy.constrained(upgradePolicy = Some(UpgradePolicy.Governed(MigrationAuthority.Signers(Set(alice)))))
     val old = smRecord(pol)
     val ok = UpgradeGate.check(old, baseDef.copy(policy = pol), binding(SemVer(2, 0, 0)), stateOf(old), Set(alice))
     val no = UpgradeGate.check(old, baseDef.copy(policy = pol), binding(SemVer(2, 0, 0)), stateOf(old), Set(bob))
@@ -124,7 +123,8 @@ object UpgradeGateSuite extends FunSuite {
   }
 
   test("Governed.Signers with an empty authority set denies everyone (soft-Immutable)") {
-    val pol = Some(FiberPolicy(upgradePolicy = Some(UpgradePolicy.Governed(MigrationAuthority.Signers(Set.empty)))))
+    val pol =
+      FiberPolicy.constrained(upgradePolicy = Some(UpgradePolicy.Governed(MigrationAuthority.Signers(Set.empty))))
     val old = smRecord(pol)
     expect(
       isPolicyViolation(
@@ -138,14 +138,15 @@ object UpgradeGateSuite extends FunSuite {
 
   test("Governed.Role admits when a verified signer keys the role map; fail-closed on missing fiber/map") {
     val registryId = uuid(99)
-    val pol = Some(
-      FiberPolicy(upgradePolicy = Some(UpgradePolicy.Governed(MigrationAuthority.Role(registryId, "admins"))))
-    )
+    val pol =
+      FiberPolicy.constrained(upgradePolicy =
+        Some(UpgradePolicy.Governed(MigrationAuthority.Role(registryId, "admins")))
+      )
     val old = smRecord(pol, id = uuid(1))
     // registry fiber whose stateData.admins = { <alice.show>: true } (the gate keys on the Base58 `show`)
     val roleMap: JsonLogicValue =
       MapValue(Map("admins" -> MapValue(Map(alice.show -> BoolValue(true)))))
-    val registryFiber = smRecord(None, state = roleMap, id = registryId)
+    val registryFiber = smRecord(FiberPolicy.Unconstrained, state = roleMap, id = registryId)
 
     val present = stateOf(old, registryFiber)
     val ok = UpgradeGate.check(old, baseDef.copy(policy = pol), binding(SemVer(2, 0, 0)), present, Set(alice))
@@ -160,12 +161,14 @@ object UpgradeGateSuite extends FunSuite {
 
   test("Governed.Role denies when the role field is missing or not a map (fail-closed)") {
     val registryId = uuid(99)
-    val pol = Some(
-      FiberPolicy(upgradePolicy = Some(UpgradePolicy.Governed(MigrationAuthority.Role(registryId, "admins"))))
-    )
+    val pol =
+      FiberPolicy.constrained(upgradePolicy =
+        Some(UpgradePolicy.Governed(MigrationAuthority.Role(registryId, "admins")))
+      )
     val old = smRecord(pol, id = uuid(1))
-    val noRoleField = smRecord(None, state = MapValue(Map("other" -> BoolValue(true))), id = registryId)
-    val nonMapState = smRecord(None, state = BoolValue(true), id = registryId)
+    val noRoleField =
+      smRecord(FiberPolicy.Unconstrained, state = MapValue(Map("other" -> BoolValue(true))), id = registryId)
+    val nonMapState = smRecord(FiberPolicy.Unconstrained, state = BoolValue(true), id = registryId)
     val r1 = UpgradeGate.check(
       old,
       baseDef.copy(policy = pol),
@@ -188,7 +191,7 @@ object UpgradeGateSuite extends FunSuite {
   test("AppendOnly admits an additive field (new number) and denies a dropped/retyped/non-strict delta") {
     val v1 = SemVer(1, 0, 0)
     val v2 = SemVer(2, 0, 0)
-    val pol = Some(FiberPolicy(upgradePolicy = Some(UpgradePolicy.AppendOnly)))
+    val pol = FiberPolicy.constrained(upgradePolicy = Some(UpgradePolicy.AppendOnly))
     val old = smRecord(pol, binding = Some(binding(v1)))
 
     val oldShape = MachineShape(
@@ -245,7 +248,7 @@ object UpgradeGateSuite extends FunSuite {
   test("AppendOnly denies when a command message is removed") {
     val v1 = SemVer(1, 0, 0)
     val v2 = SemVer(2, 0, 0)
-    val pol = Some(FiberPolicy(upgradePolicy = Some(UpgradePolicy.AppendOnly)))
+    val pol = FiberPolicy.constrained(upgradePolicy = Some(UpgradePolicy.AppendOnly))
     val old = smRecord(pol, binding = Some(binding(v1)))
 
     val stateMsg = msg(FieldShape("x", 1, "int64", repeated = false, optional = false))
@@ -277,9 +280,10 @@ object UpgradeGateSuite extends FunSuite {
   // ── compatBridge ─────────────────────────────────────────────────────────────────────────────────
 
   test("compatBridge: a target inside the OLD declared window admits; outside denies") {
-    val pol = Some(
-      FiberPolicy(compatibleWith = Some(VersionRange(min = Some(SemVer(2, 0, 0)), max = Some(SemVer(3, 0, 0)))))
-    )
+    val pol =
+      FiberPolicy.constrained(compatibleWith =
+        Some(VersionRange(min = Some(SemVer(2, 0, 0)), max = Some(SemVer(3, 0, 0))))
+      )
     val old = smRecord(pol)
     val inside = UpgradeGate.check(old, baseDef.copy(policy = pol), binding(SemVer(2, 5, 0)), stateOf(old), Set(alice))
     val below = UpgradeGate.check(old, baseDef.copy(policy = pol), binding(SemVer(1, 9, 0)), stateOf(old), Set(alice))
@@ -298,10 +302,17 @@ object UpgradeGateSuite extends FunSuite {
   // ── tighten-only (also enforced inside the gate) ─────────────────────────────────────────────────
 
   test("gate rejects a loosening migration via the tighten lattice") {
-    val oldPol = Some(FiberPolicy(allowedEffects = Some(Set(EffectKind.Emit))))
+    val oldPol = FiberPolicy.constrained(allowedEffects = Some(Set(EffectKind.Emit)))
     val old = smRecord(oldPol)
-    // new drops allowedEffects ⇒ loosening
-    val r = UpgradeGate.check(old, baseDef.copy(policy = None), binding(SemVer(2, 0, 0)), stateOf(old), Set(alice))
+    // new drops allowedEffects (⇒ Unconstrained) ⇒ loosening
+    val r =
+      UpgradeGate.check(
+        old,
+        baseDef.copy(policy = FiberPolicy.Unconstrained),
+        binding(SemVer(2, 0, 0)),
+        stateOf(old),
+        Set(alice)
+      )
     expect(isPolicyViolation(r, "tighten"))
   }
 }


### PR DESCRIPTION
Replaces `StateMachineDefinition.policy: Option[FiberPolicy]` (and its hand-rolled normalize codec) with a required, **named ADT** — and serializes the default to **nothing** on the wire.

## What
- `sealed trait FiberPolicy { case object Unconstrained; final case class Constrained(<the existing 14 dials, unchanged>) }`; field `policy: FiberPolicy = FiberPolicy.Unconstrained`.
- Smart constructor `FiberPolicy.constrained(...)` collapses an all-empty `Constrained` → `Unconstrained` (one canonical "unconstrained"); the decoder routes through it. `dials: Option[Constrained]` keeps consumer call sites readable.
- `tightens(FiberPolicy, FiberPolicy)`: `Unconstrained` is the lattice **bottom** (loosest); `Constrained→Constrained` is the existing per-dial order, preserved verbatim; `Constrained→Unconstrained` loosens → rejected (names the first dial).
- Extensible to named presets later (e.g. `Immutable`) as companion factories that build a `Constrained`, or promoted to first-class case-object variants — the binary is the foundation either way.

## The wire form (the load-bearing decision)
The named variant lives in **code, not the bytes**. A small custom codec (the same pattern `UpgradePolicy`/`MigrationAuthority` already use) encodes **`Unconstrained → null`**, which the canonical/signing path's `dropNulls` strips — so an unconstrained definition carries **no `policy` key at all**. No empty objects, no sentinel. `Constrained` encodes as its bare dials object.

`Absence == Unconstrained` — exactly what every pre-policy / e2e / SDK payload already produces, so **client↔chain byte-parity is free**:
- The two signing-canonical guards (`E2eSignedPayloadCompatSuite` — uses the real `e2e-test/examples/*/definition.json` files and mirrors the SDK `batchSign(dropNulls)` path — and `PublishVersionSigningCanonicalSuite`) pass with **zero e2e/SDK changes**.
- **The SDK needs no change for parity** (no FiberPolicy/`policy` field in `ottochain-sdk` `records.ts` or `src`). A companion SDK PR adds an opt-in builder so external clients can *set* a `Constrained` policy.

## Verification
- `sbt sharedData/test` → **563 / 563 green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)