### PR TITLE
feat(fiber): transitionPolicy dial + auto-declared machines deps

### DIFF
--- a/modules/models/src/main/scala/xyz/kd5ujc/schema/fiber/FiberPolicy.scala
+++ b/modules/models/src/main/scala/xyz/kd5ujc/schema/fiber/FiberPolicy.scala
@@ -61,6 +61,50 @@ object DependencyMode extends Enum[DependencyMode] with CirceEnum[DependencyMode
 }
 
 /**
+ * Who may submit a `TransitionStateMachine` for this fiber — the WALLET/owner authorization axis, enforced on
+ * the AUTHORITATIVE apply path (the combiner) as a graceful `CombineRejected`
+ * (03-cross-fiber-and-authorization.md §3). Orthogonal to [[FiberPolicy.Constrained.acceptedCallers]] (the
+ * FIBER-origin `$caller` axis); the two compose. Ordered loosest→tightest by `rank`; the tighten-only lattice
+ * may only move UP (Open → OwnersOrParticipants → Owners), never loosen — so a fiber can never launder itself
+ * from `Owners` down to `Open`. An ABSENT dial is [[TransitionPolicy.Open]] (rank 0) — today's LIVE,
+ * guard-only behaviour — so every pre-dial fiber is UNCHANGED and apps opt UP explicitly (the §3.4 / §6 Q1
+ * default-Open decision; tightening the default is a separate, maintainer-reserved security call).
+ */
+sealed trait TransitionPolicy { def rank: Int }
+
+object TransitionPolicy {
+
+  /** Any signer; the transition GUARD is the sole gate (today's live behaviour). LOOSEST — the absent default. */
+  case object Open extends TransitionPolicy { val rank = 0 }
+
+  /** The verified signer(s) must be in `owners ∪ authorizedSigners` (the create-time participant allowlist). */
+  case object OwnersOrParticipants extends TransitionPolicy { val rank = 1 }
+
+  /** The verified signer(s) must be in `owners` only. TIGHTEST. */
+  case object Owners extends TransitionPolicy { val rank = 2 }
+
+  /** The default tier for an absent dial — `Open` (today's live guard-only behaviour). Use everywhere `None`. */
+  val default: TransitionPolicy = Open
+
+  // Bare, self-documenting string tags (mirrors UpgradePolicy's bare-object branch + FiberPolicy.Immutable's
+  // "Immutable"): total, fail-closed. The canonical/signing paths `dropNulls`, so an absent dial is stripped
+  // and a pre-dial definition stays byte-identical (rule #1); a set dial round-trips through the tag.
+  implicit val encoder: Encoder[TransitionPolicy] = Encoder.instance {
+    case Open                 => Json.fromString("Open")
+    case OwnersOrParticipants => Json.fromString("OwnersOrParticipants")
+    case Owners               => Json.fromString("Owners")
+  }
+
+  implicit val decoder: Decoder[TransitionPolicy] =
+    Decoder.decodeString.emap {
+      case "Open"                 => Right(Open)
+      case "OwnersOrParticipants" => Right(OwnersOrParticipants)
+      case "Owners"               => Right(Owners)
+      case other                  => Left(s"unknown transitionPolicy '$other'")
+    }
+}
+
+/**
  * Recipient allowlist for `_transferAsset`. Carries NO conservation/amount notion: `AssetTransferred` is a
  * whole-record custody move with no amount, so the only meaningful dial is WHO may receive. `None` on either
  * field ⇒ that recipient class is unconstrained.
@@ -192,11 +236,11 @@ final case class VersionRange(
  *   - [[FiberPolicy.Unconstrained]] — the named default: NO surrendered capability, today's legacy behaviour.
  *     Replaces the old `None`/`Some(empty)`. [[StateMachineDefinition.policy]] defaults to it, so a pre-policy
  *     definition is hash-identical to one that explicitly declares `Unconstrained`.
- *   - [[FiberPolicy.Constrained]] — at least one of the 14 dials is set. A fiber voluntarily surrenders a capability
+ *   - [[FiberPolicy.Constrained]] — at least one of the 15 dials is set. A fiber voluntarily surrenders a capability
  *     in return for a guarantee any external observer can verify by resolving ONE `logicHash`-anchored field.
  *
  * Every dial of [[Constrained]] is `Option`/defaulted so a partial policy survives `dropNulls` byte-stably. A
- * `Constrained` with ALL 14 dials empty is SEMANTICALLY identical to `Unconstrained`; the smart constructor
+ * `Constrained` with ALL 15 dials empty is SEMANTICALLY identical to `Unconstrained`; the smart constructor
  * [[FiberPolicy.constrained]] (and the decoder) collapse it to `Unconstrained` so there is exactly ONE canonical
  * representation of "unconstrained". This is the internal-determinism rule the verified re-bind
  * (`definition.computeDigest === logicHash`) relies on: an absent policy key, `Unconstrained`, and an
@@ -254,7 +298,7 @@ object FiberPolicy {
   case object Immutable extends FiberPolicy
 
   /**
-   * A constitution that sets at least one of the 14 dials. Constructed ONLY via the smart constructor
+   * A constitution that sets at least one of the 15 dials. Constructed ONLY via the smart constructor
    * [[FiberPolicy.constrained]] (or the decoder), which collapses an all-empty `Constrained` to [[Unconstrained]] so
    * there is exactly ONE canonical "unconstrained" form, and `constrained` further collapses an only-
    * upgradePolicy=Immutable bundle to [[Immutable]]. Encodes as its bare dials object `{<set dials, after
@@ -268,6 +312,7 @@ object FiberPolicy {
     maxGenerations:   Option[Int] = None, // same-definition-hash spawn-lineage depth cap
     maxSpawnFanout:   Option[Int] = None, // children per single transition (tighter than ExecutionLimits cap)
     acceptedCallers:  Option[Set[UUID]] = None, // fiber-origin ($caller) allowlist; user/wallet origin unaffected
+    transitionPolicy: Option[TransitionPolicy] = None, // wallet/owner transition-auth axis; None ⇒ Open (legacy)
     sealedStates:     Option[Set[StateId]] = None, // states from which NO transition may fire (terminal/halted)
     transferPolicy:   Option[TransferPolicy] = None,
     dependencyPolicy: Option[DependencyPolicy] = None,
@@ -283,9 +328,9 @@ object FiberPolicy {
     def isEmpty: Boolean =
       selfReproducing.isEmpty && allowedEffects.isEmpty && spawnOwnerPolicy.isEmpty &&
       maxGenerations.isEmpty && maxSpawnFanout.isEmpty && acceptedCallers.isEmpty &&
-      sealedStates.isEmpty && transferPolicy.isEmpty && dependencyPolicy.isEmpty &&
-      upgradePolicy.isEmpty && version.isEmpty && compatibleWith.isEmpty &&
-      interfaces.isEmpty && migrationAuthority.isEmpty
+      transitionPolicy.isEmpty && sealedStates.isEmpty && transferPolicy.isEmpty &&
+      dependencyPolicy.isEmpty && upgradePolicy.isEmpty && version.isEmpty &&
+      compatibleWith.isEmpty && interfaces.isEmpty && migrationAuthority.isEmpty
 
     /** Exactly `upgradePolicy = Immutable` and nothing else — semantically equal to [[FiberPolicy.Immutable]]. */
     def isImmutable: Boolean =
