### PR TITLE
feat(fiber): object-form-only _transferAsset recipient, fail-loud

### DIFF
--- a/e2e-test/examples/riverdale-economy/bank.definition.json
+++ b/e2e-test/examples/riverdale-economy/bank.definition.json
@@ -46,7 +46,7 @@
         "_transferAsset": [
           {
             "assetId": { "var": "event.loanAssetId" },
-            "recipient": { "var": "event.consumerId" }
+            "recipient": { "Fiber": { "fiberId": { "var": "event.consumerId" } } }
           }
         ],
         "status": "loan_servicing",

--- a/e2e-test/examples/riverdale-economy/consumer.definition.json
+++ b/e2e-test/examples/riverdale-economy/consumer.definition.json
@@ -38,7 +38,7 @@
         "_transferAsset": [
           {
             "assetId": { "var": "event.payAssetId" },
-            "recipient": { "var": "event.retailerId" }
+            "recipient": { "Fiber": { "fiberId": { "var": "event.retailerId" } } }
           }
         ],
         "status": "debt_current",
@@ -65,7 +65,7 @@
         "_transferAsset": [
           {
             "assetId": { "var": "event.repayAssetId" },
-            "recipient": { "var": "event.bankId" }
+            "recipient": { "Fiber": { "fiberId": { "var": "event.bankId" } } }
           }
         ],
         "status": "debt_current",
@@ -83,7 +83,7 @@
         "_transferAsset": [
           {
             "assetId": { "var": "event.taxAssetId" },
-            "recipient": { "var": "event.govId" }
+            "recipient": { "Fiber": { "fiberId": { "var": "event.govId" } } }
           }
         ],
         "status": "debt_current",

--- a/e2e-test/examples/riverdale-economy/manufacturer.definition.json
+++ b/e2e-test/examples/riverdale-economy/manufacturer.definition.json
@@ -21,7 +21,7 @@
         "_transferAsset": [
           {
             "assetId": { "var": "event.goodsAssetId" },
-            "recipient": { "var": "event.retailerId" }
+            "recipient": { "Fiber": { "fiberId": { "var": "event.retailerId" } } }
           }
         ],
         "status": "shipped",

--- a/e2e-test/examples/riverdale-economy/retailer-v1.definition.json
+++ b/e2e-test/examples/riverdale-economy/retailer-v1.definition.json
@@ -26,7 +26,7 @@
         "_transferAsset": [
           {
             "assetId": { "var": "event.goodsAssetId" },
-            "recipient": { "var": "event.buyerId" }
+            "recipient": { "Fiber": { "fiberId": { "var": "event.buyerId" } } }
           }
         ],
         "status": "received",

--- a/e2e-test/examples/riverdale-economy/retailer-v2.definition.json
+++ b/e2e-test/examples/riverdale-economy/retailer-v2.definition.json
@@ -37,7 +37,7 @@
         "_transferAsset": [
           {
             "assetId": { "var": "event.goodsAssetId" },
-            "recipient": { "var": "event.buyerId" }
+            "recipient": { "Fiber": { "fiberId": { "var": "event.buyerId" } } }
           }
         ],
         "status": "received",

--- a/e2e-test/examples/staked-oracle-pool/definition.json
+++ b/e2e-test/examples/staked-oracle-pool/definition.json
@@ -1466,7 +1466,7 @@
                   "var": "event.rewardAssetId"
                 },
                 "recipient": {
-                  "var": "event.agent"
+                  "Wallet": { "address": { "var": "event.agent" } }
                 }
               }
             ]
@@ -1564,7 +1564,7 @@
                   "var": "event.rewardAssetId"
                 },
                 "recipient": {
-                  "var": "event.agent"
+                  "Wallet": { "address": { "var": "event.agent" } }
                 }
               }
             ]
@@ -1648,7 +1648,7 @@
                   ]
                 },
                 "recipient": {
-                  "var": "event.agent"
+                  "Wallet": { "address": { "var": "event.agent" } }
                 }
               }
             ]
@@ -1732,7 +1732,7 @@
                   ]
                 },
                 "recipient": {
-                  "var": "event.agent"
+                  "Wallet": { "address": { "var": "event.agent" } }
                 }
               }
             ]

--- a/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/fiber/evaluation/EffectExtractor.scala
+++ b/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/fiber/evaluation/EffectExtractor.scala
@@ -9,14 +9,14 @@ import cats.syntax.all._
 import cats.{Monad, ~>}
 
 import io.constellationnetwork.metagraph_sdk.json_logic._
