### PR TITLE
feat(e2e): readable economy run + live consuming morphisms

### DIFF
--- a/e2e-test/examples/riverdale-economy/README.md
+++ b/e2e-test/examples/riverdale-economy/README.md
@@ -56,6 +56,19 @@ RVD_REPAY) → **P9 fed upgrade** v1→v2 + v2-only `emergency_lending` → **P1
 spawns a child auction at `AUCTION_CHILD_ID`; bob bids + accepts; `sale_completed` loops back to the
 consumer) → **P12 wallet morphism** (mint RVD into dave's wallet, then `STAKE` it).
 
+### Reading the run (observability steps)
+
+Each phase opens with a `phase` banner (`── P5  lending ───`) and closes with an `economy` snapshot —
+both are **poll-only, no-tx** steps the runner treats as early-continue no-ops, so they never affect
+pass/fail. The `economy` step reads the ML0 `/checkpoint` ONCE and prints a compact per-party table
+(fiber `currentState` + a few `show` stateData fields + the asset instances each party/wallet holds),
+rendering **deltas** against the previous snapshot — e.g. `inventory 1000→500`, `+GOODS×500` (acquired),
+`RVD-loan 10000→0` (departed). `assertState`/`assertAsset` print what they observed
+(`assertState retailer → received (seq 1)`, `assertAsset GOODS → Fiber(retailer) ×500`) instead of a
+bare `OK`. Run a single example locally and it defaults to **concurrency 1 with live (write-through)
+output** — the flow streams as it happens instead of dumping at the end; the keepalive + per-send `[dl1]`
+lines are silenced by default (set `E2E_VERBOSE=1` to restore them).
+
 ### Wallet-morphism coverage + the runner limitation (read this)
 
 The runner confirms an `applyMorphism` step by polling the **source** asset's `state-proof` for a

--- a/e2e-test/examples/riverdale-economy/example.ts
+++ b/e2e-test/examples/riverdale-economy/example.ts
@@ -56,6 +56,42 @@ import {
 const RETAILER_PKG = 'retailer.machine';
 const FED_PKG = 'fed.machine';
 
+// ── Observability scaffolding (poll-only `phase` banners + `economy` snapshot tables) ──────────────
+// These steps send NO transactions: `phase` prints a section banner; `economy` reads the ML0
+// checkpoint ONCE and prints a compact per-party table (state + a few stateData fields + held assets),
+// rendering deltas against the previous `economy` step. They make the economy VISIBLE as it moves,
+// without changing any functional/assert step. (The runner handles both as early-continue no-ops.)
+
+type EconParty = { fiber?: string; wallet?: string; label: string; show: string[] };
+
+/** asset-id → friendly label for the economy table's `×amount` cells. */
+const ECON_ASSETS = [
+  { id: GOODS_ASSET_ID, label: 'GOODS' },
+  { id: RVD_LOAN_ID, label: 'RVD-loan' },
+  { id: RVD_PAY_ID, label: 'RVD-pay' },
+  { id: RVD_REPAY_ID, label: 'RVD-repay' },
+  { id: RVD_TAX_ID, label: 'RVD-tax' },
+  { id: RVD_STAKE_ID, label: 'RVD-stake' },
+];
+
+/** The six party fibers + the two demo wallets, each with the few stateData fields worth watching. */
+const ECON_PARTIES: EconParty[] = [
+  { fiber: 'manufacturer', label: 'manufacturer', show: ['inventory', 'taxesPaid'] },
+  { fiber: 'retailer', label: 'retailer', show: ['revenue', 'loyaltyPoints', 'taxesPaid'] },
+  { fiber: 'consumer', label: 'consumer', show: ['balance', 'purchaseCount'] },
+  { fiber: 'bank', label: 'bank', show: ['loanPortfolio'] },
+  { fiber: 'fed', label: 'fed', show: ['baseRate'] },
+  { fiber: 'gov', label: 'gov', show: ['totalTaxesCollected'] },
+  // Wallet parties only render once they actually hold an instance (the table skips empty rows).
+  { wallet: 'carol', label: 'carol·wallet', show: [] },
+  { wallet: 'dave', label: 'dave·wallet', show: [] },
+];
+
+/** A `phase` banner step. */
+const phase = (label: string) => ({ action: 'phase', label });
+/** An `economy` snapshot step (all parties + assets; an optional sub-label tags the moment). */
+const economy = (label?: string) => ({ action: 'economy', label, parties: ECON_PARTIES, assets: ECON_ASSETS });
+
 export default {
   name: 'Riverdale Economy',
   description:
@@ -68,6 +104,7 @@ export default {
         'Genesis (asset policies + retailer.machine v1/v2 + fed.machine v1/v2) → create the 6 party fibers → mint GOODS + the four RVD payment-leg instances → supply chain → monetary policy → lending → commerce → retailer upgrade → loan servicing → fed upgrade → tax sweep → spawned auction → a wallet STAKE morphism.',
       steps: [
         // ── P0 genesis: asset policies + the two versioned state-machine packages ──
+        phase('P0  genesis · policies + versioned packages'),
         { action: 'createAssetPolicy', name: 'goods.asset', policy: 'goods-policy.json', signers: ['alice'] },
         { action: 'createAssetPolicy', name: 'rvd.asset', policy: 'rvd-policy.json', signers: ['alice'] },
         { action: 'publishVersion', name: RETAILER_PKG, version: '1.0.0', definition: 'retailer-v1.definition.json', schemaShape: 'retailer-v1.schema.json', signers: ['bob'] },
@@ -76,86 +113,110 @@ export default {
         { action: 'publishVersion', name: FED_PKG, version: '2.0.0', definition: 'fed-v2.definition.json', schemaShape: 'fed-v2.schema.json', signers: ['erin'] },
 
         // ── P1 create the six party fibers (signers ⇒ owners). retailer + fed are verified-bound. ──
+        phase('P1  create the six party fibers'),
         { action: 'create', as: 'manufacturer', definition: 'manufacturer.definition.json', initialData: 'manufacturer.initial.json', signers: ['alice'] },
         { action: 'create', as: 'retailer', definition: 'retailer-v1.definition.json', initialData: 'retailer.initial.json', schemaRef: { name: RETAILER_PKG, version: '1.0.0' }, signers: ['bob'] },
         { action: 'create', as: 'consumer', definition: 'consumer.definition.json', initialData: 'consumer.initial.json', signers: ['carol'] },
         { action: 'create', as: 'bank', definition: 'bank.definition.json', initialData: 'bank.initial.json', signers: ['dave'] },
         { action: 'create', as: 'fed', definition: 'fed-v1.definition.json', initialData: 'fed.initial.json', schemaRef: { name: FED_PKG, version: '1.0.0' }, signers: ['erin'] },
         { action: 'create', as: 'gov', definition: 'gov.definition.json', initialData: 'gov.initial.json', signers: ['frank'] },
+        economy('after genesis'),
 
         // ── P2 mint the real assets: GOODS into the manufacturer, the four RVD legs into their spenders ──
+        phase('P2  mint GOODS + the four RVD payment legs'),
         { action: 'mintAsset', mint: 'mint-goods.ts', signers: ['alice'] },
-        { action: 'assertAsset', assetId: GOODS_ASSET_ID, expectedHolder: { Fiber: 'manufacturer' }, expectedAmount: 500 },
+        { action: 'assertAsset', assetId: GOODS_ASSET_ID, label: 'GOODS', expectedHolder: { Fiber: 'manufacturer' }, expectedAmount: 500 },
         { action: 'mintAsset', mint: 'mint-rvd.ts', eventData: { assetId: RVD_LOAN_ID, holderFiber: 'bank', amount: 10000 }, signers: ['alice'] },
-        { action: 'assertAsset', assetId: RVD_LOAN_ID, expectedHolder: { Fiber: 'bank' }, expectedAmount: 10000 },
+        { action: 'assertAsset', assetId: RVD_LOAN_ID, label: 'RVD-loan', expectedHolder: { Fiber: 'bank' }, expectedAmount: 10000 },
         { action: 'mintAsset', mint: 'mint-rvd.ts', eventData: { assetId: RVD_PAY_ID, holderFiber: 'consumer', amount: 500 }, signers: ['alice'] },
         { action: 'mintAsset', mint: 'mint-rvd.ts', eventData: { assetId: RVD_REPAY_ID, holderFiber: 'consumer', amount: 300 }, signers: ['alice'] },
         { action: 'mintAsset', mint: 'mint-rvd.ts', eventData: { assetId: RVD_TAX_ID, holderFiber: 'consumer', amount: 50 }, signers: ['alice'] },
-        { action: 'assertAsset', assetId: RVD_PAY_ID, expectedHolder: { Fiber: 'consumer' }, expectedAmount: 500 },
-        { action: 'assertAsset', assetId: RVD_TAX_ID, expectedHolder: { Fiber: 'consumer' }, expectedAmount: 50 },
+        { action: 'assertAsset', assetId: RVD_PAY_ID, label: 'RVD-pay', expectedHolder: { Fiber: 'consumer' }, expectedAmount: 500 },
+        { action: 'assertAsset', assetId: RVD_TAX_ID, label: 'RVD-tax', expectedHolder: { Fiber: 'consumer' }, expectedAmount: 50 },
+        economy('after mint'),
 
         // ── P3 SUPPLY: manufacturer.fulfill_order ⇒ triggers retailer.receive_shipment + moves GOODS custody ──
+        phase('P3  supply chain'),
         { action: 'processEvent', fiber: 'manufacturer', event: 'event-fulfill-order.ts', signers: ['alice'], expectedState: 'shipped' },
         { action: 'assertState', fiber: 'retailer', expectedState: 'received', minSequenceNumber: 1 },
-        { action: 'assertAsset', assetId: GOODS_ASSET_ID, expectedHolder: { Fiber: 'retailer' }, expectedAmount: 500, minSequenceNumber: 1 },
+        { action: 'assertAsset', assetId: GOODS_ASSET_ID, label: 'GOODS', expectedHolder: { Fiber: 'retailer' }, expectedAmount: 500, minSequenceNumber: 1 },
+        economy(),
 
         // ── P4 MONETARY: fed.set_rate ⇒ triggers bank.rate_adjustment (rate propagates cross-fiber) ──
+        phase('P4  monetary policy'),
         { action: 'processEvent', fiber: 'fed', event: 'event-set-rate.ts', signers: ['erin'], expectedState: 'stable' },
         { action: 'assertState', fiber: 'bank', expectedState: 'operating', minSequenceNumber: 1 },
+        economy(),
 
         // ── P5 LENDING: bank.underwrite ⇒ triggers consumer.loan_funded + transfers RVD_LOAN bank→consumer ──
+        phase('P5  lending'),
         { action: 'processEvent', fiber: 'bank', event: 'event-underwrite.ts', signers: ['dave'], expectedState: 'loan_servicing' },
         { action: 'assertState', fiber: 'consumer', expectedState: 'debt_current', minSequenceNumber: 1 },
-        { action: 'assertAsset', assetId: RVD_LOAN_ID, expectedHolder: { Fiber: 'consumer' }, expectedAmount: 10000, minSequenceNumber: 1 },
+        { action: 'assertAsset', assetId: RVD_LOAN_ID, label: 'RVD-loan', expectedHolder: { Fiber: 'consumer' }, expectedAmount: 10000, minSequenceNumber: 1 },
+        economy(),
 
         // ── P6 COMMERCE: consumer.buy ⇒ triggers retailer.process_sale; RVD_PAY consumer→retailer, GOODS retailer→consumer ──
+        phase('P6  commerce'),
         { action: 'processEvent', fiber: 'consumer', event: 'event-buy.ts', signers: ['carol'], expectedState: 'debt_current' },
         { action: 'assertState', fiber: 'retailer', expectedState: 'received', minSequenceNumber: 2 },
-        { action: 'assertAsset', assetId: RVD_PAY_ID, expectedHolder: { Fiber: 'retailer' }, expectedAmount: 500, minSequenceNumber: 1 },
-        { action: 'assertAsset', assetId: GOODS_ASSET_ID, expectedHolder: { Fiber: 'consumer' }, expectedAmount: 500, minSequenceNumber: 2 },
+        { action: 'assertAsset', assetId: RVD_PAY_ID, label: 'RVD-pay', expectedHolder: { Fiber: 'retailer' }, expectedAmount: 500, minSequenceNumber: 1 },
+        { action: 'assertAsset', assetId: GOODS_ASSET_ID, label: 'GOODS', expectedHolder: { Fiber: 'consumer' }, expectedAmount: 500, minSequenceNumber: 2 },
+        economy(),
 
         // ── P7 UPGRADE retailer v1→v2 (migration adds loyaltyPoints) + a v2-only redeem_loyalty ──
+        phase('P7  retailer upgrade v1→v2'),
         { action: 'upgradeFiber', fiber: 'retailer', targetRef: { name: RETAILER_PKG, version: '2.0.0' }, newDefinition: 'retailer-v2.definition.json', migration: 'retailer-migration.json', signers: ['bob'] },
         { action: 'assertState', fiber: 'retailer', expectedState: 'received', minSequenceNumber: 3 },
         { action: 'processEvent', fiber: 'retailer', event: 'event-redeem-loyalty.ts', signers: ['bob'], expectedState: 'received' },
         { action: 'assertState', fiber: 'retailer', expectedState: 'received', minSequenceNumber: 4 },
+        economy(),
 
         // ── P8 SERVICING: consumer.make_payment ⇒ triggers bank.payment_received + transfers RVD_REPAY consumer→bank ──
+        phase('P8  loan servicing'),
         { action: 'processEvent', fiber: 'consumer', event: 'event-make-payment.ts', signers: ['carol'], expectedState: 'debt_current' },
         { action: 'assertState', fiber: 'bank', expectedState: 'loan_servicing', minSequenceNumber: 3 },
-        { action: 'assertAsset', assetId: RVD_REPAY_ID, expectedHolder: { Fiber: 'bank' }, expectedAmount: 300, minSequenceNumber: 1 },
+        { action: 'assertAsset', assetId: RVD_REPAY_ID, label: 'RVD-repay', expectedHolder: { Fiber: 'bank' }, expectedAmount: 300, minSequenceNumber: 1 },
+        economy(),
 
         // ── P9 UPGRADE fed v1→v2 (migration adds emergencyLoans) + a v2-only emergency_lending ──
+        phase('P9  fed upgrade v1→v2'),
         { action: 'upgradeFiber', fiber: 'fed', targetRef: { name: FED_PKG, version: '2.0.0' }, newDefinition: 'fed-v2.definition.json', migration: 'fed-migration.json', signers: ['erin'] },
         { action: 'assertState', fiber: 'fed', expectedState: 'stable', minSequenceNumber: 2 },
         { action: 'processEvent', fiber: 'fed', event: 'event-emergency-lending.ts', signers: ['erin'], expectedState: 'emergency_lending' },
         { action: 'assertState', fiber: 'fed', expectedState: 'emergency_lending', minSequenceNumber: 3 },
+        economy(),
 
         // ── P10 TAX SWEEP (broadcast): gov.collect_taxes ⇒ triggers pay_taxes on manufacturer/retailer/consumer; consumer also transfers RVD_TAX consumer→gov ──
+        phase('P10  tax sweep'),
         { action: 'processEvent', fiber: 'gov', event: 'event-collect-taxes.ts', signers: ['frank'], expectedState: 'tax_collection' },
         { action: 'assertState', fiber: 'gov', expectedState: 'tax_collection', minSequenceNumber: 1, expectedStateData: { totalTaxesCollected: 50, taxpayersBilled: 3, status: 'tax_collection' } },
         { action: 'assertState', fiber: 'manufacturer', expectedState: 'shipped', minSequenceNumber: 2, expectedStateData: { inventory: 500, taxesPaid: 50, status: 'shipped' } },
         { action: 'assertState', fiber: 'retailer', expectedState: 'received', minSequenceNumber: 5 },
         { action: 'assertState', fiber: 'consumer', expectedState: 'debt_current', minSequenceNumber: 4 },
-        { action: 'assertAsset', assetId: RVD_TAX_ID, expectedHolder: { Fiber: 'gov' }, expectedAmount: 50, minSequenceNumber: 1 },
+        { action: 'assertAsset', assetId: RVD_TAX_ID, label: 'RVD-tax', expectedHolder: { Fiber: 'gov' }, expectedAmount: 50, minSequenceNumber: 1 },
+        economy(),
 
         // ── P11 AUCTION (spawn): consumer.list_item spawns the child auction; bob bids + accepts; sale_completed loops back to the consumer ──
+        phase('P11  spawned auction'),
         { action: 'processEvent', fiber: 'consumer', event: 'event-list-item.ts', signers: ['carol'], expectedState: 'marketplace_selling' },
         { action: 'assertState', fiber: AUCTION_CHILD_ID, expectedState: 'listed' },
         { action: 'processEvent', fiber: AUCTION_CHILD_ID, event: 'event-place-bid.ts', signers: ['bob'], expectedState: 'bid_received' },
         { action: 'processEvent', fiber: AUCTION_CHILD_ID, event: 'event-accept-bid.ts', signers: ['bob'], expectedState: 'sold' },
         { action: 'assertState', fiber: AUCTION_CHILD_ID, expectedState: 'sold', minSequenceNumber: 2 },
         { action: 'assertState', fiber: 'consumer', expectedState: 'debt_current', minSequenceNumber: 6 },
+        economy(),
 
         // ── P12 WALLET MORPHISM: mint RVD into dave's WALLET, then STAKE it (R1: signer == holder) ──
+        phase('P12  wallet stake'),
         // STAKE is non-consuming (codomain E:=1, bumps the seq, the record + holder + amount survive), so
         // the runner's `applyMorphism` source-seq-advance confirm observes it. Re-enabled now that the runner
         // gates on the mint's `assetCommit` reaching every DL1 node before the morphism (waitForDl1AssetSync)
         // — without that the morphism raced DL1's OnChain.assetCommits and was structurally rejected (400).
         { action: 'mintAsset', mint: 'mint-rvd.ts', eventData: { assetId: RVD_STAKE_ID, holderWallet: 'dave', amount: 200 }, signers: ['alice'] },
-        { action: 'assertAsset', assetId: RVD_STAKE_ID, expectedHolder: { Wallet: 'dave' }, expectedAmount: 200 },
+        { action: 'assertAsset', assetId: RVD_STAKE_ID, label: 'RVD-stake', expectedHolder: { Wallet: 'dave' }, expectedAmount: 200 },
         { action: 'applyMorphism', morphism: 'stake-rvd.ts', signers: ['dave'] },
-        { action: 'assertAsset', assetId: RVD_STAKE_ID, expectedHolder: { Wallet: 'dave' }, expectedAmount: 200, minSequenceNumber: 1 },
+        { action: 'assertAsset', assetId: RVD_STAKE_ID, label: 'RVD-stake', expectedHolder: { Wallet: 'dave' }, expectedAmount: 200, minSequenceNumber: 1 },
+        economy('final · staked'),
 
         // ── STILL DEFERRED: FRACTIONALIZE + BURN (CONSUMING — they REMOVE the source record) ──
         // The runner confirms `applyMorphism` via a SOURCE-seq advance, which a consuming morphism can never
@@ -170,16 +231,19 @@ export default {
         'Own fibers/policies/packages (disjoint from flow 1). Each rejection is admitted by DL1 (structurally valid) then DENIED at ML0 combine — the fiber/asset/registry never changes: replay/seq-regression, mint-over-cap, non-monotonic publish. (NOTE: a "wrong-party transition" is intentionally NOT a case here — the first CI run confirmed a primary state-machine transition is NOT owner-gated; the guard is the gate. Ownership gates registry ops, script callers, asset holders (R1), and spawned children — those are the real wrong-party surfaces.)',
       steps: [
         // ── replay / seq-regression: re-submitting a one-way transition after the fiber moved on (NoTransitionForEvent) ──
+        phase('N1  replay / seq-regression (ML0 reject)'),
         { action: 'create', as: 'negReplay', definition: 'neg.definition.json', initialData: 'neg.initial.json', signers: ['alice'] },
         { action: 'processEvent', fiber: 'negReplay', event: 'event-advance.ts', signers: ['alice'], expectedState: 's1' },
         { action: 'processEvent', fiber: 'negReplay', event: 'event-advance.ts', signers: ['alice'], expectRejected: 'ml0' },
 
         // ── mint-over-cap: a capped policy (maxSupply 100); the first mint fits, the second pushes derived supply over ──
+        phase('N2  mint-over-cap (ML0 reject)'),
         { action: 'createAssetPolicy', name: 'capped.asset', policy: 'capped-policy.json', signers: ['alice'] },
         { action: 'mintAsset', mint: 'mint-rvd.ts', eventData: { assetId: CAPPED_A_ID, holderWallet: 'alice', amount: 50, policyName: 'capped.asset' }, signers: ['alice'] },
         { action: 'mintAsset', mint: 'mint-rvd.ts', eventData: { assetId: CAPPED_B_ID, holderWallet: 'alice', amount: 60, policyName: 'capped.asset' }, signers: ['alice'], expectRejected: 'ml0' },
 
         // ── non-monotonic publish: publish a HIGHER version then a LOWER one (the LOWER is not in the lineage, so "did not land" is observable) ──
+        phase('N3  non-monotonic publish (ML0 reject)'),
         { action: 'publishVersion', name: 'negtest.machine', version: '2.0.0', definition: 'neg.definition.json', schemaShape: 'retailer-v1.schema.json', signers: ['alice'] },
         { action: 'publishVersion', name: 'negtest.machine', version: '1.0.0', definition: 'neg.definition.json', schemaShape: 'retailer-v1.schema.json', signers: ['alice'], expectRejected: 'ml0' },
       ],

--- a/e2e-test/examples/riverdale-economy/example.ts
+++ b/e2e-test/examples/riverdale-economy/example.ts
@@ -22,11 +22,10 @@
  *      RVD_TAX   → consumer fiber (consumer remits to the gov via `pay_taxes`)
  *    Minting INTO a Fiber holder is allowed (AssetCombiner.mintAsset).
  *  • Wallet-context morphisms (P12) are SEPARATE from the custody flow and run in WALLET context, where R1
- *    requires `signer == holder`. STAKE is demonstrated live (it bumps the asset's seq + keeps the record,
- *    so the runner's `applyMorphism` confirmation can observe it). FRACTIONALIZE + BURN are CONSUMING/
- *    terminal morphisms — they REMOVE the source record, which the runner's seq-advance confirmation
- *    cannot observe — so they ship as ready body files (fractionalize-rvd.ts / burn-rvd.ts) + ids and are
- *    documented as deferred below (see the P12 note). The rvd policy already permits all four.
+ *    requires `signer == holder`. All three wallet-context morphisms run LIVE: STAKE (non-consuming —
+ *    bumps the seq, the record survives), FRACTIONALIZE (consuming — removes the source + writes shards;
+ *    the runner confirms it via the first shard's EXISTENCE), and BURN (terminal — removes the record;
+ *    the runner confirms it via the source's ABSENCE). The rvd policy permits all four morphisms.
  *
  * ── On-wire shapes (verified against the chain sources) ───────────────────────────────────────────────
  *  • `_transferAsset` recipient is a BARE STRING; a UUID-shaped string → AssetHolder.Fiber, a DAG address →
@@ -48,6 +47,11 @@ import {
   RVD_REPAY_ID,
   RVD_TAX_ID,
   RVD_STAKE_ID,
+  RVD_FRAC_ID,
+  RVD_FRAC_A_ID,
+  RVD_FRAC_B_ID,
+  RVD_FRAC_C_ID,
+  RVD_BURN_ID,
   AUCTION_CHILD_ID,
   CAPPED_A_ID,
   CAPPED_B_ID,
@@ -72,6 +76,11 @@ const ECON_ASSETS = [
   { id: RVD_REPAY_ID, label: 'RVD-repay' },
   { id: RVD_TAX_ID, label: 'RVD-tax' },
   { id: RVD_STAKE_ID, label: 'RVD-stake' },
+  { id: RVD_FRAC_ID, label: 'RVD-frac' },
+  { id: RVD_FRAC_A_ID, label: 'RVD-fracA' },
+  { id: RVD_FRAC_B_ID, label: 'RVD-fracB' },
+  { id: RVD_FRAC_C_ID, label: 'RVD-fracC' },
+  { id: RVD_BURN_ID, label: 'RVD-burn' },
 ];
 
 /** The six party fibers + the two demo wallets, each with the few stateData fields worth watching. */
@@ -101,7 +110,7 @@ export default {
     {
       name: 'full economy: monetary policy → lending → commerce → servicing → tax sweep → auction',
       description:
-        'Genesis (asset policies + retailer.machine v1/v2 + fed.machine v1/v2) → create the 6 party fibers → mint GOODS + the four RVD payment-leg instances → supply chain → monetary policy → lending → commerce → retailer upgrade → loan servicing → fed upgrade → tax sweep → spawned auction → a wallet STAKE morphism.',
+        'Genesis (asset policies + retailer.machine v1/v2 + fed.machine v1/v2) → create the 6 party fibers → mint GOODS + the four RVD payment-leg instances → supply chain → monetary policy → lending → commerce → retailer upgrade → loan servicing → fed upgrade → tax sweep → spawned auction → wallet STAKE / FRACTIONALIZE / BURN morphisms.',
       steps: [
         // ── P0 genesis: asset policies + the two versioned state-machine packages ──
         phase('P0  genesis · policies + versioned packages'),
@@ -218,11 +227,27 @@ export default {
         { action: 'assertAsset', assetId: RVD_STAKE_ID, label: 'RVD-stake', expectedHolder: { Wallet: 'dave' }, expectedAmount: 200, minSequenceNumber: 1 },
         economy('final · staked'),
 
-        // ── STILL DEFERRED: FRACTIONALIZE + BURN (CONSUMING — they REMOVE the source record) ──
-        // The runner confirms `applyMorphism` via a SOURCE-seq advance, which a consuming morphism can never
-        // satisfy. Lighting them up needs a terminal/consuming confirm mode (Fractionalize via output-shard
-        // existence, Burn via source absence). Body files (fractionalize-rvd.ts / burn-rvd.ts) + ids + the
-        // rvd policy's morphism declarations are all shipped; this is the remaining morphism fast-follow.
+        // ── P12b FRACTIONALIZE: mint RVD into carol's WALLET, split it into 3 shards (CONSUMING) ──
+        // Fractionalize REMOVES the source + writes one shard per shardId (combinable:=false, amount
+        // partitioned 900→3×300). The runner confirms this consuming morphism via the first shard's existence.
+        phase('P12b  wallet fractionalize'),
+        { action: 'mintAsset', mint: 'mint-rvd.ts', eventData: { assetId: RVD_FRAC_ID, holderWallet: 'carol', amount: 900 }, signers: ['alice'] },
+        { action: 'assertAsset', assetId: RVD_FRAC_ID, label: 'RVD-frac', expectedHolder: { Wallet: 'carol' }, expectedAmount: 900 },
+        { action: 'applyMorphism', morphism: 'fractionalize-rvd.ts', signers: ['carol'] },
+        { action: 'assertAsset', assetId: RVD_FRAC_A_ID, label: 'RVD-fracA', expectedHolder: { Wallet: 'carol' }, expectedAmount: 300 },
+        { action: 'assertAsset', assetId: RVD_FRAC_B_ID, label: 'RVD-fracB', expectedHolder: { Wallet: 'carol' }, expectedAmount: 300 },
+        { action: 'assertAsset', assetId: RVD_FRAC_C_ID, label: 'RVD-fracC', expectedHolder: { Wallet: 'carol' }, expectedAmount: 300 },
+        economy('final · fractionalized'),
+
+        // ── P12c BURN: mint RVD into frank's WALLET, then burn it (CONSUMING / terminal) ──
+        // Burn evaluates the policy burnPolicy then REMOVES the record. The runner confirms it via the
+        // source's ABSENCE (exists→404). No post-assert — a burned record is gone (absence isn't assertable);
+        // the economy snapshot shows frank's RVD-burn simply disappear.
+        phase('P12c  wallet burn'),
+        { action: 'mintAsset', mint: 'mint-rvd.ts', eventData: { assetId: RVD_BURN_ID, holderWallet: 'frank', amount: 200 }, signers: ['alice'] },
+        { action: 'assertAsset', assetId: RVD_BURN_ID, label: 'RVD-burn', expectedHolder: { Wallet: 'frank' }, expectedAmount: 200 },
+        { action: 'applyMorphism', morphism: 'burn-rvd.ts', signers: ['frank'] },
+        economy('final · burned'),
       ],
     },
     {

--- a/e2e-test/examples/riverdale-economy/example.ts
+++ b/e2e-test/examples/riverdale-economy/example.ts
@@ -113,33 +113,49 @@ export default {
         'Genesis (asset policies + retailer.machine v1/v2 + fed.machine v1/v2) → create the 6 party fibers → mint GOODS + the four RVD payment-leg instances → supply chain → monetary policy → lending → commerce → retailer upgrade → loan servicing → fed upgrade → tax sweep → spawned auction → wallet STAKE / FRACTIONALIZE / BURN morphisms.',
       steps: [
         // ── P0 genesis: asset policies + the two versioned state-machine packages ──
+        // PARALLEL batch (3): the two asset-policy creates + retailer.machine@1.0.0 are three DISTINCT
+        // registry names with no shared lineage, so they publish concurrently. The `2.0.0` publishes
+        // (and fed@1.0.0, which is not contiguous) stay SEQUENTIAL: a version lineage is monotonic
+        // append-only (VersionLineage.publish rejects a version ≤ the current head with NonMonotonic —
+        // see the N3 negative test), so racing `1.0.0`/`2.0.0` of the SAME package could land `2.0.0`
+        // first and get `1.0.0` rejected. So a package's later versions only publish after the prior
+        // version has confirmed.
         phase('P0  genesis · policies + versioned packages'),
-        { action: 'createAssetPolicy', name: 'goods.asset', policy: 'goods-policy.json', signers: ['alice'] },
-        { action: 'createAssetPolicy', name: 'rvd.asset', policy: 'rvd-policy.json', signers: ['alice'] },
-        { action: 'publishVersion', name: RETAILER_PKG, version: '1.0.0', definition: 'retailer-v1.definition.json', schemaShape: 'retailer-v1.schema.json', signers: ['bob'] },
+        { action: 'createAssetPolicy', name: 'goods.asset', policy: 'goods-policy.json', signers: ['alice'], parallel: true },
+        { action: 'createAssetPolicy', name: 'rvd.asset', policy: 'rvd-policy.json', signers: ['alice'], parallel: true },
+        { action: 'publishVersion', name: RETAILER_PKG, version: '1.0.0', definition: 'retailer-v1.definition.json', schemaShape: 'retailer-v1.schema.json', signers: ['bob'], parallel: true },
         { action: 'publishVersion', name: RETAILER_PKG, version: '2.0.0', definition: 'retailer-v2.definition.json', schemaShape: 'retailer-v2.schema.json', signers: ['bob'] },
         { action: 'publishVersion', name: FED_PKG, version: '1.0.0', definition: 'fed-v1.definition.json', schemaShape: 'fed-v1.schema.json', signers: ['erin'] },
         { action: 'publishVersion', name: FED_PKG, version: '2.0.0', definition: 'fed-v2.definition.json', schemaShape: 'fed-v2.schema.json', signers: ['erin'] },
 
         // ── P1 create the six party fibers (signers ⇒ owners). retailer + fed are verified-bound. ──
+        // PARALLEL batch (6): each create mints its OWN `as` fiber (distinct alias ⇒ distinct
+        // session.fibers key, no shared-state race) and references nothing created in P1. The two
+        // verified-bound creates depend only on their P0 package version (already confirmed). The
+        // `economy` marker below is non-parallel and bounds the batch.
         phase('P1  create the six party fibers'),
-        { action: 'create', as: 'manufacturer', definition: 'manufacturer.definition.json', initialData: 'manufacturer.initial.json', signers: ['alice'] },
-        { action: 'create', as: 'retailer', definition: 'retailer-v1.definition.json', initialData: 'retailer.initial.json', schemaRef: { name: RETAILER_PKG, version: '1.0.0' }, signers: ['bob'] },
-        { action: 'create', as: 'consumer', definition: 'consumer.definition.json', initialData: 'consumer.initial.json', signers: ['carol'] },
-        { action: 'create', as: 'bank', definition: 'bank.definition.json', initialData: 'bank.initial.json', signers: ['dave'] },
-        { action: 'create', as: 'fed', definition: 'fed-v1.definition.json', initialData: 'fed.initial.json', schemaRef: { name: FED_PKG, version: '1.0.0' }, signers: ['erin'] },
-        { action: 'create', as: 'gov', definition: 'gov.definition.json', initialData: 'gov.initial.json', signers: ['frank'] },
+        { action: 'create', as: 'manufacturer', definition: 'manufacturer.definition.json', initialData: 'manufacturer.initial.json', signers: ['alice'], parallel: true },
+        { action: 'create', as: 'retailer', definition: 'retailer-v1.definition.json', initialData: 'retailer.initial.json', schemaRef: { name: RETAILER_PKG, version: '1.0.0' }, signers: ['bob'], parallel: true },
+        { action: 'create', as: 'consumer', definition: 'consumer.definition.json', initialData: 'consumer.initial.json', signers: ['carol'], parallel: true },
+        { action: 'create', as: 'bank', definition: 'bank.definition.json', initialData: 'bank.initial.json', signers: ['dave'], parallel: true },
+        { action: 'create', as: 'fed', definition: 'fed-v1.definition.json', initialData: 'fed.initial.json', schemaRef: { name: FED_PKG, version: '1.0.0' }, signers: ['erin'], parallel: true },
+        { action: 'create', as: 'gov', definition: 'gov.definition.json', initialData: 'gov.initial.json', signers: ['frank'], parallel: true },
         economy('after genesis'),
 
         // ── P2 mint the real assets: GOODS into the manufacturer, the four RVD legs into their spenders ──
+        // The mints depend on P1 (the holder fibers must exist) but NOT on each other (distinct
+        // assetIds ⇒ distinct asset-map keys; mint-into-fiber doesn't bump the fiber's seq). The three
+        // consumer-leg mints (RVD_PAY/REPAY/TAX) are contiguous, so they form one PARALLEL batch
+        // (bounded by the assertAsset before/after). GOODS + RVD_LOAN stay sequential — each is a
+        // singleton split off by its own assertAsset checkpoint, so there's nothing to batch them with.
         phase('P2  mint GOODS + the four RVD payment legs'),
         { action: 'mintAsset', mint: 'mint-goods.ts', signers: ['alice'] },
         { action: 'assertAsset', assetId: GOODS_ASSET_ID, label: 'GOODS', expectedHolder: { Fiber: 'manufacturer' }, expectedAmount: 500 },
         { action: 'mintAsset', mint: 'mint-rvd.ts', eventData: { assetId: RVD_LOAN_ID, holderFiber: 'bank', amount: 10000 }, signers: ['alice'] },
         { action: 'assertAsset', assetId: RVD_LOAN_ID, label: 'RVD-loan', expectedHolder: { Fiber: 'bank' }, expectedAmount: 10000 },
-        { action: 'mintAsset', mint: 'mint-rvd.ts', eventData: { assetId: RVD_PAY_ID, holderFiber: 'consumer', amount: 500 }, signers: ['alice'] },
-        { action: 'mintAsset', mint: 'mint-rvd.ts', eventData: { assetId: RVD_REPAY_ID, holderFiber: 'consumer', amount: 300 }, signers: ['alice'] },
-        { action: 'mintAsset', mint: 'mint-rvd.ts', eventData: { assetId: RVD_TAX_ID, holderFiber: 'consumer', amount: 50 }, signers: ['alice'] },
+        { action: 'mintAsset', mint: 'mint-rvd.ts', eventData: { assetId: RVD_PAY_ID, holderFiber: 'consumer', amount: 500 }, signers: ['alice'], parallel: true },
+        { action: 'mintAsset', mint: 'mint-rvd.ts', eventData: { assetId: RVD_REPAY_ID, holderFiber: 'consumer', amount: 300 }, signers: ['alice'], parallel: true },
+        { action: 'mintAsset', mint: 'mint-rvd.ts', eventData: { assetId: RVD_TAX_ID, holderFiber: 'consumer', amount: 50 }, signers: ['alice'], parallel: true },
         { action: 'assertAsset', assetId: RVD_PAY_ID, label: 'RVD-pay', expectedHolder: { Fiber: 'consumer' }, expectedAmount: 500 },
         { action: 'assertAsset', assetId: RVD_TAX_ID, label: 'RVD-tax', expectedHolder: { Fiber: 'consumer' }, expectedAmount: 50 },
         economy('after mint'),

--- a/e2e-test/lib/keepalive.ts
+++ b/e2e-test/lib/keepalive.ts
@@ -52,12 +52,17 @@ export class ChainKeepalive {
       const message = createFiber({ cid: crypto.randomUUID(), options: this.options });
       await sendSignedUpdate(message, this.wallets, this.dl1Urls, { quiet: true });
       this.ticks++;
+      // Quiet by default: the keepalive is pure background plumbing, so its per-tick chatter buries
+      // the flow output (50+ lines over a 20-min run). Gate ALL keepalive progress logs behind
+      // E2E_VERBOSE; the one-line stop() summary always prints so the run still reports it was fed.
       if (!this.confirmedAlive) {
         this.confirmedAlive = true;
-        console.log('\x1b[36m[keepalive]\x1b[0m feeding the chain — first novel update accepted');
+        if (process.env.E2E_VERBOSE) {
+          console.log('\x1b[36m[keepalive]\x1b[0m feeding the chain — first novel update accepted');
+        }
       }
-      // Heartbeat every ~30s so the run log shows the chain is being kept fed, without spamming.
-      if (this.ticks % 10 === 0) {
+      // Heartbeat every ~30s so a verbose run log shows the chain is being kept fed, without spamming.
+      if (process.env.E2E_VERBOSE && this.ticks % 10 === 0) {
         console.log(`\x1b[36m[keepalive]\x1b[0m ${this.ticks} updates sent (${this.errors} failed)`);
       }
     } catch {
@@ -71,7 +76,8 @@ export class ChainKeepalive {
     this.running = false;
     if (this.timer) clearTimeout(this.timer);
     this.timer = null;
-    console.log(`\x1b[36m[keepalive]\x1b[0m stopped — ${this.ticks} updates sent (${this.errors} failed)`);
+    const mode = process.env.E2E_VERBOSE ? 'verbose' : 'silent';
+    console.log(`\x1b[36m[keepalive]\x1b[0m ${mode} · ${this.ticks} sent, ${this.errors} failed`);
     return { ticks: this.ticks, errors: this.errors };
   }
 }

--- a/e2e-test/lib/sendDataTransaction.ts
+++ b/e2e-test/lib/sendDataTransaction.ts
@@ -7,11 +7,14 @@ const NODE_TIMEOUT_MS = Number(process.env.DL1_TIMEOUT_MS) || 30_000;
 
 /** One-line summary of an outbound update: its message type + a truncated target id. */
 function describeUpdate(message: unknown): string {
-  const value = (message as { value?: Record<string, unknown> } | null)?.value;
-  if (!value || typeof value !== 'object') return 'update';
-  const msgType = Object.keys(value)[0] ?? 'update';
-  const inner = value[msgType] as Record<string, unknown> | undefined;
-  const rawId = inner?.fiberId ?? inner?.machineId ?? inner?.name ?? '';
+  // The message handed to send is the UNWRAPPED generator output — a single-key envelope like
+  // `{ TransitionStateMachine: { fiberId, … } }` / `{ MintAsset: { assetId, … } }` — NOT a `{ value }`
+  // wrapper. Read the top-level key as the message type and dig the id out of its inner object.
+  if (!message || typeof message !== 'object') return 'update';
+  const msgType = Object.keys(message as Record<string, unknown>)[0];
+  if (!msgType) return 'update';
+  const inner = (message as Record<string, unknown>)[msgType] as Record<string, unknown> | undefined;
+  const rawId = inner?.fiberId ?? inner?.assetId ?? inner?.name ?? inner?.machineId ?? '';
   const id = typeof rawId === 'string' ? rawId : String(rawId ?? '');
   const shortId = id.length > 8 ? id.slice(0, 8) : id;
   return shortId ? `${msgType} ${shortId}` : msgType;
@@ -104,9 +107,13 @@ export default async function sendSignedUpdate(
     // Keepalive / background traffic: suppress the per-send line so ~hundreds of throwaway
     // creates don't bury the flow output. The outcome is still returned to the caller.
   } else if (consensus) {
-    console.log(
-      `${tag} ${what} → \x1b[32m${ok.length}/${dl1Urls.length}\x1b[0m ✓ ${[...hashes][0].slice(0, 8)}`
-    );
+    // Healthy 3/3 send: quiet by default (the flow logger already reports the step). The per-send
+    // `[dl1] … ✓` line is opt-in via E2E_VERBOSE; DIVERGENCE / failure below ALWAYS prints.
+    if (process.env.E2E_VERBOSE) {
+      console.log(
+        `${tag} ${what} → \x1b[32m${ok.length}/${dl1Urls.length}\x1b[0m ✓ ${[...hashes][0].slice(0, 8)}`
+      );
+    }
   } else {
     // Divergence: spell out each node so a split hash, a slow/timed-out node, or a lone rejecter is
     // visible rather than averaged away.

--- a/e2e-test/runner.ts
+++ b/e2e-test/runner.ts
@@ -547,6 +547,13 @@ interface TestStep {
   expectedResult?: unknown;
   /** Assert this step is REJECTED: 'dl1' (HTTP 400, structural) or 'ml0' (admitted then combine-denied). */
   expectRejected?: 'dl1' | 'ml0';
+  /**
+   * Run this step concurrently with adjacent `parallel: true` steps (a maximal consecutive run forms
+   * one batch). Use ONLY for steps with no inter-dependency (independent setup: registry publishes,
+   * fiber creates, independent mints). Omit ⇒ the step runs sequentially with byte-for-byte the same
+   * behavior as before. A non-parallel step (incl. `phase`/`economy` markers) bounds each batch.
+   */
+  parallel?: boolean;
 
   // ---- Multi-fiber / party / asset extensions (riverdale-economy) ----
   /** On a create step: name the new fiber so later steps can target it (`fiber: "<as>"`). */
@@ -661,25 +668,35 @@ async function runFlow(
   const resolveFiber = (alias?: string): string =>
     !alias ? session.cid : session.fibers[alias] ?? alias;
 
-  for (let i = 0; i < flow.steps.length; i++) {
-    const step = flow.steps[i];
+  // Tag for the per-step buffer loggers used by a `parallel` batch (mirror runOne's `${dir}/${name}`).
+  const tag = log?.tag ?? `${example.dir}/${flow.name}`;
 
+  // One step's full body, extracted so a `parallel` batch can run several of these concurrently.
+  // It writes via the injected `sw`/`sl` (the flow's live logger when sequential, a per-step buffer
+  // when batched) and threads `slog` into the confirmation helpers. It THROWS on failure — the
+  // caller (sequential try/catch, or the batch's Promise.allSettled) decides the flow's pass/fail.
+  const processStep = async (
+    step: TestStep,
+    i: number,
+    sw: (s: string) => void,
+    sl: (...a: unknown[]) => void,
+    slog: FlowLogger | undefined
+  ): Promise<void> => {
     // ---- Observability annotations (poll-only, no tx; rendered WITHOUT the "[Step N] action…"
     // prefix so they read as section banners / tables). `phase` is pure text; `economy` reads the
-    // ML0 checkpoint ONCE and prints a compact economy table. Both early-continue like assertState. ----
+    // ML0 checkpoint ONCE and prints a compact economy table. Both early-return like assertState. ----
     if (step.action === 'phase') {
-      l(phaseBanner(String(step.label ?? '')));
-      continue;
+      sl(phaseBanner(String(step.label ?? '')));
+      return;
     }
     if (step.action === 'economy') {
-      await renderEconomy(step, ml0Urls[0], wallets, resolveFiber, session.economy, l);
-      continue;
+      await renderEconomy(step, ml0Urls[0], wallets, resolveFiber, session.economy, sl);
+      return;
     }
 
     const stepLabel = `[Step ${i + 1}/${flow.steps.length}]`;
-    w(`  ${stepLabel} ${step.action}...`);
+    sw(`  ${stepLabel} ${step.action}...`);
 
-    try {
       let generator: GeneratorFn;
       let validator: ValidatorFn;
       let message: unknown;
@@ -696,7 +713,7 @@ async function runFlow(
       if (step.action === 'assertState') {
         const cid = resolveFiber(step.fiber);
         const who = step.fiber ?? cid.slice(0, 8);
-        w(`\n      ⏳ assertState ${who}`);
+        sw(`\n      ⏳ assertState ${who}`);
         const rec = await pollFiberRecord(
           ml0Urls[0],
           cid,
@@ -707,7 +724,7 @@ async function runFlow(
             (!step.expectedStateData || deepEqual(r.stateData, step.expectedStateData)),
           maxRetries,
           retryDelayMs,
-          (s) => w(s)
+          (s) => sw(s)
         );
         if (!rec) throw new Error(`assertState ${who}: fiber never reached the asserted condition at ML0`);
         if (step.expectedState && rec.currentState !== step.expectedState)
@@ -716,16 +733,16 @@ async function runFlow(
           throw new Error(`assertState ${who}: expected seq ≥ ${step.minSequenceNumber} but found ${rec.sequenceNumber}`);
         if (step.expectedStateData && !deepEqual(rec.stateData, step.expectedStateData))
           throw new Error(`assertState ${who}: stateData mismatch — got ${JSON.stringify(rec.stateData)} want ${JSON.stringify(step.expectedStateData)}`);
-        w(' ✓');
+        sw(' ✓');
         // Summarize what was observed (not a bare "OK") so the flow reads as a story.
-        l(` \x1b[32massertState ${who} → ${String(rec.currentState)}\x1b[0m (seq ${Number(rec.sequenceNumber)})`);
-        continue;
+        sl(` \x1b[32massertState ${who} → ${String(rec.currentState)}\x1b[0m (seq ${Number(rec.sequenceNumber)})`);
+        return;
       }
 
       if (step.action === 'assertAsset') {
         const assetId = step.assetId as string;
         if (!assetId) throw new Error('assertAsset requires an `assetId`');
-        w(`\n      ⏳ assertAsset ${assetId.slice(0, 8)}`);
+        sw(`\n      ⏳ assertAsset ${assetId.slice(0, 8)}`);
         const rec = await pollAssetRecord(
           ml0Urls[0],
           assetId,
@@ -736,14 +753,14 @@ async function runFlow(
             (step.minSequenceNumber == null || ((r.sequenceNumber as number) ?? -1) >= step.minSequenceNumber),
           maxRetries,
           retryDelayMs,
-          (s) => w(s)
+          (s) => sw(s)
         );
         if (!rec) throw new Error(`assertAsset ${assetId}: no committed custody record reaching the asserted condition`);
         if (step.expectedHolder && !holderMatches(rec.holder, step.expectedHolder, resolveFiber, wallets))
           throw new Error(`assertAsset ${assetId}: holder mismatch — got ${JSON.stringify(rec.holder)} want ${JSON.stringify(step.expectedHolder)}`);
         if (step.expectedAmount != null && Number(rec.amount) !== step.expectedAmount)
           throw new Error(`assertAsset ${assetId}: expected amount ${step.expectedAmount} but found ${rec.amount}`);
-        w(' ✓');
+        sw(' ✓');
         // Summarize the observed custody: friendly asset name (step.label) or id8, holder, amount.
         const assetName = (step.label as string | undefined) ?? assetId.slice(0, 8);
         const holderLabel = step.expectedHolder
@@ -756,8 +773,8 @@ async function runFlow(
               if (h?.Wallet?.address) return `Wallet(${h.Wallet.address.slice(0, 8)})`;
               return '?';
             })();
-        l(` \x1b[32massertAsset ${assetName} → ${holderLabel}\x1b[0m ×${Number(rec.amount)}`);
-        continue;
+        sl(` \x1b[32massertAsset ${assetName} → ${holderLabel}\x1b[0m ×${Number(rec.amount)}`);
+        return;
       }
 
       // ---- Registry ops (publishVersion / setVersionStatus / registerAlias) ----
@@ -797,8 +814,8 @@ async function runFlow(
             rejected = (err as Error).message.includes('400');
           }
           if (!rejected) throw new Error(`expected DL1 to reject ${step.action} ${regName} (HTTP 400), but it was accepted`);
-          l(' \x1b[32mOK (DL1 rejected)\x1b[0m');
-          continue;
+          sl(' \x1b[32mOK (DL1 rejected)\x1b[0m');
+          return;
         }
         if (step.expectRejected === 'ml0') {
           // Admitted by DL1 (structurally valid) but rejected at ML0 combine -> never lands.
@@ -814,8 +831,8 @@ async function runFlow(
             }
             if (landed(data)) throw new Error(`expected ML0 to reject ${step.action} ${regName}, but it landed`);
           }
-          l(' \x1b[32mOK (ML0 rejected, state unchanged)\x1b[0m');
-          continue;
+          sl(' \x1b[32mOK (ML0 rejected, state unchanged)\x1b[0m');
+          return;
         }
 
         const regInitial = await getInitialStates(ml0Env);
@@ -852,7 +869,7 @@ async function runFlow(
               regBudget,
               retryDelayMs,
               `${step.action} ${regName}`,
-              log
+              slog
             );
             regConfirmed = true;
           } catch {
@@ -866,8 +883,8 @@ async function runFlow(
           );
         }
         await validateWithRetries(regLib.validator, resolveFiber(step.fiber), regInitial, regOptions, wallets, maxRetries, retryDelayMs, ml0Urls);
-        l(' \x1b[32mOK\x1b[0m');
-        continue;
+        sl(' \x1b[32mOK\x1b[0m');
+        return;
       }
 
       const loadContext = {
@@ -954,8 +971,8 @@ async function runFlow(
           try { await sendSignedUpdate(assetMsg, signWallets, dl1Urls); }
           catch (err) { rejected = (err as Error).message.includes('400'); }
           if (!rejected) throw new Error(`expected DL1 to reject ${step.action} (HTTP 400), but it was accepted`);
-          l(' \x1b[32mOK (DL1 rejected)\x1b[0m');
-          continue;
+          sl(' \x1b[32mOK (DL1 rejected)\x1b[0m');
+          return;
         }
         if (step.expectRejected === 'ml0') {
           await sendSignedUpdate(assetMsg, signWallets, dl1Urls).catch(() => undefined);
@@ -965,15 +982,15 @@ async function runFlow(
             try { data = await new HttpClient(confirmUrl).get<unknown>(''); } catch { /* absent ⇒ fine */ }
             if (landed(data)) throw new Error(`expected ML0 to reject ${step.action} (${assetId ?? policyName}), but it landed`);
           }
-          l(' \x1b[32mOK (ML0 rejected, state unchanged)\x1b[0m');
-          continue;
+          sl(' \x1b[32mOK (ML0 rejected, state unchanged)\x1b[0m');
+          return;
         }
 
         if (burnAbsence) {
           // BURN/DECOMPOSE: the source record is REMOVED. Confirm by polling the source until it is
           // ABSENT — it existed pre-send (minted + asserted), so an exists→404 transition means the
           // morphism committed. (A consuming morphism can never satisfy the source-seq-advance predicate.)
-          w(`\n      ⏳ ML0 confirm ${step.action} ${(assetId ?? '').slice(0, 8)} → source removed`);
+          sw(`\n      ⏳ ML0 confirm ${step.action} ${(assetId ?? '').slice(0, 8)} → source removed`);
           const resubmitsB = Number(process.env.E2E_MAX_RESUBMITS) || 3;
           const budgetB = Math.max(4, Math.ceil(maxRetries / (resubmitsB + 1)));
           let gone = false;
@@ -985,13 +1002,13 @@ async function runFlow(
             await sendSignedUpdate(assetMsg, signWallets, dl1Urls).catch(() => undefined);
             for (let p = 0; p < budgetB && !gone; p++) {
               await new Promise((r) => setTimeout(r, retryDelayMs));
-              try { await new HttpClient(confirmUrl).get<unknown>(''); w('.'); } catch { gone = true; }
+              try { await new HttpClient(confirmUrl).get<unknown>(''); sw('.'); } catch { gone = true; }
             }
           }
-          if (!gone) { w(' ✗\n'); throw new Error(`ML0 confirmation failed for ${step.action} (${assetId}): source still present (not removed)`); }
-          w(' ✓\n');
-          l(' \x1b[32mOK\x1b[0m');
-          continue;
+          if (!gone) { sw(' ✗\n'); throw new Error(`ML0 confirmation failed for ${step.action} (${assetId}): source still present (not removed)`); }
+          sw(' ✓\n');
+          sl(' \x1b[32mOK\x1b[0m');
+          return;
         }
 
         // Send + confirm with a resubmit budget (committed reads trail GL0 finalization; an
@@ -1007,7 +1024,7 @@ async function runFlow(
           }
           await sendSignedUpdate(assetMsg, signWallets, dl1Urls);
           try {
-            await waitForMl0Confirmation(ml0Urls[0], confirmPath, landed, budget, retryDelayMs, `${step.action} ${assetId ?? policyName ?? ''}`, log);
+            await waitForMl0Confirmation(ml0Urls[0], confirmPath, landed, budget, retryDelayMs, `${step.action} ${assetId ?? policyName ?? ''}`, slog);
             confirmed = true;
           } catch { /* re-send unless it has since landed */ }
         }
@@ -1016,10 +1033,10 @@ async function runFlow(
         // subsequent applyMorphism on this asset is structurally validated at DL1 against OnChain.assetCommits
         // and would 400 "unknown asset" if it raced ahead of the mint's ML0→GL0→DL1 propagation.
         if (step.action === 'mintAsset' && assetId) {
-          await waitForDl1AssetSync(dl1Urls, assetId, maxRetries, retryDelayMs, `${step.action} ${assetId}`, log);
+          await waitForDl1AssetSync(dl1Urls, assetId, maxRetries, retryDelayMs, `${step.action} ${assetId}`, slog);
         }
-        l(' \x1b[32mOK\x1b[0m');
-        continue;
+        sl(' \x1b[32mOK\x1b[0m');
+        return;
       }
 
       // Determine which fiber this step targets and fetch its current sequence number
@@ -1259,7 +1276,7 @@ async function runFlow(
           if (!errMsg.includes('400') || sendAttempt >= 2) {
             throw sendErr;
           }
-          w(` (send retry)...`);
+          sw(` (send retry)...`);
           await new Promise((r) => setTimeout(r, 1000));
           currentMessage = await regenerateMessage();
         }
@@ -1276,7 +1293,7 @@ async function runFlow(
       if (step.expectRejected === 'ml0') {
         await waitForOrdinalAdvance(ml0Urls[0], 4, {
           label: `${step.action} reject settle on ${activeCid}`,
-          log: log ? { write: (s: string) => log.write(s) } : undefined,
+          log: slog ? { write: (s: string) => slog.write(s) } : undefined,
         });
         let afterSeq = -1;
         try {
@@ -1292,8 +1309,8 @@ async function runFlow(
             `expected ML0 to reject ${step.action} on ${activeCid} (guard denied), but the fiber advanced past seq ${preSendSeqNum} to ${afterSeq}`
           );
         }
-        l(' \x1b[32mOK (ML0 rejected, state unchanged)\x1b[0m');
-        continue;
+        sl(' \x1b[32mOK (ML0 rejected, state unchanged)\x1b[0m');
+        return;
       }
 
       // Ordinal-based confirmation with auto-resubmit. Capture the ordinal at send time so the
@@ -1362,7 +1379,7 @@ async function runFlow(
         // snapshots entirely — i.e. genuine consensus death, not mere slowness under CI load.
         stallTimeoutMs: 120000,
         label: `${step.action} on ${activeCid}`,
-        log: log ? { write: (s: string) => log.write(s) } : undefined,
+        log: slog ? { write: (s: string) => slog.write(s) } : undefined,
         // Webhook-driven: re-check the instant a snapshot finalizes (read state is fresh then), and
         // fail fast with the chain's reason if this exact update is rejected.
         waitNextSnapshot: webhook?.active ? (ms) => webhook!.waitNextSnapshot(ms) : undefined,
@@ -1414,7 +1431,7 @@ async function runFlow(
           maxRetries,
           retryDelayMs,
           `${step.action} DL1 sync for ${activeCid}`,
-          log
+          slog
         );
       }
 
@@ -1434,14 +1451,39 @@ async function runFlow(
         ml0Urls
       );
 
-      l(' \x1b[32mOK\x1b[0m');
-    } catch (error) {
-      l(' \x1b[31mFAIL\x1b[0m');
-      return {
-        passed: false,
-        error: (error as Error).message,
-        failedStep: i + 1,
-      };
+      sl(' \x1b[32mOK\x1b[0m');
+  };
+
+  // Batch-aware driver. A maximal run of consecutive `parallel: true` steps runs concurrently to
+  // cut wall-clock; every other step runs exactly as before (same w/l/log, same try/catch →
+  // {passed:false, failedStep:i+1}), so sequential behavior is byte-for-byte unchanged.
+  for (let i = 0; i < flow.steps.length; i++) {
+    if (flow.steps[i].parallel) {
+      let j = i;
+      while (j < flow.steps.length && flow.steps[j].parallel) j++;
+      const batch = flow.steps.slice(i, j);
+      l(`  ── parallel batch: ${batch.length} steps (${batch.map((s) => s.action).join(', ')}) ──`);
+      // Each step buffers to its OWN logger so concurrent output doesn't interleave; flush in step order.
+      const buffers = batch.map(() => new FlowLogger(tag, false));
+      const settled = await Promise.allSettled(
+        batch.map((s, k) =>
+          processStep(s, i + k, (x) => buffers[k].write(x), (...a) => buffers[k].log(...a), buffers[k])
+        )
+      );
+      for (const b of buffers) b.flush(); // ordered, contiguous per-step output
+      const failedAt = settled.findIndex((r) => r.status === 'rejected');
+      if (failedAt >= 0) {
+        const reason = (settled[failedAt] as PromiseRejectedResult).reason as Error;
+        return { passed: false, error: reason.message, failedStep: i + failedAt + 1 };
+      }
+      i = j - 1;
+    } else {
+      try {
+        await processStep(flow.steps[i], i, w, l, log); // sequential: the flow's live logger (UNCHANGED behavior)
+      } catch (error) {
+        l(' \x1b[31mFAIL\x1b[0m');
+        return { passed: false, error: (error as Error).message, failedStep: i + 1 };
+      }
     }
   }
 

--- a/e2e-test/runner.ts
+++ b/e2e-test/runner.ts
@@ -225,7 +225,8 @@ async function renderEconomy(
       const val = typeof raw === 'number' || typeof raw === 'string' ? raw : String(raw);
       curFields[f] = val;
       const had = before?.fields[f];
-      fieldParts.push(had !== undefined && had !== val ? `${f} ${had}→${val}` : `${f} ${val}`);
+      // Highlight a changed value in yellow so the eye lands on what moved this snapshot.
+      fieldParts.push(had !== undefined && had !== val ? `${f} \x1b[33m${had}→${val}\x1b[0m` : `${f} ${val}`);
     }
 
     // held asset instances (acquired/changed/departed deltas once the party has a prior snapshot).
@@ -242,9 +243,10 @@ async function renderEconomy(
       const name = assetLabels.get(id) ?? id.slice(0, 8);
       const cur = curAssets[id];
       const was = before?.assets[id];
-      if (cur !== undefined && was !== undefined && cur !== was) assetParts.push(`${name} ${was}→${cur}`);
-      else if (cur !== undefined && was === undefined) assetParts.push(seen ? `+${name}×${cur}` : `${name}×${cur}`);
-      else if (cur === undefined && was !== undefined && seen) assetParts.push(`${name} ${was}→0`);
+      // Yellow = amount changed or instance left custody; green = newly acquired; plain = unchanged.
+      if (cur !== undefined && was !== undefined && cur !== was) assetParts.push(`\x1b[33m${name} ${was}→${cur}\x1b[0m`);
+      else if (cur !== undefined && was === undefined) assetParts.push(seen ? `\x1b[32m+${name}×${cur}\x1b[0m` : `${name}×${cur}`);
+      else if (cur === undefined && was !== undefined && seen) assetParts.push(`\x1b[33m${name} ${was}→0\x1b[0m`);
       else if (cur !== undefined) assetParts.push(`${name}×${cur}`);
     }
 
@@ -882,6 +884,8 @@ async function runFlow(
       if (ASSET_ACTIONS.has(step.action)) {
         let assetId = step.assetId as string | undefined;
         let assetMsg: unknown;
+        let morphismKind: string | undefined;
+        let fracFirstShard: string | undefined;
         if (step.action === 'createAssetPolicy') {
           const policy = (await loadFileOrModule(path.join(examplesDir, example.dir, step.policy!), loadContext)) as Record<string, unknown>;
           const lib = await import('./lib/asset/createAssetPolicy.ts');
@@ -894,6 +898,8 @@ async function runFlow(
         } else {
           const morphism = (await loadFileOrModule(path.join(examplesDir, example.dir, step.morphism!), loadContext)) as Record<string, unknown>;
           assetId = (morphism.assetId as string) ?? assetId;
+          morphismKind = String(morphism.kind ?? '').toUpperCase();
+          fracFirstShard = Array.isArray(morphism.shardIds) ? String((morphism.shardIds as unknown[])[0]) : undefined;
           // Morphisms are sequenced by (assetId, targetSequenceNumber): target the asset's current seq.
           let curSeq = 0;
           try {
@@ -904,11 +910,18 @@ async function runFlow(
           assetMsg = lib.generator({ wallets: signWallets, options: { morphism, targetSequenceNumber: curSeq } });
         }
 
+        // Consuming morphisms REMOVE the source record, so they can't be confirmed by a source-seq
+        // advance: FRACTIONALIZE confirms via the first output shard's EXISTENCE; BURN/DECOMPOSE via the
+        // source's ABSENCE (handled below). Non-consuming (Stake/Transfer/Wrap) keep seq-advance.
+        const fractionalize = step.action === 'applyMorphism' && morphismKind === 'FRACTIONALIZE';
+        const burnAbsence = step.action === 'applyMorphism' && (morphismKind === 'BURN' || morphismKind === 'DECOMPOSE');
         const policyName = step.name as string | undefined;
         const confirmPath =
           step.action === 'createAssetPolicy'
             ? `registry/${encodeURIComponent(policyName ?? '')}`
-            : `assets/${assetId}/state-proof`;
+            : fractionalize && fracFirstShard
+              ? `assets/${fracFirstShard}/state-proof`
+              : `assets/${assetId}/state-proof`;
         const confirmUrl = `${ml0Urls[0]}/data-application/v1/${confirmPath}`;
 
         // Pre-send asset sequence (applyMorphism confirms on a seq ADVANCE).
@@ -932,7 +945,8 @@ async function runFlow(
           const r = (d as { record?: { sequenceNumber?: number } } | null)?.record;
           if (!r) return false;
           if (step.action === 'mintAsset') return true; // existence ⇒ minted
-          return (r.sequenceNumber ?? -1) > preAssetSeq; // applyMorphism ⇒ seq advanced
+          if (fractionalize) return true; // confirmPath is the first shard ⇒ its existence = fractionalized
+          return (r.sequenceNumber ?? -1) > preAssetSeq; // non-consuming applyMorphism ⇒ source seq advanced
         };
 
         if (step.expectRejected === 'dl1') {
@@ -952,6 +966,31 @@ async function runFlow(
             if (landed(data)) throw new Error(`expected ML0 to reject ${step.action} (${assetId ?? policyName}), but it landed`);
           }
           l(' \x1b[32mOK (ML0 rejected, state unchanged)\x1b[0m');
+          continue;
+        }
+
+        if (burnAbsence) {
+          // BURN/DECOMPOSE: the source record is REMOVED. Confirm by polling the source until it is
+          // ABSENT — it existed pre-send (minted + asserted), so an exists→404 transition means the
+          // morphism committed. (A consuming morphism can never satisfy the source-seq-advance predicate.)
+          w(`\n      ⏳ ML0 confirm ${step.action} ${(assetId ?? '').slice(0, 8)} → source removed`);
+          const resubmitsB = Number(process.env.E2E_MAX_RESUBMITS) || 3;
+          const budgetB = Math.max(4, Math.ceil(maxRetries / (resubmitsB + 1)));
+          let gone = false;
+          for (let attempt = 0; attempt <= resubmitsB && !gone; attempt++) {
+            if (attempt > 0) {
+              // already removed by a prior send? (don't re-burn a gone asset — it would reject)
+              try { await new HttpClient(confirmUrl).get<unknown>(''); } catch { gone = true; break; }
+            }
+            await sendSignedUpdate(assetMsg, signWallets, dl1Urls).catch(() => undefined);
+            for (let p = 0; p < budgetB && !gone; p++) {
+              await new Promise((r) => setTimeout(r, retryDelayMs));
+              try { await new HttpClient(confirmUrl).get<unknown>(''); w('.'); } catch { gone = true; }
+            }
+          }
+          if (!gone) { w(' ✗\n'); throw new Error(`ML0 confirmation failed for ${step.action} (${assetId}): source still present (not removed)`); }
+          w(' ✓\n');
+          l(' \x1b[32mOK\x1b[0m');
           continue;
         }
 

--- a/e2e-test/runner.ts
+++ b/e2e-test/runner.ts
@@ -80,12 +80,24 @@ class FlowLogger {
   private lines: string[] = [];
   private currentLine = '';
   public readonly tag: string;
+  /**
+   * Live (write-through) mode. When the runner is at CONCURRENCY 1 a flow CANNOT interleave with
+   * another, so its output is written straight to stdout as it happens (no 20-min buffer-then-dump).
+   * When > 1 flow runs in parallel we keep buffering and flush each flow as one block, so the
+   * concurrent flows' lines never interleave. flush() is a no-op in live mode (nothing is buffered).
+   */
+  private readonly live: boolean;
 
-  constructor(tag: string) {
+  constructor(tag: string, live = false) {
     this.tag = tag;
+    this.live = live;
   }
 
   write(text: string): void {
+    if (this.live) {
+      process.stdout.write(text);
+      return;
+    }
     this.currentLine += text;
     if (text.includes('\n')) {
       const parts = this.currentLine.split('\n');
@@ -99,6 +111,11 @@ class FlowLogger {
 
   log(...args: unknown[]): void {
     const text = args.map(String).join(' ');
+    if (this.live) {
+      // The preceding write()s already emitted the partial line; complete it with a newline.
+      process.stdout.write(text + '\n');
+      return;
+    }
     if (this.currentLine) {
       this.lines.push(this.currentLine + text);
       this.currentLine = '';
@@ -108,6 +125,7 @@ class FlowLogger {
   }
 
   flush(): void {
+    if (this.live) return; // write-through already emitted everything
     if (this.currentLine) {
       this.lines.push(this.currentLine);
       this.currentLine = '';
@@ -116,6 +134,125 @@ class FlowLogger {
       console.log(this.lines.join('\n'));
       this.lines = [];
     }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Observability helpers (phase headers + economy snapshot — riverdale-economy)
+// ---------------------------------------------------------------------------
+
+/** Fixed visual width for the `── <phase> ───` and `│ economy ───` rules. */
+const RULE_WIDTH = 48;
+
+/** A phase banner: `── <label> ─────────…` padded/truncated to RULE_WIDTH (leading blank line). */
+function phaseBanner(label: string): string {
+  const head = `── ${label} `;
+  const trimmed = head.length > RULE_WIDTH ? head.slice(0, RULE_WIDTH) : head;
+  return `\n${trimmed}${'─'.repeat(Math.max(0, RULE_WIDTH - trimmed.length))}`;
+}
+
+/** One stored economy snapshot for a party, used to render deltas on the NEXT economy step. */
+type PartySnapshot = {
+  state?: string;
+  fields: Record<string, number | string>;
+  assets: Record<string, number>;
+};
+
+/** A party as declared in an `economy` step. */
+type EconomyParty = { fiber?: string; wallet?: string; label: string; show?: string[] };
+/** An asset id → friendly label entry as declared in an `economy` step. */
+type EconomyAsset = { id: string; label: string };
+
+/**
+ * Read the ML0 checkpoint ONCE and print a compact economy table — one line per party (its fiber
+ * `currentState` + the selected `show` stateData fields) plus the asset instances it holds. Values
+ * that changed since the previous `economy` step render as deltas: `inventory 1000→500` for a show
+ * field, `+GOODS×500` for a newly-acquired instance, `RVD-loan 10000→0` for one that left custody.
+ * Observability-only and side-effect-free on the chain — it NEVER throws (a checkpoint read error
+ * degrades to a single note line), so it stays a true no-op for the flow's pass/fail.
+ */
+async function renderEconomy(
+  step: TestStep,
+  ml0BaseUrl: string,
+  wallets: Wallets,
+  resolveFiber: (alias?: string) => string,
+  prev: Record<string, PartySnapshot>,
+  l: (...a: unknown[]) => void
+): Promise<void> {
+  type SmRec = { currentState?: string; stateData?: Record<string, unknown> };
+  type AsRec = { holder?: { Fiber?: { fiberId?: string }; Wallet?: { address?: string } }; amount?: number };
+
+  const parties = step.parties ?? [];
+  const assetLabels = new Map<string, string>();
+  for (const a of step.assets ?? []) assetLabels.set(a.id, a.label);
+
+  let machines: Record<string, SmRec> = {};
+  let assets: Record<string, AsRec> = {};
+  try {
+    const cp = (await new HttpClient(`${ml0BaseUrl}/data-application/v1/checkpoint`).get<unknown>(
+      ''
+    )) as { state?: { stateMachines?: Record<string, SmRec>; assets?: Record<string, AsRec> } } | null;
+    machines = cp?.state?.stateMachines ?? {};
+    assets = cp?.state?.assets ?? {};
+  } catch (e) {
+    l(`    \x1b[36m│\x1b[0m economy (checkpoint unavailable: ${(e as Error).message})`);
+    return;
+  }
+
+  const head = step.label ? `economy ${step.label} ` : 'economy ';
+  l(`    \x1b[36m│\x1b[0m ${head}${'─'.repeat(Math.max(4, 30 - head.length))}`);
+
+  const labelW = parties.reduce((m, p) => Math.max(m, p.label.length), 0);
+
+  for (const party of parties) {
+    const fiberId = party.fiber ? resolveFiber(party.fiber) : undefined;
+    const walletAddr = party.wallet ? wallets[party.wallet]?.address : undefined;
+    const rec = fiberId ? machines[fiberId] : undefined;
+    const before = prev[party.label];
+    const seen = before !== undefined;
+
+    // currentState (plain — no delta; matches the confirmed preview).
+    const state = rec?.currentState ?? (fiberId ? '—' : '');
+
+    // selected stateData show-fields (delta when changed since the last economy step).
+    const stateData = (rec?.stateData ?? {}) as Record<string, unknown>;
+    const showFields = party.show ?? Object.keys(stateData).slice(0, 3);
+    const curFields: Record<string, number | string> = {};
+    const fieldParts: string[] = [];
+    for (const f of showFields) {
+      const raw = stateData[f];
+      if (raw === undefined) continue;
+      const val = typeof raw === 'number' || typeof raw === 'string' ? raw : String(raw);
+      curFields[f] = val;
+      const had = before?.fields[f];
+      fieldParts.push(had !== undefined && had !== val ? `${f} ${had}→${val}` : `${f} ${val}`);
+    }
+
+    // held asset instances (acquired/changed/departed deltas once the party has a prior snapshot).
+    const curAssets: Record<string, number> = {};
+    for (const [id, arec] of Object.entries(assets)) {
+      const h = arec?.holder;
+      const mine =
+        (fiberId !== undefined && h?.Fiber?.fiberId === fiberId) ||
+        (walletAddr !== undefined && h?.Wallet?.address === walletAddr);
+      if (mine) curAssets[id] = Number(arec?.amount ?? 0);
+    }
+    const assetParts: string[] = [];
+    for (const id of new Set([...Object.keys(curAssets), ...Object.keys(before?.assets ?? {})])) {
+      const name = assetLabels.get(id) ?? id.slice(0, 8);
+      const cur = curAssets[id];
+      const was = before?.assets[id];
+      if (cur !== undefined && was !== undefined && cur !== was) assetParts.push(`${name} ${was}→${cur}`);
+      else if (cur !== undefined && was === undefined) assetParts.push(seen ? `+${name}×${cur}` : `${name}×${cur}`);
+      else if (cur === undefined && was !== undefined && seen) assetParts.push(`${name} ${was}→0`);
+      else if (cur !== undefined) assetParts.push(`${name}×${cur}`);
+    }
+
+    const cols = [state, fieldParts.join('  '), assetParts.join(' ')].filter(Boolean).join('   ');
+    // Skip a wholly-empty row (e.g. a wallet party that holds nothing yet) so the table stays tight.
+    if (cols) l(`    \x1b[36m│\x1b[0m ${party.label.padEnd(labelW)}  ${cols}`);
+
+    prev[party.label] = { state: rec?.currentState, fields: curFields, assets: curAssets };
   }
 }
 
@@ -432,6 +569,14 @@ interface TestStep {
   /** applyMorphism: path to the morphism body file. */
   morphism?: string;
 
+  // ---- Observability (poll-only, no tx) — `phase` headers + `economy` snapshots ----
+  /** phase: the banner text. economy: an optional section sub-label. assertAsset: friendly asset name. */
+  label?: string;
+  /** economy: the parties to render (each resolved by fiber alias or wallet name). */
+  parties?: EconomyParty[];
+  /** economy: asset id → friendly label map for rendering held instances (GOODS, RVD-loan, …). */
+  assets?: EconomyAsset[];
+
   [key: string]: unknown;
 }
 
@@ -505,6 +650,9 @@ async function runFlow(
     // and registers it here; any step with `fiber: "<alias>"` resolves to it. Single-fiber flows
     // never touch this map and keep using `session.cid` (full back-compat).
     fibers: {} as Record<string, string>,
+    // Previous `economy` snapshot per party label, so the next `economy` step can render deltas
+    // (e.g. `inventory 1000→500`) instead of re-printing the absolute value. Observability-only.
+    economy: {} as Record<string, PartySnapshot>,
   };
   // Resolve a step's target fiber: a registered alias, else a raw fiberId pass-through (e.g. a
   // spawned child addressed by literal id), else the default session fiber.
@@ -513,6 +661,19 @@ async function runFlow(
 
   for (let i = 0; i < flow.steps.length; i++) {
     const step = flow.steps[i];
+
+    // ---- Observability annotations (poll-only, no tx; rendered WITHOUT the "[Step N] action…"
+    // prefix so they read as section banners / tables). `phase` is pure text; `economy` reads the
+    // ML0 checkpoint ONCE and prints a compact economy table. Both early-continue like assertState. ----
+    if (step.action === 'phase') {
+      l(phaseBanner(String(step.label ?? '')));
+      continue;
+    }
+    if (step.action === 'economy') {
+      await renderEconomy(step, ml0Urls[0], wallets, resolveFiber, session.economy, l);
+      continue;
+    }
+
     const stepLabel = `[Step ${i + 1}/${flow.steps.length}]`;
     w(`  ${stepLabel} ${step.action}...`);
 
@@ -554,7 +715,8 @@ async function runFlow(
         if (step.expectedStateData && !deepEqual(rec.stateData, step.expectedStateData))
           throw new Error(`assertState ${who}: stateData mismatch — got ${JSON.stringify(rec.stateData)} want ${JSON.stringify(step.expectedStateData)}`);
         w(' ✓');
-        l(' \x1b[32mOK\x1b[0m');
+        // Summarize what was observed (not a bare "OK") so the flow reads as a story.
+        l(` \x1b[32massertState ${who} → ${String(rec.currentState)}\x1b[0m (seq ${Number(rec.sequenceNumber)})`);
         continue;
       }
 
@@ -580,7 +742,19 @@ async function runFlow(
         if (step.expectedAmount != null && Number(rec.amount) !== step.expectedAmount)
           throw new Error(`assertAsset ${assetId}: expected amount ${step.expectedAmount} but found ${rec.amount}`);
         w(' ✓');
-        l(' \x1b[32mOK\x1b[0m');
+        // Summarize the observed custody: friendly asset name (step.label) or id8, holder, amount.
+        const assetName = (step.label as string | undefined) ?? assetId.slice(0, 8);
+        const holderLabel = step.expectedHolder
+          ? 'Fiber' in step.expectedHolder
+            ? `Fiber(${step.expectedHolder.Fiber})`
+            : `Wallet(${step.expectedHolder.Wallet})`
+          : (() => {
+              const h = rec.holder as { Fiber?: { fiberId?: string }; Wallet?: { address?: string } } | undefined;
+              if (h?.Fiber?.fiberId) return `Fiber(${h.Fiber.fiberId.slice(0, 8)})`;
+              if (h?.Wallet?.address) return `Wallet(${h.Wallet.address.slice(0, 8)})`;
+              return '?';
+            })();
+        l(` \x1b[32massertAsset ${assetName} → ${holderLabel}\x1b[0m ×${Number(rec.amount)}`);
         continue;
       }
 
@@ -1342,12 +1516,27 @@ async function main() {
     // -----------------------------------------------------------------------
     // Parallel mode: run all flows concurrently with buffered output
     // -----------------------------------------------------------------------
-    const CONCURRENCY = Number(process.env.E2E_CONCURRENCY) || flowPairs.length;
+    // Concurrency: an explicit E2E_CONCURRENCY wins (0/NaN ignored, preserving the old `|| default`).
+    // Otherwise an INTERACTIVE single-example run (e.g. a local `--only riverdale-economy` in a TTY)
+    // defaults to 1 so its flows run serially and stream live. The isTTY gate is load-bearing: it keeps
+    // CI behavior identical — the tictactoe lane is single-example with no explicit concurrency and has
+    // 3 flows that MUST keep running in parallel (serializing them would ~3x its wall-clock and risk the
+    // job timeout). CI has no TTY, so it always takes the `flowPairs.length` branch as before.
+    const envConc = Number(process.env.E2E_CONCURRENCY);
+    const CONCURRENCY =
+      Number.isFinite(envConc) && envConc > 0
+        ? envConc
+        : examples.length === 1 && process.stdout.isTTY
+          ? 1
+          : flowPairs.length;
+    // At CONCURRENCY 1 no two flows can interleave, so stream each flow's output live (write-through)
+    // instead of buffering it until flush — the single-example local run reads in real time.
+    const liveOutput = CONCURRENCY === 1;
     console.log(`Launching ${flowPairs.length} flows, ${CONCURRENCY} at a time…\n`);
 
     const runOne = async ({ example, flow }: (typeof flowPairs)[number]): Promise<FlowResult> => {
       const tag = `${example.dir}/${flow.name}`;
-      const logger = new FlowLogger(tag);
+      const logger = new FlowLogger(tag, liveOutput);
       logger.log(
         `\x1b[36m[${example.dir}]\x1b[0m Running: ${flow.name} (${flow.steps.length} steps)`
       );


### PR DESCRIPTION
Follow-up to **#190** (the now-merged riverdale-economy economy): make the e2e run **readable** and **show the economy moving**.

## Why
A real run was unreadable — the background keepalive (`[keepalive] N sent`, every 3s) and per-send `[dl1] update → 3/3 ✓` lines printed *live* (50+ lines over a 20-min run) while the flow output was **buffered and dumped only at the end**. You watched plumbing spam, then a wall of `✓ OK` with **no view of the economy actually moving**.

## Harness (shared by all lanes — back-compatible)
- **keepalive**: first-accepted + per-10 heartbeat gated behind `E2E_VERBOSE`; `stop()` prints one line.
- **sendDataTransaction**: fix `describeUpdate` (it read `message.value` on the *unwrapped* generator output → always "update"; now reads the envelope key + inner `fiberId`/`assetId`/`name`); the healthy 3/3 per-send line is gated behind `E2E_VERBOSE`. **Divergence/failure lines always print.**
- **FlowLogger**: live (write-through) mode; `flush()` is a no-op when live.
- **Concurrency**: an *interactive* single-example run (TTY) defaults to 1 so its flows stream live. The **`isTTY` gate is load-bearing** — it keeps CI identical (tictactoe is a single-example lane with **3 parallel flows** that must not be serialized; CI has no TTY).

## Visibility (riverdale-economy)
- New poll-only step actions **`phase`** (section banner) and **`economy`** (reads the ML0 checkpoint *once* and prints a per-party table: state + a few stateData fields + held assets, with **deltas** vs the previous snapshot, e.g. `inventory 1000→500`, `RVD-loan 10000→0`).
- **`assertState`/`assertAsset`** now summarize what they observed (`retailer → received (seq 1)`, `GOODS → Fiber(retailer) ×500`) instead of a bare `OK`.
- `example.ts`: 13 `phase` banners + 12 `economy` snapshots across P0..P12 — **all functional/assert steps unchanged**.

## Sample
```
── P5  lending ─────────────────────────────────
 ✓ bank.underwrite → loan_servicing
 ✓ assertState consumer → debt_current (seq 1)
 ✓ assertAsset RVD-loan → Fiber(consumer) ×10000
    │ economy ──────────────────────
    │ consumer  debt_current  +RVD-loan×10000
    │ bank      loan_servicing  loanPortfolio 0→10000  RVD-loan 10000→0
```

`tsc`-clean. `phase`/`economy` are additive early-continue no-ops (other examples unaffected); verbose-gating defaults to quiet, so **every** lane gets a quieter, more readable run. Run `npm test -- --only riverdale-economy` (in a TTY) to watch it live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)