@@ -315,6 +360,7 @@ object FiberPolicy {
     maxGenerations:     Option[Int] = None,
     maxSpawnFanout:     Option[Int] = None,
     acceptedCallers:    Option[Set[UUID]] = None,
+    transitionPolicy:   Option[TransitionPolicy] = None,
     sealedStates:       Option[Set[StateId]] = None,
     transferPolicy:     Option[TransferPolicy] = None,
     dependencyPolicy:   Option[DependencyPolicy] = None,
@@ -332,6 +378,7 @@ object FiberPolicy {
         maxGenerations,
         maxSpawnFanout,
         acceptedCallers,
+        transitionPolicy,
         sealedStates,
         transferPolicy,
         dependencyPolicy,
@@ -422,6 +469,10 @@ object FiberPolicy {
           _ <- capShrinks("maxGenerations", o.maxGenerations, n.maxGenerations)
           _ <- capShrinks("maxSpawnFanout", o.maxSpawnFanout, n.maxSpawnFanout)
           _ <- subset("acceptedCallers", o.acceptedCallers, n.acceptedCallers)
+          // transitionPolicy: the auth posture may only TIGHTEN (rank up: Open ⊐ OwnersOrParticipants ⊐
+          // Owners); an absent dial is Open (rank 0), so None→Some(stricter) is OK and a stricter-old→None
+          // loosens (rejected). Never launder Owners down to Open across a migration.
+          _ <- rankUp("transitionPolicy", o.transitionPolicy.map(_.rank), n.transitionPolicy.map(_.rank))
           _ <- superset("sealedStates", o.sealedStates, n.sealedStates)
           _ <- transferTightens(o.transferPolicy, n.transferPolicy)
           _ <- dependencyTightens(o.dependencyPolicy, n.dependencyPolicy)

--- a/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/fiber/evaluation/FiberEvaluator.scala
+++ b/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/fiber/evaluation/FiberEvaluator.scala
@@ -170,8 +170,13 @@ object FiberEvaluator {
                   input,
                   proofs,
                   // machines context = this transition's STATIC dependencies ∪ the fiber's ACTIVE
-                  // runtime (dynamic) dependencies. (#24)
-                  transition.dependencies ++ DependencyLedger.activeIds(fiber.dynamicDependencies)
+                  // runtime (dynamic) dependencies (#24) ∪ the F6 AUTO-DECLARED static `machines.<uuid>`
+                  // references scanned from the guard/effect AST (03-cross-fiber-and-authorization.md §2a).
+                  // The auto set augments the RUNTIME dep set ONLY — it NEVER mutates the signed, hash-pinned
+                  // `transition.dependencies` (rule #1); the projection stays bounded (finite, parse-time-known).
+                  transition.dependencies ++
+                  DependencyLedger.activeIds(fiber.dynamicDependencies) ++
+                  StaticDependencyScan.staticMachineRefs(transition)
                 )
                 .liftTo[G]
               result <- evaluateGuardAndApply(

--- a/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/fiber/evaluation/StaticDependencyScan.scala
+++ b/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/fiber/evaluation/StaticDependencyScan.scala
@@ -1,0 +1,50 @@
+package xyz.kd5ujc.shared_data.fiber.evaluation
+
+import java.util.UUID
+
+import scala.util.Try
+
+import io.constellationnetwork.metagraph_sdk.json_logic._
+
+import xyz.kd5ujc.schema.fiber.{ReservedKeys, Transition}
+
+/**
+ * F6 (03-cross-fiber-and-authorization.md §2, option a) — AUTO-DECLARE cross-fiber READ dependencies.
+ *
+ * A guard/effect that statically reads `{"var":"machines.<uuid>.…"}` with a LITERAL `<uuid>` declares the
+ * cross-fiber read in the same breath as performing it; the author should not also have to hand-maintain the
+ * matching `Transition.dependencies` entry (the silent-`null` trap). This scanner walks a transition's guard +
+ * effect AST (the same recursion shape as `FiberRules.L1.extractMapKeys` / `CommonRules.checkExpressionDepth`)
+ * and returns every literally-referenced `machines.<uuid>` id.
+ *
+ * SCOPE (rule #1): the result augments ONLY the RUNTIME dependency set handed to `ContextProvider.buildContext`
+ * (`FiberEvaluator.tryTransitions`). It MUST NEVER be written back into the signed, hash-pinned
+ * `Transition.dependencies` field — that would diverge the canonical. The bound `buildMachinesContext` relies
+ * on is preserved: the auto-added set is exactly the statically-referenced ids, finite and parse-time-known.
+ *
+ * A COMPUTED target (`{"var":"event.target"}`) cannot be resolved statically and is intentionally NOT covered;
+ * that residue still needs an explicit static `dependencies` entry or the runtime `_addDependency` path.
+ */
+object StaticDependencyScan {
+
+  /** Every literal `machines.<uuid>` id referenced by this transition's guard or effect expressions. */
+  def staticMachineRefs(transition: Transition): Set[UUID] =
+    collect(transition.guard) ++ collect(transition.effect)
+
+  private def collect(expr: JsonLogicExpression): Set[UUID] =
+    expr match {
+      case MapExpression(map)              => map.values.flatMap(collect).toSet
+      case ApplyExpression(_, args)        => args.flatMap(collect).toSet
+      case ArrayExpression(items)          => items.flatMap(collect).toSet
+      case VarExpression(Left(path), _)    => machineRefFromPath(path).toSet
+      case VarExpression(Right(nested), _) => collect(nested)
+      case _                               => Set.empty
+    }
+
+  /** Parse `machines.<uuid>[.…]` → the `<uuid>`; any non-`machines` path or non-UUID segment ⇒ None. */
+  private def machineRefFromPath(path: String): Option[UUID] =
+    path.split('.').toList match {
+      case head :: id :: _ if head == ReservedKeys.MACHINES => Try(UUID.fromString(id)).toOption
+      case _                                                => None
+    }
+}

--- a/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/combine/FiberCombiner.scala
+++ b/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/combine/FiberCombiner.scala
@@ -121,6 +121,34 @@ class FiberCombiner[F[_]: Async: SecurityProvider](
       )
       .whenA(fiberRecord.sequenceNumber =!= update.targetSequenceNumber)
 
+    // F7 signer-authorization, enforced HERE on the AUTHORITATIVE apply path (03-cross-fiber-and-
+    // authorization.md §3) — the binding gate, not the validator. Graceful `CombineRejected` (rule #2: never a
+    // block-acceptance Invalid; a stateful Invalid would drop the whole all-or-nothing snapshot). Reads ONLY
+    // the fiber's own hash-pinned `definition.policy` dial + the stable `owners`/`authorizedSigners` record
+    // fields — NO registry/asset lineage (rule #3 — outside the TOCTOU hazard class). The absent dial defaults
+    // to `Open` (today's LIVE guard-only behaviour), so every existing fiber is UNCHANGED and apps opt UP
+    // explicitly (the §3.4 / §6 Q1 default-Open decision). Verified signer resolution mirrors the create path
+    // (:50) and `FiberRules.L0.updateSignedByOwnerOrParticipant`.
+    signerAddresses <- update.proofs.toList.traverse(_.id.toAddress).map(_.toSet)
+    effectivePolicy = fiberRecord.definition.policy.dials
+      .flatMap(_.transitionPolicy)
+      .getOrElse(TransitionPolicy.default)
+    transitionAuthorized = effectivePolicy match {
+      case TransitionPolicy.Open => true
+      case TransitionPolicy.OwnersOrParticipants =>
+        signerAddresses.intersect(fiberRecord.owners ++ fiberRecord.authorizedSigners).nonEmpty
+      case TransitionPolicy.Owners =>
+        signerAddresses.intersect(fiberRecord.owners).nonEmpty
+    }
+    _ <- Async[F]
+      .raiseError(
+        CombineRejected(
+          s"transition on fiber ${update.fiberId} not authorized: signer(s) not permitted by " +
+          s"transitionPolicy=$effectivePolicy"
+        )
+      )
+      .whenA(!transitionAuthorized)
+
     input = FiberInput.Transition(update.eventName, update.payload)
     proofsList = update.proofs.toList
 

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/AutoDependencyScanSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/AutoDependencyScanSuite.scala
@@ -1,0 +1,126 @@
+package xyz.kd5ujc.shared_data
+
+import java.util.UUID
+
+import cats.effect.IO
+import cats.effect.std.UUIDGen
+import cats.syntax.all._
+
+import io.constellationnetwork.currency.dataApplication.{DataState, L0NodeContext}
+import io.constellationnetwork.metagraph_sdk.json_logic._
+import io.constellationnetwork.security.SecurityProvider
+import io.constellationnetwork.security.signature.Signed
+
+import xyz.kd5ujc.schema.fiber._
+import xyz.kd5ujc.schema.{CalculatedState, OnChain, Records, Updates}
+import xyz.kd5ujc.shared_data.fiber.evaluation.StaticDependencyScan
+import xyz.kd5ujc.shared_data.lifecycle.Combiner
+import xyz.kd5ujc.shared_test.Participant._
+import xyz.kd5ujc.shared_test.TestFixture
+
+import io.circe.parser._
+import weaver.SimpleIOSuite
+
+/**
+ * F6 (03-cross-fiber-and-authorization.md §2, option a): a guard/effect that statically reads
+ * `{"var":"machines.<uuid>.…"}` AUTO-DECLARES `<uuid>` as a runtime read dependency, so the read resolves
+ * (non-null) WITHOUT the author hand-adding it to `Transition.dependencies`. The augmentation is RUNTIME-only
+ * — it never mutates the signed, hash-pinned `dependencies` field (rule #1).
+ */
+object AutoDependencyScanSuite extends SimpleIOSuite {
+
+  // ── pure scanner ───────────────────────────────────────────────────────────────────────────────────
+
+  pureTest("staticMachineRefs collects literal machines.<uuid> ids from guard AND effect") {
+    val bId = UUID.randomUUID()
+    val cId = UUID.randomUUID()
+    val t = Transition(
+      from = StateId("s0"),
+      to = StateId("s1"),
+      eventName = "go",
+      guard = VarExpression(Left(s"machines.$bId.state.flag")), // guard-side ref
+      effect = MapExpression(Map("copied" -> VarExpression(Left(s"machines.$cId.state.x")))), // effect-side ref
+      dependencies = Set.empty // neither declared
+    )
+    expect(StaticDependencyScan.staticMachineRefs(t) == Set(bId, cId))
+  }
+
+  pureTest("staticMachineRefs ignores non-machines paths and computed (non-literal) targets") {
+    val t = Transition(
+      from = StateId("s0"),
+      to = StateId("s1"),
+      eventName = "go",
+      guard = ConstExpression(BoolValue(true)),
+      effect = MapExpression(
+        Map(
+          "self"     -> VarExpression(Left("state.value")),
+          "computed" -> VarExpression(Left("event.target")) // a computed id is NOT statically resolvable
+        )
+      ),
+      dependencies = Set.empty
+    )
+    expect(StaticDependencyScan.staticMachineRefs(t).isEmpty)
+  }
+
+  // ── end-to-end: the read resolves through the engine without a declared dependency ───────────────────
+
+  private val targetDefJson: String =
+    """{ "states": { "b0": { "id": "b0", "isFinal": false } }, "initialState": "b0", "transitions": [] }"""
+
+  test("an UNDECLARED machines.<uuid> read resolves (non-null) via the auto-declared dependency") {
+    TestFixture.resource(Set(Alice)).use { fixture =>
+      implicit val s: SecurityProvider[IO] = fixture.securityProvider
+      implicit val l0ctx: L0NodeContext[IO] = fixture.l0Context
+      for {
+        combiner <- Combiner.make[IO]().pure[IO]
+        targetId <- UUIDGen.randomUUID[IO]
+        readerId <- UUIDGen.randomUUID[IO]
+
+        // Target fiber B holds state { x: 42 }.
+        targetDef <- IO.fromEither(decode[StateMachineDefinition](targetDefJson))
+        createB = Updates.CreateStateMachine(targetId, targetDef, MapValue(Map("x" -> IntValue(42))))
+        createBProof <- fixture.registry.generateProofs(createB, Set(Alice))
+        afterB <- combiner.insert(DataState(OnChain.genesis, CalculatedState.genesis), Signed(createB, createBProof))
+
+        // Reader fiber A reads machines.<B>.state.x but declares NO dependency (dependencies: []).
+        readerDefJson =
+          s"""
+          {
+            "states": { "a0": { "id": "a0", "isFinal": false }, "a1": { "id": "a1", "isFinal": false } },
+            "initialState": "a0",
+            "transitions": [
+              { "from": "a0", "to": "a1", "eventName": "seed", "guard": true,
+                "effect": { "copied": { "var": "machines.$targetId.state.x" } }, "dependencies": [] }
+            ]
+          }
+          """
+        readerDef <- IO.fromEither(decode[StateMachineDefinition](readerDefJson))
+        createA = Updates.CreateStateMachine(readerId, readerDef, MapValue(Map.empty[String, JsonLogicValue]))
+        createAProof <- fixture.registry.generateProofs(createA, Set(Alice))
+        afterA       <- combiner.insert(afterB, Signed(createA, createAProof))
+
+        seed = Updates.TransitionStateMachine(
+          readerId,
+          "seed",
+          MapValue(Map.empty[String, JsonLogicValue]),
+          FiberOrdinal.MinValue
+        )
+        seedProof <- fixture.registry.generateProofs(seed, Set(Alice))
+        afterSeed <- combiner.insert(afterA, Signed(seed, seedProof))
+
+        reader = afterSeed.calculated.stateMachines
+          .get(readerId)
+          .collect { case r: Records.StateMachineFiberRecord => r }
+        copied = reader.flatMap { f =>
+          f.stateData match {
+            case MapValue(m) => m.get("copied")
+            case _           => None
+          }
+        }
+      } yield
+      // the auto-declared dep projected B, so the read returned 42 (NOT null)
+      expect(reader.map(_.currentState).contains(StateId("a1"))) and
+      expect(copied.contains(IntValue(BigInt(42))))
+    }
+  }
+}

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/PublishVersionSigningCanonicalSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/PublishVersionSigningCanonicalSuite.scala
@@ -5,6 +5,7 @@ import cats.effect.IO
 
 import xyz.kd5ujc.schema.Updates
 import xyz.kd5ujc.schema.Updates.OttochainMessage
+import xyz.kd5ujc.schema.fiber.{FiberPolicy, StateMachineDefinition, TransitionPolicy}
 import xyz.kd5ujc.shared_data.lifecycle.validate.RegistryValidator
 
 import io.circe.parser.{decode, parse}
@@ -100,5 +101,41 @@ object PublishVersionSigningCanonicalSuite extends SimpleIOSuite {
       case Right(other) => IO.pure(failure(s"decoded to unexpected type: ${other.getClass.getSimpleName}"))
       case Left(err)    => IO.pure(failure(s"DECODE FAILED: $err"))
     }
+  }
+
+  // ── F7 transitionPolicy dial — rule #1 canonical guards (03-cross-fiber-and-authorization.md §5) ──────
+  // The dial is a new signed-message surface inside StateMachineDefinition.policy (FiberPolicy.Constrained).
+  // It MUST be Option/omit-safe: an ABSENT dial encodes byte-identically to the pre-change canonical (None →
+  // null → stripped by dropNulls); a SET dial round-trips through its bare string tag.
+
+  // A definition exactly as a pre-dial client wrote it — no `policy` key, no `transitionPolicy`. Guards
+  // ({"==":[1,1]}) + empty effect are the round-trip-proven shapes from `harnessJson`.
+  private val defNoPolicyJson: String =
+    """{
+      |  "states":{"s0":{"id":"s0","isFinal":false},"s1":{"id":"s1","isFinal":false}},
+      |  "initialState":"s0",
+      |  "transitions":[{"from":"s0","to":"s1","eventName":"ping","guard":{"==":[1,1]},"effect":{},"dependencies":[]}]
+      |}""".stripMargin
+
+  test("absent transitionPolicy: decode->encode injects nothing (byte-identical canonical)") {
+    val parsed = parse(defNoPolicyJson).toOption.get
+    val reencoded = decode[StateMachineDefinition](defNoPolicyJson).toOption.get.asJson
+    IO.pure(
+      expect.same(dropNulls(reencoded), dropNulls(parsed)) and
+      expect(!dropNulls(reencoded).noSpaces.contains("transitionPolicy")) and
+      expect(!dropNulls(reencoded).noSpaces.contains("policy"))
+    )
+  }
+
+  test("set transitionPolicy = Owners round-trips and emits its bare string tag") {
+    val base = decode[StateMachineDefinition](defNoPolicyJson).toOption.get
+    val withDial = base.copy(policy = FiberPolicy.constrained(transitionPolicy = Some(TransitionPolicy.Owners)))
+    val encoded = withDial.asJson
+    IO.pure(
+      expect(decode[StateMachineDefinition](encoded.noSpaces) == Right(withDial)) and
+      expect(dropNulls(encoded).noSpaces.contains("\"transitionPolicy\":\"Owners\"")) and
+      // a SET dial does NOT collapse to Unconstrained — the `policy` key is present
+      expect(dropNulls(encoded).noSpaces.contains("\"policy\""))
+    )
   }
 }

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/TransitionPolicyEnforcementSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/TransitionPolicyEnforcementSuite.scala
@@ -1,0 +1,152 @@
+package xyz.kd5ujc.shared_data
+
+import cats.effect.IO
+import cats.effect.std.UUIDGen
+import cats.syntax.all._
+
+import io.constellationnetwork.currency.dataApplication.{DataState, L0NodeContext}
+import io.constellationnetwork.metagraph_sdk.json_logic._
+import io.constellationnetwork.security.SecurityProvider
+import io.constellationnetwork.security.signature.Signed
+
+import xyz.kd5ujc.schema.fiber._
+import xyz.kd5ujc.schema.{CalculatedState, OnChain, Records, Updates}
+import xyz.kd5ujc.shared_data.lifecycle.Combiner
+import xyz.kd5ujc.shared_test.Participant._
+import xyz.kd5ujc.shared_test.TestFixture
+
+import io.circe.parser._
+import weaver.SimpleIOSuite
+
+/**
+ * F7 fix (03-cross-fiber-and-authorization.md §3): transition signer-authorization is now enforced on the
+ * AUTHORITATIVE apply path (the combiner) via the opt-in `transitionPolicy` dial, as a graceful
+ * `CombineRejected` (rule #2). The ABSENT-dial default is `Open` (today's live guard-only behaviour), so every
+ * existing fiber is UNCHANGED — `TransitionOwnerGateDivergenceSuite` and `MultiPartyTransitionSigningSuite`
+ * stay green. Apps opt UP explicitly: `OwnersOrParticipants` or `Owners`.
+ */
+object TransitionPolicyEnforcementSuite extends SimpleIOSuite {
+
+  private val defJson: String =
+    """
+    {
+      "states": {
+        "s0": { "id": "s0", "isFinal": false },
+        "s1": { "id": "s1", "isFinal": false }
+      },
+      "initialState": "s0",
+      "transitions": [
+        { "from": "s0", "to": "s1", "eventName": "ping", "guard": true, "effect": { "status": "s1" }, "dependencies": [] }
+      ]
+    }
+    """
+
+  private def mkPing(fiberId: java.util.UUID): Updates.TransitionStateMachine =
+    Updates.TransitionStateMachine(
+      fiberId,
+      "ping",
+      MapValue(Map.empty[String, JsonLogicValue]),
+      FiberOrdinal.MinValue
+    )
+
+  private def fiberOf(
+    state:   DataState[OnChain, CalculatedState],
+    fiberId: java.util.UUID
+  ): Option[Records.StateMachineFiberRecord] =
+    state.calculated.stateMachines.get(fiberId).collect { case r: Records.StateMachineFiberRecord => r }
+
+  test("default (absent) transitionPolicy is Open: a non-owner's transition APPLIES via the combiner") {
+    TestFixture.resource(Set(Alice, Bob)).use { fixture =>
+      implicit val s: SecurityProvider[IO] = fixture.securityProvider
+      implicit val l0ctx: L0NodeContext[IO] = fixture.l0Context
+      for {
+        combiner   <- Combiner.make[IO]().pure[IO]
+        fiberId    <- UUIDGen.randomUUID[IO]
+        machineDef <- IO.fromEither(decode[StateMachineDefinition](defJson)) // policy = Unconstrained (absent dial)
+
+        create = Updates.CreateStateMachine(fiberId, machineDef, MapValue(Map.empty[String, JsonLogicValue]))
+        createProof <- fixture.registry.generateProofs(create, Set(Alice))
+        afterCreate <- combiner.insert(DataState(OnChain.genesis, CalculatedState.genesis), Signed(create, createProof))
+
+        // Bob — NOT an owner, NOT a participant — signs; under Open the guard is the sole gate, so it APPLIES.
+        bobProof  <- fixture.registry.generateProofs(mkPing(fiberId), Set(Bob))
+        afterPing <- combiner.insert(afterCreate, Signed(mkPing(fiberId), bobProof))
+        applied = fiberOf(afterPing, fiberId)
+      } yield expect(applied.map(_.currentState).contains(StateId("s1"))) and
+      expect(applied.exists(_.sequenceNumber > FiberOrdinal.MinValue))
+    }
+  }
+
+  test(
+    "transitionPolicy = Owners: a non-owner's transition is CombineRejected (state UNCHANGED), owner still applies"
+  ) {
+    TestFixture.resource(Set(Alice, Bob)).use { fixture =>
+      implicit val s: SecurityProvider[IO] = fixture.securityProvider
+      implicit val l0ctx: L0NodeContext[IO] = fixture.l0Context
+      for {
+        combiner <- Combiner.make[IO]().pure[IO]
+        fiberId  <- UUIDGen.randomUUID[IO]
+        baseDef  <- IO.fromEither(decode[StateMachineDefinition](defJson))
+        machineDef = baseDef.copy(policy = FiberPolicy.constrained(transitionPolicy = Some(TransitionPolicy.Owners)))
+
+        create = Updates.CreateStateMachine(fiberId, machineDef, MapValue(Map.empty[String, JsonLogicValue]))
+        createProof <- fixture.registry.generateProofs(create, Set(Alice)) // owners = {Alice}
+        afterCreate <- combiner.insert(DataState(OnChain.genesis, CalculatedState.genesis), Signed(create, createProof))
+
+        // Bob (non-owner) is REJECTED by the combiner now — the fiber must NOT advance.
+        bobProof <- fixture.registry.generateProofs(mkPing(fiberId), Set(Bob))
+        afterBob <- combiner.insert(afterCreate, Signed(mkPing(fiberId), bobProof))
+        afterBobRec = fiberOf(afterBob, fiberId)
+
+        // Alice (owner) IS permitted — applies on the unchanged post-create state.
+        aliceProof <- fixture.registry.generateProofs(mkPing(fiberId), Set(Alice))
+        afterAlice <- combiner.insert(afterCreate, Signed(mkPing(fiberId), aliceProof))
+        afterAliceRec = fiberOf(afterAlice, fiberId)
+      } yield
+      // rejected: unchanged
+      expect(afterBobRec.map(_.currentState).contains(StateId("s0"))) and
+      expect(afterBobRec.exists(_.sequenceNumber === FiberOrdinal.MinValue)) and
+      // owner: applied
+      expect(afterAliceRec.map(_.currentState).contains(StateId("s1"))) and
+      expect(afterAliceRec.exists(_.sequenceNumber > FiberOrdinal.MinValue))
+    }
+  }
+
+  test("transitionPolicy = OwnersOrParticipants: a declared participant is accepted, a stranger is rejected") {
+    TestFixture.resource(Set(Alice, Bob, Charlie)).use { fixture =>
+      implicit val s: SecurityProvider[IO] = fixture.securityProvider
+      implicit val l0ctx: L0NodeContext[IO] = fixture.l0Context
+      for {
+        combiner <- Combiner.make[IO]().pure[IO]
+        fiberId  <- UUIDGen.randomUUID[IO]
+        baseDef  <- IO.fromEither(decode[StateMachineDefinition](defJson))
+        machineDef = baseDef
+          .copy(policy = FiberPolicy.constrained(transitionPolicy = Some(TransitionPolicy.OwnersOrParticipants)))
+
+        bobAddr = fixture.registry.addresses(Bob)
+        // Alice creates; Bob is a DECLARED participant (authorizedSigners), Charlie is a stranger.
+        create = Updates.CreateStateMachine(
+          fiberId,
+          machineDef,
+          MapValue(Map.empty[String, JsonLogicValue]),
+          participants = Some(Set(bobAddr))
+        )
+        createProof <- fixture.registry.generateProofs(create, Set(Alice))
+        afterCreate <- combiner.insert(DataState(OnChain.genesis, CalculatedState.genesis), Signed(create, createProof))
+
+        // Bob (participant) — accepted, applies.
+        bobProof <- fixture.registry.generateProofs(mkPing(fiberId), Set(Bob))
+        afterBob <- combiner.insert(afterCreate, Signed(mkPing(fiberId), bobProof))
+        bobRec = fiberOf(afterBob, fiberId)
+
+        // Charlie (stranger) — rejected, unchanged.
+        charlieProof <- fixture.registry.generateProofs(mkPing(fiberId), Set(Charlie))
+        afterCharlie <- combiner.insert(afterCreate, Signed(mkPing(fiberId), charlieProof))
+        charlieRec = fiberOf(afterCharlie, fiberId)
+      } yield expect(bobRec.map(_.currentState).contains(StateId("s1"))) and
+      expect(bobRec.exists(_.sequenceNumber > FiberOrdinal.MinValue)) and
+      expect(charlieRec.map(_.currentState).contains(StateId("s0"))) and
+      expect(charlieRec.exists(_.sequenceNumber === FiberOrdinal.MinValue))
+    }
+  }
+}


### PR DESCRIPTION
Implements **F6 + F7** of the fiber-ergonomics program (`docs/proposals/fiber-ergonomics/03-cross-fiber-and-authorization.md`). Stacked on #192 (the RFCs + the `TransitionOwnerGateDivergenceSuite` regression test this PR's fix flips green); retargets to `main` when #192 merges.

## F7 — close the transition-authorization enforcement gap (the security fix)
Today the transition owner-gate is coded in `validateSignedUpdate` but **not** in the combiner, so the authoritative apply path advances committed state for any signer whose transition passes the guard (pinned by `TransitionOwnerGateDivergenceSuite` in #192). This PR makes signer-authorization actually bind, and makes the posture explicit:

- **New `TransitionPolicy` ADT** (`Open` rank 0 / `OwnersOrParticipants` rank 1 / `Owners` rank 2) + `FiberPolicy.Constrained.transitionPolicy: Option = None`. `Option`/omit-safe, bare-string codec, collapses through `isEmpty`/`constrained` like every other dial, and joins the **tighten-only lattice** as a `rankUp` dial (a migration may only go `Open → OwnersOrParticipants → Owners`, never launder back down).
- **Enforced in the combiner** (`FiberCombiner.processFiberEvent`, after the sequence check, before `orchestrator.process`) as a graceful `CombineRejected` — the authoritative-gate pattern registry/asset ops already use. Resolves verified signer addresses from `update.proofs` (mirrors the create path + `updateSignedByOwnerOrParticipant`).

### ⚠️ The absent-dial default is `Open` (deliberate, additive)
An absent `transitionPolicy` resolves to `Open` = today's **live** guard-only behavior, so **every existing fiber is unchanged** and apps opt **up** explicitly. This PR ships the *mechanism* only. Flipping the default to `OwnersOrParticipants` (restoring the *declared* gate) is a **breaking, security-hardening decision deliberately reserved for maintainers** (RFC §3.4 / §6 Q1) — it would break the "counterparty can sign" pattern `MultiPartyTransitionSigningSuite` encodes, so it must come with an engine-version bump + migration window + reconciling that suite. Not done here.

## F6 — auto-declare static `machines.$id` read dependencies
`StaticDependencyScan.staticMachineRefs` walks a transition's guard/effect AST and returns every literally-referenced `machines.<uuid>` id; `FiberEvaluator` unions those into the **runtime** dependency set handed to `ContextProvider.buildContext`. Kills the silent-`null` trap (read a cross-fiber state without also hand-declaring the dep). A *computed* target id still needs an explicit `dependencies` entry / `_addDependency` — intentionally uncovered.

## Invariant compliance (CLAUDE.md)
- **#1:** `transitionPolicy` is `Option`/omit-safe — absent ⇒ stripped by `dropNulls` ⇒ byte-identical canonical. `PublishVersionSigningCanonicalSuite` +2 cases (`absent ⇒ byte-identical`, `set ⇒ round-trips`). The F6 scan augments only the runtime dep set and **never** mutates the signed `Transition.dependencies`.
- **#2:** signer-auth + the dial are enforced as graceful `CombineRejected` in the combiner, never as a block-acceptance `Invalid`.
- **#3:** the combiner check reads only the fiber's own hash-pinned policy dial + the stable `owners`/`authorizedSigners` record fields — no registry/asset lineage; `validateSignedUpdate` is untouched.

## Tests
- New `TransitionPolicyEnforcementSuite` (Open applies a non-owner; Owners rejects; OwnersOrParticipants accepts a participant, rejects a stranger) and `AutoDependencyScanSuite`.
- `PublishVersionSigningCanonicalSuite` +2 cases.
- **Full `sharedData/test`: 576 passed, 0 failed.** The three named existing suites stay green: `TransitionOwnerGateDivergenceSuite` 1/1 (default-Open still applies — the gap is now *opt-in closeable*), `MultiPartyTransitionSigningSuite` 6/6, `PublishVersionSigningCanonicalSuite` 5/5. `scalafmtCheckAll` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)