-import io.constellationnetwork.metagraph_sdk.json_logic.core.{BoolValue, StrValue}
-import io.constellationnetwork.schema.address.{Address, DAGAddressRefined}
+import io.constellationnetwork.metagraph_sdk.json_logic.core.{BoolValue, MapValue, StrValue}
 
 import xyz.kd5ujc.schema.asset.AssetHolder
 import xyz.kd5ujc.schema.fiber._
 import xyz.kd5ujc.shared_data.fiber.core._
+import xyz.kd5ujc.shared_data.lifecycle.combine.CombineRejected
 
-import eu.timepit.refined.refineV
+import io.circe.syntax._
 
 /**
  * Extracts side effects from transition effect results.
@@ -178,9 +178,11 @@ object EffectExtractor {
    * Extract fiber-held asset custody transfers (`_transferAsset`, asset-model.md §10) with gas metering via
    * StateT. Mirrors [[extractTriggerEvents]] EXACTLY: the directive's `assetId`/`recipient` JSON-Logic
    * expressions are RESOLVED here (against the transition context), so the resulting [[FiberEffect.AssetTransferred]]
-   * carries values, not logic. Gas is charged under [[GasExhaustionPhase.Morphism]]. A malformed directive
-   * (non-UUID `assetId`, or a `recipient` that resolves to neither a UUID nor a DAG address) is DROPPED —
-   * the same fail-silent mode the other extractors use for malformed items.
+   * carries values, not logic. Gas is charged under [[GasExhaustionPhase.Morphism]]. The `recipient` is the
+   * canonical [[AssetHolder]] OBJECT form ONLY (`{"Fiber":{"fiberId":..}}` / `{"Wallet":{"address":..}}`) —
+   * see [[parseAssetTransfer]]. A malformed directive (non-UUID `assetId`, a `recipient` that is not a
+   * well-formed `AssetHolder` object, or a gas/eval failure) raises a graceful [[CombineRejected]] — NOT a
+   * silent drop; surfacing the parse failure is deliberate (a silently-dropped transfer is a latent bug).
    *
    * SECURITY: this extractor carries NO authorization. The combiner ([[xyz.kd5ujc.shared_data.lifecycle.combine.AssetCombiner.applyFiberTransfer]])
    * enforces `holder == AssetHolder.Fiber(emittingFiberId)` before applying any extracted transfer (R1).
@@ -194,10 +196,23 @@ object EffectExtractor {
     lift: F ~> G
   ): G[List[FiberEffect.AssetTransferred]] =
     extractArrayByKey(effectResult, ReservedKeys.TRANSFER_ASSET)
-      .flatTraverse { item =>
-        parseAssetTransfer[F, G](item, contextData).map(_.toList)
-      }
+      .traverse(item => parseAssetTransfer[F, G](item, contextData))
 
+  /**
+   * Parse one `_transferAsset` directive item into an [[FiberEffect.AssetTransferred]]. The `assetId` /
+   * `recipient` expressions are RESOLVED here (gas charged under [[GasExhaustionPhase.Morphism]]) so the
+   * effect carries values, not logic.
+   *
+   * The recipient is the canonical [[AssetHolder]] OBJECT form ONLY — `{"Fiber":{"fiberId":..}}` /
+   * `{"Wallet":{"address":..}}` — decoded strictly through the same magnolia `AssetHolder` codec used on every
+   * other surface (`MintAsset.holder`, `ApplyMorphism.recipient`, `AssetRecord.holder`). The old bare-string
+   * UUID/DAG-address disambiguation is GONE. Any malformation — a non-object item, a missing/non-UUID
+   * `assetId`, a recipient that is not a well-formed `AssetHolder` object, or a gas/eval failure — raises a
+   * graceful [[CombineRejected]] (NOT a silent drop): extraction runs only on the combiner apply path, so the
+   * raise is caught at `Combiner.insert` → `RejectionReceipt` (rule #2; the same authoritative-gate pattern
+   * `AssetCombiner` already uses), never a block-acceptance `Invalid`. Surfacing the error is deliberate — a
+   * silently-dropped transfer is a latent bug, not a no-op.
+   */
   private def parseAssetTransfer[F[_]: Async, G[_]: Monad](
     value:       JsonLogicValue,
     contextData: JsonLogicValue
@@ -205,45 +220,72 @@ object EffectExtractor {
     S:    Stateful[G, ExecutionState],
     A:    Ask[G, FiberContext],
     lift: F ~> G
-  ): G[Option[FiberEffect.AssetTransferred]] =
+  ): G[FiberEffect.AssetTransferred] =
     value match {
       case MapValue(transferMap) =>
-        (for {
-          assetIdValue <- OptionT.fromOption[G](transferMap.get(ReservedKeys.ASSET_ID))
-          assetIdExpr = ExpressionParser.valueToExpression(assetIdValue)
-          // Charge gas for assetId resolution under the Morphism phase.
-          evaluatedAssetId <- OptionT(
-            MeteredEvaluator.evalOpt[F, G](assetIdExpr, contextData, GasExhaustionPhase.Morphism)
-          )
-          assetIdStr <- OptionT.fromOption[G](evaluatedAssetId match {
-            case StrValue(s) => Some(s); case _ => None
-          })
-          assetId <- OptionT.fromOption[G](scala.util.Try(UUID.fromString(assetIdStr)).toOption)
-
-          recipientValue <- OptionT.fromOption[G](transferMap.get(ReservedKeys.RECIPIENT))
-          recipientExpr = ExpressionParser.valueToExpression(recipientValue)
-          // Charge gas for recipient resolution under the Morphism phase.
-          evaluatedRecipient <- OptionT(
-            MeteredEvaluator.evalOpt[F, G](recipientExpr, contextData, GasExhaustionPhase.Morphism)
-          )
-          recipientStr <- OptionT.fromOption[G](evaluatedRecipient match {
-            case StrValue(s) => Some(s); case _ => None
-          })
-          recipient <- OptionT.fromOption[G](parseRecipient(recipientStr))
-        } yield FiberEffect.AssetTransferred(assetId = assetId, recipient = recipient)).value
-      case _ => none[FiberEffect.AssetTransferred].pure[G]
+        for {
+          assetIdValue     <- requireField[F, G](transferMap, ReservedKeys.ASSET_ID, "assetId")
+          evaluatedAssetId <- evalOrReject[F, G](assetIdValue, contextData, "assetId")
+          assetId <- evaluatedAssetId match {
+            case StrValue(s) =>
+              scala.util.Try(UUID.fromString(s)).toOption match {
+                case Some(uuid) => uuid.pure[G]
+                case None       => rejectTransfer[F, G, UUID](s"assetId is not a valid UUID: '$s'")
+              }
+            case other => rejectTransfer[F, G, UUID](s"assetId must be a UUID string, got $other")
+          }
+          recipientValue     <- requireField[F, G](transferMap, ReservedKeys.RECIPIENT, "recipient")
+          evaluatedRecipient <- evalOrReject[F, G](recipientValue, contextData, "recipient")
+          recipient <- evaluatedRecipient match {
+            case MapValue(_) =>
+              evaluatedRecipient.asJson.as[AssetHolder] match {
+                case Right(holder) => holder.pure[G]
+                case Left(err) =>
+                  rejectTransfer[F, G, AssetHolder](
+                    s"recipient is not a valid AssetHolder object {Fiber|Wallet}: ${err.getMessage}"
+                  )
+              }
+            case other =>
+              rejectTransfer[F, G, AssetHolder](
+                s"""recipient must be an AssetHolder object {"Fiber":{"fiberId":..}} / {"Wallet":{"address":..}}, got $other"""
+              )
+          }
+        } yield FiberEffect.AssetTransferred(assetId = assetId, recipient = recipient)
+      case other =>
+        rejectTransfer[F, G, FiberEffect.AssetTransferred](s"malformed item (expected an object), got $other")
     }
 
