### PR TITLE
test(e2e): raise sigma-mixer lane concurrency to 2 (gas-heavy stress)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -56,7 +56,11 @@ jobs:
           #     submit-window removed, sigma 1 reject) and runs its flows serially (concurrency 1).
           - name: sigma-mixer
             filter: '--only sigma-mixer'
-            concurrency: '1'
+            # Raised 1->2: the "concurrency>1 chokes DL1 (candidates=Set() stall)" hazard noted above
+            # IS the idle deadlock the chain keepalive now prevents. sigma_verify is the gas-heavy
+            # combine, so this is the real stress test of whether the keepalive holds the chain fed
+            # under gas pressure at concurrency. Revert to 1 if it regresses.
+            concurrency: '2'
             ordinalThreshold: '10'
             maxResubmits: '4'
             timeout: 25


### PR DESCRIPTION
The remaining rigor lever. `sigma_verify` is the gas-heavy combine whose mempool flood was the original *"concurrency>1 chokes DL1 (candidates=Set() stall)"* hazard — i.e. the idle deadlock the chain keepalive now prevents. This bumps the sigma-mixer lane `1 → 2` to stress-test whether the keepalive holds the chain fed under gas pressure at concurrency.

This is an **experiment** — it never got a CI run before (the original push landed on a branch with no PR). If the e2e regresses, revert to 1; if it holds, sigma joins rule110 at >1.

Single-line change; the other four lanes are unaffected (automatic regression check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)