-  /**
-   * Disambiguate a recipient string into an [[AssetHolder]]: a UUID-shaped string is a fiber custody target
-   * ([[AssetHolder.Fiber]]); otherwise a valid DAG address is a wallet ([[AssetHolder.Wallet]]). Neither →
-   * `None` (malformed, dropped). UUID is tried FIRST so a UUID never accidentally validates as an address.
-   */
-  private def parseRecipient(s: String): Option[AssetHolder] =
-    scala.util.Try(UUID.fromString(s)).toOption match {
-      case Some(uuid) => Some(AssetHolder.Fiber(uuid))
-      case None       => refineV[DAGAddressRefined](s).toOption.map(refined => AssetHolder.Wallet(Address(refined)))
+  /** Look up a required `_transferAsset` field, or raise a graceful [[CombineRejected]] naming what is missing. */
+  private def requireField[F[_]: Async, G[_]: Monad](
+    map:   Map[String, JsonLogicValue],
+    key:   String,
+    label: String
+  )(implicit lift: F ~> G): G[JsonLogicValue] =
+    map.get(key) match {
+      case Some(v) => v.pure[G]
+      case None    => rejectTransfer[F, G, JsonLogicValue](s"missing $label")
     }
+
+  /** Evaluate a `_transferAsset` sub-expression under the Morphism gas phase; a `Left` (gas/eval failure) is LOUD. */
+  private def evalOrReject[F[_]: Async, G[_]: Monad](
+    value:       JsonLogicValue,
+    contextData: JsonLogicValue,
+    label:       String
+  )(implicit
+    S:    Stateful[G, ExecutionState],
+    A:    Ask[G, FiberContext],
+    lift: F ~> G
+  ): G[JsonLogicValue] =
+    MeteredEvaluator
+      .eval[F, G](ExpressionParser.valueToExpression(value), contextData, GasExhaustionPhase.Morphism)
+      .flatMap {
+        case Right(v)     => v.pure[G]
+        case Left(reason) => rejectTransfer[F, G, JsonLogicValue](s"$label did not evaluate: $reason")
+      }
+
+  /** Raise a graceful, combiner-caught [[CombineRejected]] for a malformed `_transferAsset` directive. */
+  private def rejectTransfer[F[_]: Async, G[_], A](reason: String)(implicit lift: F ~> G): G[A] =
+    lift(Async[F].raiseError[A](CombineRejected(s"_transferAsset: $reason")))
 
   /**
    * Extract dynamic-dependency mutations (`_addDependency` / `_setDependencyActive`) with gas metering.

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/AssetFiberTransferSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/AssetFiberTransferSuite.scala
@@ -24,6 +24,7 @@ import xyz.kd5ujc.schema.{CalculatedState, OnChain, Records, Updates}
 import xyz.kd5ujc.shared_data.fiber.core._
 import xyz.kd5ujc.shared_data.fiber.evaluation.EffectExtractor
 import xyz.kd5ujc.shared_data.lifecycle.Combiner
+import xyz.kd5ujc.shared_data.lifecycle.combine.CombineRejected
 import xyz.kd5ujc.shared_test.Participant._
 import xyz.kd5ujc.shared_test.TestFixture
 
@@ -39,7 +40,8 @@ import weaver.SimpleIOSuite
  *   (2) HOLDER DEFENSE (R1) — a fiber that emits `_transferAsset` for an asset it does NOT hold is
  *       gracefully rejected (RejectionReceipt) and the asset is unchanged,
  *   (3) heldAssets — a transition guard that reads `heldAssets.<id>.amount` evaluates correctly,
- *   (4) EffectExtractor — `_transferAsset` parses into `AssetTransferred` with gas charged; malformed drops.
+ *   (4) EffectExtractor — `_transferAsset` (object-form recipient) parses into `AssetTransferred` with gas
+ *       charged; a malformed directive is REJECTED (graceful CombineRejected), never silently dropped.
  */
 object AssetFiberTransferSuite extends SimpleIOSuite {
 
@@ -64,9 +66,15 @@ object AssetFiberTransferSuite extends SimpleIOSuite {
       latestUpdateOrdinal = ordinal
     )
 
+  // Object-form AssetHolder recipient literals for embedding in a `_transferAsset` effect — the recipient is
+  // the canonical `{"Fiber":{"fiberId":..}}` / `{"Wallet":{"address":..}}` form ONLY (no bare strings).
+  private def fiberHolderJson(fiberId:  String): String = s"""{ "Fiber": { "fiberId": "$fiberId" } }"""
+  private def walletHolderJson(address: String): String = s"""{ "Wallet": { "address": "$address" } }"""
+
   // An escrow state machine: HOLDING -> RELEASED on a "release" event whose effect emits _transferAsset.
-  // `$asset` is the held asset id, `$recipient` is the destination wallet/fiber id string.
-  private def escrowJson(assetId: UUID, recipient: String): String =
+  // `$assetId` is the held asset id; `recipientJson` is the destination AssetHolder OBJECT literal
+  // (fiberHolderJson(..) / walletHolderJson(..)).
+  private def escrowJson(assetId: UUID, recipientJson: String): String =
     s"""
     {
       "states": {
@@ -82,7 +90,7 @@ object AssetFiberTransferSuite extends SimpleIOSuite {
           "guard": true,
           "effect": {
             "_transferAsset": [
-              { "assetId": "$assetId", "recipient": "$recipient" }
+              { "assetId": "$assetId", "recipient": $recipientJson }
             ],
             "released": true
           },
@@ -128,7 +136,7 @@ object AssetFiberTransferSuite extends SimpleIOSuite {
       val bobStr = bobAddr.value.value
 
       for {
-        escrow <- buildEscrow(escrowId, escrowJson(assetId, bobStr), fixture.ordinal)
+        escrow <- buildEscrow(escrowId, escrowJson(assetId, walletHolderJson(bobStr)), fixture.ordinal)
         asset = heldAsset(assetId, escrowId, ordinal = fixture.ordinal)
         genesis = DataState(
           OnChain.genesis,
@@ -164,8 +172,9 @@ object AssetFiberTransferSuite extends SimpleIOSuite {
       val assetId = UUID.fromString("a55e7000-0000-4000-8000-000000000010")
 
       for {
-        escrow <- buildEscrow(escrowId, escrowJson(assetId, vaultId.toString), fixture.ordinal)
-        vault  <- buildEscrow(vaultId, escrowJson(assetId, "unused"), fixture.ordinal)
+        escrow <- buildEscrow(escrowId, escrowJson(assetId, fiberHolderJson(vaultId.toString)), fixture.ordinal)
+        // the vault never releases, so its recipient is never evaluated — any valid object literal suffices
+        vault <- buildEscrow(vaultId, escrowJson(assetId, fiberHolderJson(vaultId.toString)), fixture.ordinal)
         asset = heldAsset(assetId, escrowId, ordinal = fixture.ordinal)
         genesis = DataState(
           OnChain.genesis,
@@ -198,7 +207,7 @@ object AssetFiberTransferSuite extends SimpleIOSuite {
 
       for {
         // the attacker fiber's transition tries to transfer an asset HELD BY ownerId
-        attacker <- buildEscrow(attackerId, escrowJson(assetId, bobStr), fixture.ordinal)
+        attacker <- buildEscrow(attackerId, escrowJson(assetId, walletHolderJson(bobStr)), fixture.ordinal)
         asset = heldAsset(assetId, ownerId, ordinal = fixture.ordinal) // held by ownerId, NOT attackerId
         genesis = DataState(
           OnChain.genesis,
@@ -233,7 +242,7 @@ object AssetFiberTransferSuite extends SimpleIOSuite {
       val bobStr = fixture.registry.addresses(Bob).value.value
 
       for {
-        escrow <- buildEscrow(escrowId, escrowJson(assetId, bobStr), fixture.ordinal)
+        escrow <- buildEscrow(escrowId, escrowJson(assetId, walletHolderJson(bobStr)), fixture.ordinal)
         asset = heldAsset(assetId, escrowId, behavior = TokenBehavior.Soulbound, ordinal = fixture.ordinal)
         genesis = DataState(
           OnChain.genesis,
@@ -277,7 +286,7 @@ object AssetFiberTransferSuite extends SimpleIOSuite {
             "eventName": "release",
             "guard": { ">": [{ "var": "heldAssets.$assetId.amount" }, 50] },
             "effect": {
-              "_transferAsset": [ { "assetId": "$assetId", "recipient": "$bobStr" } ],
+              "_transferAsset": [ { "assetId": "$assetId", "recipient": ${walletHolderJson(bobStr)} } ],
               "released": true
             },
             "dependencies": []
@@ -329,7 +338,7 @@ object AssetFiberTransferSuite extends SimpleIOSuite {
             "eventName": "release",
             "guard": { ">": [{ "var": "heldAssets.$assetId.amount" }, 50] },
             "effect": {
-              "_transferAsset": [ { "assetId": "$assetId", "recipient": "$bobStr" } ],
+              "_transferAsset": [ { "assetId": "$assetId", "recipient": ${walletHolderJson(bobStr)} } ],
               "released": true
             },
             "dependencies": []
@@ -358,7 +367,7 @@ object AssetFiberTransferSuite extends SimpleIOSuite {
     }
   }
 
-  // ── (4) EffectExtractor: _transferAsset parses into AssetTransferred, gas charged, malformed drops ──
+  // ── (4) EffectExtractor: _transferAsset parses into AssetTransferred, gas charged, malformed REJECTED ──
 
   // A tiny harness to drive EffectExtractor.extractAssetTransfers in the same FiberT MTL stack the engine uses.
   import xyz.kd5ujc.shared_data.fiber.core.FiberTInstances._
@@ -396,8 +405,10 @@ object AssetFiberTransferSuite extends SimpleIOSuite {
           List(
             MapValue(
               Map(
-                ReservedKeys.ASSET_ID  -> StrValue(assetId.toString),
-                ReservedKeys.RECIPIENT -> StrValue(fiberRecipient.toString)
+                ReservedKeys.ASSET_ID -> StrValue(assetId.toString),
+                ReservedKeys.RECIPIENT -> MapValue(
+                  Map("Fiber" -> MapValue(Map("fiberId" -> StrValue(fiberRecipient.toString))))
+                )
               )
             )
           )
@@ -421,8 +432,10 @@ object AssetFiberTransferSuite extends SimpleIOSuite {
           List(
             MapValue(
               Map(
-                ReservedKeys.ASSET_ID  -> MapValue(Map(ReservedKeys.VAR -> StrValue("aid"))),
-                ReservedKeys.RECIPIENT -> MapValue(Map(ReservedKeys.VAR -> StrValue("rcp")))
+                ReservedKeys.ASSET_ID -> MapValue(Map(ReservedKeys.VAR -> StrValue("aid"))),
+                ReservedKeys.RECIPIENT -> MapValue(
+                  Map("Fiber" -> MapValue(Map("fiberId" -> MapValue(Map(ReservedKeys.VAR -> StrValue("rcp"))))))
+                )
               )
             )
           )
@@ -435,7 +448,7 @@ object AssetFiberTransferSuite extends SimpleIOSuite {
     }
   }
 
-  test("EffectExtractor: a recipient DAG-address string resolves to a Wallet holder") {
+  test("EffectExtractor: an object-form Wallet recipient resolves to a Wallet holder") {
     TestFixture.resource(Set(Bob)).use { fixture =>
       val assetId = UUID.fromString("a55e7000-0000-4000-8000-0000000000aa")
       val bobAddr: Address = fixture.registry.addresses(Bob)
@@ -445,8 +458,10 @@ object AssetFiberTransferSuite extends SimpleIOSuite {
             List(
               MapValue(
                 Map(
-                  ReservedKeys.ASSET_ID  -> StrValue(assetId.toString),
-                  ReservedKeys.RECIPIENT -> StrValue(bobAddr.value.value)
+                  ReservedKeys.ASSET_ID -> StrValue(assetId.toString),
+                  ReservedKeys.RECIPIENT -> MapValue(
+                    Map("Wallet" -> MapValue(Map("address" -> StrValue(bobAddr.value.value))))
+                  )
                 )
               )
             )
@@ -459,15 +474,17 @@ object AssetFiberTransferSuite extends SimpleIOSuite {
     }
   }
 
-  test("EffectExtractor: a malformed _transferAsset directive (non-UUID assetId, junk recipient) is dropped") {
+  test("EffectExtractor: a malformed _transferAsset directive is REJECTED (not silently dropped)") {
     val effectBadAsset = MapValue(
       Map(
         ReservedKeys.TRANSFER_ASSET -> ArrayValue(
           List(
             MapValue(
               Map(
-                ReservedKeys.ASSET_ID  -> StrValue("not-a-uuid"),
-                ReservedKeys.RECIPIENT -> StrValue("also-not-anything")
+                ReservedKeys.ASSET_ID -> StrValue("not-a-uuid"),
+                ReservedKeys.RECIPIENT -> MapValue(
+                  Map("Fiber" -> MapValue(Map("fiberId" -> StrValue(UUID.randomUUID().toString))))
+                )
               )
             )
           )
@@ -481,10 +498,12 @@ object AssetFiberTransferSuite extends SimpleIOSuite {
         )
       )
     )
+    def rejected(io: IO[(List[FiberEffect.AssetTransferred], Long)]): IO[Boolean] =
+      io.attempt.map(_.left.toOption.exists(_.isInstanceOf[CombineRejected]))
     for {
-      bad     <- runExtract(effectBadAsset).map(_._1)
-      missing <- runExtract(effectMissingRecipient).map(_._1)
-      none    <- runExtract(MapValue(Map.empty)).map(_._1)
-    } yield expect(bad.isEmpty) and expect(missing.isEmpty) and expect(none.isEmpty)
+      badRejected     <- rejected(runExtract(effectBadAsset))
+      missingRejected <- rejected(runExtract(effectMissingRecipient))
+      none            <- runExtract(MapValue(Map.empty)).map(_._1) // absent directive: no transfer, no error
+    } yield expect(badRejected) and expect(missingRejected) and expect(none.isEmpty)
   }
 }

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/AssetTransferRecipientObjectFormSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/AssetTransferRecipientObjectFormSuite.scala
@@ -1,0 +1,132 @@
+package xyz.kd5ujc.shared_data
+
+import java.util.UUID
+
+import cats.effect.IO
+
+import io.constellationnetwork.metagraph_sdk.json_logic._
+import io.constellationnetwork.schema.SnapshotOrdinal
+import io.constellationnetwork.schema.address.Address
+import io.constellationnetwork.security.hash.Hash
+
+import xyz.kd5ujc.schema.asset.AssetHolder
+import xyz.kd5ujc.schema.fiber._
+import xyz.kd5ujc.shared_data.fiber.core._
+import xyz.kd5ujc.shared_data.fiber.evaluation.EffectExtractor
+import xyz.kd5ujc.shared_data.lifecycle.combine.CombineRejected
+import xyz.kd5ujc.shared_test.Participant._
+import xyz.kd5ujc.shared_test.TestFixture
+
+import weaver.SimpleIOSuite
+
+/**
+ * F2 — asset-effect ergonomics (docs/proposals/fiber-ergonomics/02-asset-effect-ergonomics.md §2): the
+ * `_transferAsset` directive's `recipient` is the canonical [[AssetHolder]] OBJECT form ONLY
+ * (`{"Fiber":{"fiberId":..}}` / `{"Wallet":{"address":..}}`), decoded strictly through the same magnolia
+ * codec as every other holder surface. The legacy bare-string UUID/DAG-address form is GONE, and any
+ * malformed recipient (or assetId) raises a graceful [[CombineRejected]] rather than being silently dropped
+ * — a dropped transfer is a latent bug, not a no-op. Asserts at the
+ * [[EffectExtractor.extractAssetTransfers]] boundary (which sees ALREADY-RESOLVED values; a DYNAMIC
+ * `{"Fiber":{"fiberId":{"var":..}}}` is resolved by the prior effect eval, proven end-to-end by
+ * `AssetFiberTransferSuite` + the e2e lanes) that:
+ *   - object `{"Fiber":{"fiberId":<uuid>}}` ⇒ Fiber, `{"Wallet":{"address":<addr>}}` ⇒ Wallet,
+ *   - a bare-string recipient is REJECTED (not silently honored under the old disambiguation),
+ *   - a malformed object (unknown variant / missing field / bad address) is REJECTED (not dropped),
+ *   - a non-UUID assetId is REJECTED (not dropped).
+ */
+object AssetTransferRecipientObjectFormSuite extends SimpleIOSuite {
+
+  import xyz.kd5ujc.shared_data.fiber.core.FiberTInstances._
+
+  // Drive EffectExtractor.extractAssetTransfers in the same FiberT MTL stack the engine uses.
+  private def runExtract(
+    effectResult: JsonLogicValue,
+    ctx:          JsonLogicValue = MapValue(Map.empty)
+  ): IO[List[FiberEffect.AssetTransferred]] = {
+    val prog: FiberT[IO, List[FiberEffect.AssetTransferred]] =
+      EffectExtractor.extractAssetTransfers[IO, FiberT[IO, *]](effectResult, ctx)
+    prog
+      .run(
+        FiberContext(
+          SnapshotOrdinal.MinValue,
+          Hash.empty,
+          io.constellationnetwork.schema.epoch
+            .EpochProgress(eu.timepit.refined.types.numeric.NonNegLong.unsafeFrom(0L)),
+          ExecutionLimits(),
+          io.constellationnetwork.metagraph_sdk.json_logic.gas.GasConfig.Default,
+          FiberGasConfig.Default
+        )
+      )
+      .runA(ExecutionState.initial)
+  }
+
+  // Build a single-directive `_transferAsset` effect with the given assetId + recipient JsonLogicValue.
+  private def transferEffect(assetId: JsonLogicValue, recipient: JsonLogicValue): JsonLogicValue =
+    MapValue(
+      Map(
+        ReservedKeys.TRANSFER_ASSET -> ArrayValue(
+          List(MapValue(Map(ReservedKeys.ASSET_ID -> assetId, ReservedKeys.RECIPIENT -> recipient)))
+        )
+      )
+    )
+
+  private def fiberObj(id: UUID): JsonLogicValue =
+    MapValue(Map("Fiber" -> MapValue(Map("fiberId" -> StrValue(id.toString)))))
+
+  private def walletObj(addr: Address): JsonLogicValue =
+    MapValue(Map("Wallet" -> MapValue(Map("address" -> StrValue(addr.value.value)))))
+
+  // The IO raises CombineRejected on any malformation; assert it failed with exactly that.
+  private def isRejected(io: IO[List[FiberEffect.AssetTransferred]]): IO[Boolean] =
+    io.attempt.map(_.left.toOption.exists(_.isInstanceOf[CombineRejected]))
+
+  // ── the canonical AssetHolder object form is accepted ───────────────────────────────────────────
+
+  test("object form {\"Fiber\":{\"fiberId\":<uuid>}} ⇒ AssetHolder.Fiber") {
+    val assetId = UUID.fromString("a55e7000-0000-4000-8000-0000000000f3")
+    val fiberRecipient = UUID.fromString("acc70000-0000-4000-8000-0000000000f3")
+    runExtract(transferEffect(StrValue(assetId.toString), fiberObj(fiberRecipient))).map { transfers =>
+      expect(transfers == List(FiberEffect.AssetTransferred(assetId, AssetHolder.Fiber(fiberRecipient))))
+    }
+  }
+
+  test("object form {\"Wallet\":{\"address\":<dag-addr>}} ⇒ AssetHolder.Wallet") {
+    TestFixture.resource(Set(Bob)).use { fixture =>
+      val assetId = UUID.fromString("a55e7000-0000-4000-8000-0000000000f4")
+      val bobAddr: Address = fixture.registry.addresses(Bob)
+      runExtract(transferEffect(StrValue(assetId.toString), walletObj(bobAddr))).map { transfers =>
+        expect(transfers == List(FiberEffect.AssetTransferred(assetId, AssetHolder.Wallet(bobAddr))))
+      }
+    }
+  }
+
+  // ── the legacy bare-string form is now REJECTED, not silently honored ───────────────────────────
+
+  test("bare-string recipient is REJECTED (CombineRejected), not honored") {
+    val assetId = UUID.fromString("a55e7000-0000-4000-8000-0000000000f1")
+    val fiberRecipient = UUID.fromString("acc70000-0000-4000-8000-0000000000f1")
+    isRejected(runExtract(transferEffect(StrValue(assetId.toString), StrValue(fiberRecipient.toString)))).map(expect(_))
+  }
+
+  // ── malformed recipients are REJECTED loudly, never dropped ─────────────────────────────────────
+
+  test("malformed object recipients are REJECTED (no silent drop)") {
+    val assetId = StrValue(UUID.fromString("a55e7000-0000-4000-8000-0000000000f5").toString)
+    val bothVariant =
+      MapValue(Map("Both" -> MapValue(Map("fiberId" -> StrValue("acc70000-0000-4000-8000-0000000000a1")))))
+    val badFiberField = MapValue(Map("Fiber" -> MapValue(Map("nope" -> StrValue("x")))))
+    val badWalletAddr = MapValue(Map("Wallet" -> MapValue(Map("address" -> StrValue("not-a-dag-address")))))
+    for {
+      a <- isRejected(runExtract(transferEffect(assetId, bothVariant)))
+      b <- isRejected(runExtract(transferEffect(assetId, badFiberField)))
+      c <- isRejected(runExtract(transferEffect(assetId, badWalletAddr)))
+    } yield expect(a) and expect(b) and expect(c)
+  }
+
+  // ── a non-UUID assetId is REJECTED loudly ───────────────────────────────────────────────────────
+
+  test("non-UUID assetId is REJECTED (no silent drop)") {
+    val fiberRecipient = UUID.fromString("acc70000-0000-4000-8000-0000000000f7")
+    isRejected(runExtract(transferEffect(StrValue("not-a-uuid"), fiberObj(fiberRecipient)))).map(expect(_))
+  }
+}


### PR DESCRIPTION
Implements **F2** of the fiber-ergonomics program, **revised per review** to drop back-compat (greenfield) and surface parse failures instead of dropping them.

## The new contract for `_transferAsset` recipient
- **Object form ONLY** — `{"Fiber":{"fiberId":..}}` / `{"Wallet":{"address":..}}`, decoded strictly through the same magnolia `AssetHolder` codec as every other holder surface. The legacy **bare-string** UUID/DAG-address disambiguation is **removed**.
- **Fail loud** — any malformed directive (non-object item, missing/non-UUID `assetId`, a recipient that isn't a well-formed `AssetHolder` object, or a gas/eval failure) raises a graceful **`CombineRejected`** instead of being silently dropped. A silently-dropped transfer is a latent bug; surfacing it is deliberate.

## Why combine is the right layer (and what's caught earlier)
The recipient isn't in the signed `TransitionStateMachine` message — it's the *evaluated* output of the definition's effect against runtime context (usually dynamic, `{"Fiber":{"fiberId":{"var":"event.x"}}}`). So the resolved holder is only knowable at combine, and extraction runs **only** on the combiner apply path (never `validateSignedUpdate`) — making the raise a rule-#2 graceful reject (caught at `insert` → `RejectionReceipt`), the same pattern `AssetCombiner` already uses for the R1 holder check. The **static** recipient shape is caught earlier and **advisory** by the `DefinitionLinter` (linter-only — no hard registration gate, per review).

## Migrates every call site
- **chain tests**: `AssetFiberTransferSuite` (escrow E2E + extractor units — escrow now moves to both `Fiber` and `Wallet` object recipients through the full combiner; "malformed dropped" → "malformed REJECTED"), `AssetTransferRecipientObjectFormSuite` (the contract). **Full `sharedData/test` green (572/0).**
- **e2e defs**: `riverdale-economy` (7 recipients → `Fiber`), `staked-oracle-pool` (4 → `Wallet`, `event.agent` = a wallet address). `sigma-mixer` has no `_transferAsset` recipients. Validated end-to-end by the e2e lanes on CI.

The SDK builder side (`@ottochain/sdk` `transferAsset`/`toFiber`/`toWallet` → object form + app examples) is migrated separately on the SDK PR (#227).

Part of the fiber-ergonomics implementation set (RFCs in #192).

🤖 Generated with [Claude Code](https://claude.com/claude-code)