### PR TITLE
feat(fiber): injection-immune directive extraction

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -165,6 +165,12 @@ jobs:
           fi
           echo "tessellation=${TESS_VER}" >> $GITHUB_OUTPUT
 
+          # Compute the release TAG to fetch — the v4.0.0 → rc.10 asset-availability mapping lives here so
+          # the JAR cache key (below) matches exactly what is downloaded.
+          TESS_TAG="v${TESS_VER}"
+          [ "$TESS_TAG" = "v4.0.0" ] && TESS_TAG="v4.0.0-rc.10"
+          echo "tess_tag=${TESS_TAG}" >> $GITHUB_OUTPUT
+
       # Clone tessellation develop for Docker infrastructure (compose-runner, Dockerfiles, scripts).
       # Develop has the latest compose-runner with SKIP_ASSEMBLY support for pre-staged JARs.
       # We do NOT build tessellation — all deps resolve from Maven Central.
@@ -173,36 +179,45 @@ jobs:
           git clone --depth 1 --branch develop \
             https://github.com/Constellation-Labs/tessellation.git tessellation
 
-      # Download pre-built GL0/GL1/keytool/wallet JARs from tessellation GitHub release.
-      # metakit and tessellation-sdk resolve from Maven Central via sbt — no publishLocal needed.
-      - name: Download tessellation release JARs
-        run: |
-          TESS_TAG="v${{ steps.versions.outputs.tessellation }}"
-          # The v4.0.0 git tag has no GitHub release with jar assets (the asset
-          # pipeline only runs on tessellation's release/* branches). v4.0.0-rc.10
-          # carries the full asset set and is version-stamp-only away from final.
-          # Remove this mapping once Constellation publishes v4.0.0 release assets.
-          [ "$TESS_TAG" = "v4.0.0" ] && TESS_TAG="v4.0.0-rc.10"
-          REPO="Constellation-Labs/tessellation"
-          BASE_URL="https://github.com/${REPO}/releases/download/${TESS_TAG}"
-          JARS_DIR="tessellation/docker/jars"
-          mkdir -p "$JARS_DIR"
+      # Cache the pre-built tessellation release JARs — they are immutable per release tag, so fetch them
+      # from the GitHub release ONCE and reuse across runs. A cache HIT also makes the lane immune to a
+      # transient release-download 404/5xx (the download step is skipped entirely).
+      - name: Cache tessellation release JARs
+        id: cache-tess-jars
+        uses: actions/cache@v4
+        with:
+          path: tess-jars
+          key: tessellation-jars-${{ steps.versions.outputs.tess_tag }}
 
-          echo "Downloading tessellation JARs from release ${TESS_TAG}..."
+      # Download pre-built GL0/GL1/keytool/wallet JARs from the tessellation GitHub release (cache MISS only).
+      # metakit + tessellation-sdk resolve from Maven Central via sbt — no publishLocal needed.
+      - name: Download tessellation release JARs
+        if: steps.cache-tess-jars.outputs.cache-hit != 'true'
+        run: |
+          BASE_URL="https://github.com/Constellation-Labs/tessellation/releases/download/${{ steps.versions.outputs.tess_tag }}"
+          mkdir -p tess-jars
+          echo "Downloading tessellation JARs from release ${{ steps.versions.outputs.tess_tag }}..."
           declare -A JAR_MAP=(
             ["cl-node.jar"]="gl0.jar"
             ["cl-dag-l1.jar"]="gl1.jar"
             ["cl-keytool.jar"]="keytool.jar"
             ["cl-wallet.jar"]="wallet.jar"
           )
-
           for release_name in "${!JAR_MAP[@]}"; do
             local_name="${JAR_MAP[$release_name]}"
             echo "  ${release_name} → ${local_name}"
-            curl -fsSL -o "${JARS_DIR}/${local_name}" "${BASE_URL}/${release_name}"
-            echo "    ✓ $(stat -c%s "${JARS_DIR}/${local_name}") bytes"
+            # --retry + --retry-all-errors rides out a TRANSIENT release-CDN 404/5xx on a cache miss
+            curl -fsSL --retry 5 --retry-delay 3 --retry-all-errors \
+              -o "tess-jars/${local_name}" "${BASE_URL}/${release_name}"
+            echo "    ✓ $(stat -c%s "tess-jars/${local_name}") bytes"
           done
-          ls -la "$JARS_DIR"
+
+      # Stage the (cached or freshly-downloaded) tessellation JARs into the compose-runner jars dir.
+      - name: Stage tessellation JARs
+        run: |
+          mkdir -p tessellation/docker/jars
+          cp tess-jars/*.jar tessellation/docker/jars/
+          ls -la tessellation/docker/jars
 
       # Only build ottochain metagraph JARs from source.
       # metakit + tessellation-sdk are resolved from Maven Central.

--- a/modules/models/src/main/scala/xyz/kd5ujc/schema/asset/AssetHolder.scala
+++ b/modules/models/src/main/scala/xyz/kd5ujc/schema/asset/AssetHolder.scala
@@ -31,4 +31,28 @@ object AssetHolder {
 
   /** Custody by a live fiber (escrow / pool / vault). Liveness is checked in the combiner (Phase 4). */
   final case class Fiber(fiberId: UUID) extends AssetHolder
+
+  /**
+   * The magnolia wire-form keys — the variant discriminators (`Fiber`/`Wallet`) and their field names
+   * (`fiberId`/`address`). The SINGLE SOURCE for any tooling that must reason about an `AssetHolder`'s static
+   * shape WITHOUT a concrete value (e.g. the DefinitionLinter's `_transferAsset` recipient-shape check, which
+   * sees an unresolved expression it cannot decode). Pinned to the actual codec output by a golden round-trip
+   * test (`AssetHolderWireKeysSuite`), so renaming a case class / field can't silently drift these.
+   */
+  object WireKeys {
+    val FiberVariant: String = "Fiber"
+    val WalletVariant: String = "Wallet"
+    val FiberIdField: String = "fiberId"
+    val AddressField: String = "address"
+
+    /** The two variant discriminator keys. */
+    val variants: Set[String] = Set(FiberVariant, WalletVariant)
+
+    /** The required inner field for a given variant discriminator, if known. */
+    def fieldFor(variant: String): Option[String] = variant match {
+      case FiberVariant  => Some(FiberIdField)
+      case WalletVariant => Some(AddressField)
+      case _             => None
+    }
+  }
 }

--- a/modules/models/src/main/scala/xyz/kd5ujc/schema/fiber/FiberDirective.scala
+++ b/modules/models/src/main/scala/xyz/kd5ujc/schema/fiber/FiberDirective.scala
@@ -1,0 +1,44 @@
+package xyz.kd5ujc.schema.fiber
+
+import enumeratum._
+
+/**
+ * The reserved `_`-directive KEYWORDS the fiber engine extracts from a transition effect, at the granularity
+ * of a single EXTRACTION HANDLER (one entry per `EffectExtractor` extractor method).
+ *
+ * Distinct from [[EffectKind]], which is the coarser POLICY family a directive belongs to (the
+ * `allowedEffects` dial): `Triggers` + `ScriptCall` share `EffectKind.Trigger`, and the two dependency
+ * keywords share `EffectKind.Dependency`. This enum exists so the engine's directive dispatch is an
+ * EXHAUSTIVE, typed registry — `EffectExtractor.handlerFor` is a total match over `FiberDirective`, so
+ * adding a directive without wiring its handler is a COMPILE error (not a silently-missing extractor) — and
+ * so the set of reserved keys has a SINGLE source of truth ([[FiberDirective.keys]] / [[resultKeys]]).
+ *
+ * `values` order is the engine's effect-emission order (triggers, script call, spawn, emit, transfer,
+ * dependency); `EffectExtractor.extractEffects` folds the handlers in this order, so the emitted
+ * `List[FiberEffect]` ordering is defined HERE.
+ */
+sealed abstract class FiberDirective(val keys: Set[String], val family: EffectKind) extends EnumEntry
+
+object FiberDirective extends Enum[FiberDirective] {
+  val values: IndexedSeq[FiberDirective] = findValues
+
+  case object Triggers extends FiberDirective(Set(ReservedKeys.TRIGGERS), EffectKind.Trigger)
+  case object ScriptCall extends FiberDirective(Set(ReservedKeys.SCRIPT_CALL), EffectKind.Trigger)
+  case object Spawn extends FiberDirective(Set(ReservedKeys.SPAWN), EffectKind.Spawn)
+  case object Emit extends FiberDirective(Set(ReservedKeys.EMIT), EffectKind.Emit)
+  case object Transfer extends FiberDirective(Set(ReservedKeys.TRANSFER_ASSET), EffectKind.Transfer)
+
+  case object Dependency
+      extends FiberDirective(
+        Set(ReservedKeys.ADD_DEPENDENCY, ReservedKeys.SET_DEPENDENCY_ACTIVE),
+        EffectKind.Dependency
+      )
+
+  /**
+   * Reserved keys honoured from the post-evaluation RESULT position — i.e. every directive EXCEPT `_spawn`,
+   * which is sourced from the authored effect EXPRESSION (and so was already injection-immune). The
+   * injection-immune `EffectExtractor.authoredDirectiveResult` gates the result-surfacing directive keys on
+   * exactly this set.
+   */
+  val resultKeys: Set[String] = values.filterNot(_ == Spawn).flatMap(_.keys).toSet
+}

--- a/modules/models/src/main/scala/xyz/kd5ujc/schema/fiber/ReservedKeys.scala
+++ b/modules/models/src/main/scala/xyz/kd5ujc/schema/fiber/ReservedKeys.scala
@@ -1,5 +1,7 @@
 package xyz.kd5ujc.schema.fiber
 
+import enumeratum.{Enum, EnumEntry}
+
 /**
  * Reserved keys used throughout the fiber processing engine.
  *
@@ -8,7 +10,9 @@ package xyz.kd5ujc.schema.fiber
  * extracted from effect results but not merged into state.
  */
 object ReservedKeys {
-  // Effect Result Keys - Used in extracting side effects from transition results
+  // Effect Result Keys - Used in extracting side effects from transition results. The FiberDirective enum
+  // (the engine's directive registry) is the single source for the directive SET; these named constants are
+  // the per-key references the extractor dispatch + FiberDirective itself use.
   val TRIGGERS = "_triggers"
   val SPAWN = "_spawn"
   val SCRIPT_CALL = "_scriptCall"
@@ -16,6 +20,9 @@ object ReservedKeys {
   val TRANSFER_ASSET = "_transferAsset" // Fiber-held asset custody transfer (asset-model.md §10)
   val ADD_DEPENDENCY = "_addDependency" // Runtime-add/re-activate a dynamic cross-fiber dependency (append-only ledger)
   val SET_DEPENDENCY_ACTIVE = "_setDependencyActive" // Toggle a dynamic dependency's active flag (never removed)
+
+  /** Every reserved directive key — derived from [[FiberDirective]] so a new directive updates all consumers. */
+  val directiveKeys: Set[String] = FiberDirective.values.flatMap(_.keys).toSet
 
   // Script Return Convention Keys - Used in extractStateAndResult for script results
   val SCRIPT_STATE = "_state"
@@ -118,5 +125,46 @@ object ReservedKeys {
   val STATUS = "status"
   val LAST_INVOCATION = "lastInvocation"
 
+  /**
+   * All `_`-prefixed keys the engine RECOGNIZES (i.e. never a typo): the [[FiberDirective]] directive keys
+   * plus the script-return convention (`_state`/`_result`) and the cross-fiber policy projection (`_policy`).
+   * Derived from `directiveKeys`, so a new directive updates it automatically.
+   */
+  val recognizedInternalKeys: Set[String] = directiveKeys ++ Set(SCRIPT_STATE, SCRIPT_RESULT, POLICY)
+
   def isInternal(key: String): Boolean = key.startsWith("_")
+}
+
+/**
+ * The first-segment context ROOTS the engine injects into a state-machine transition's evaluation context
+ * (`ContextProvider.buildStateMachineContext`). A `{"var":"X.…"}` whose first segment `X` is not one of these
+ * can only ever resolve to `null`. This enum is the single source of the root set ([[FiberContextRoot.keys]]),
+ * so tooling (e.g. the offline linter) derives it instead of hand-maintaining a duplicate. Each entry names an
+ * existing `ReservedKeys` constant — the roots are multi-purpose strings, so this DECLARES which keys are
+ * roots rather than re-homing the constants.
+ */
+sealed abstract class FiberContextRoot(val key: String) extends EnumEntry
+
+object FiberContextRoot extends Enum[FiberContextRoot] {
+  case object State extends FiberContextRoot(ReservedKeys.STATE)
+  case object Event extends FiberContextRoot(ReservedKeys.EVENT)
+  case object EventName extends FiberContextRoot(ReservedKeys.EVENT_NAME)
+  case object MachineId extends FiberContextRoot(ReservedKeys.MACHINE_ID)
+  case object CurrentStateId extends FiberContextRoot(ReservedKeys.CURRENT_STATE_ID)
+  case object SequenceNumber extends FiberContextRoot(ReservedKeys.SEQUENCE_NUMBER)
+  case object Ordinal extends FiberContextRoot(ReservedKeys.ORDINAL)
+  case object LastSnapshotHash extends FiberContextRoot(ReservedKeys.LAST_SNAPSHOT_HASH)
+  case object EpochProgress extends FiberContextRoot(ReservedKeys.EPOCH_PROGRESS)
+  case object Caller extends FiberContextRoot(ReservedKeys.CALLER)
+  case object Proofs extends FiberContextRoot(ReservedKeys.PROOFS)
+  case object Machines extends FiberContextRoot(ReservedKeys.MACHINES)
+  case object Parent extends FiberContextRoot(ReservedKeys.PARENT)
+  case object Children extends FiberContextRoot(ReservedKeys.CHILDREN)
+  case object Scripts extends FiberContextRoot(ReservedKeys.SCRIPTS)
+  case object HeldAssets extends FiberContextRoot(ReservedKeys.HELD_ASSETS)
+
+  override val values: IndexedSeq[FiberContextRoot] = findValues
+
+  /** Every context-root key — the single source for "is this a valid first-segment var root". */
+  val keys: Set[String] = values.map(_.key).toSet
 }

--- a/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/fiber/DefinitionLinter.scala
+++ b/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/fiber/DefinitionLinter.scala
@@ -1,0 +1,553 @@
+package xyz.kd5ujc.shared_data.fiber
+
+import cats.Id
+
+import io.constellationnetwork.metagraph_sdk.json_logic._
+
+import xyz.kd5ujc.schema.asset.AssetHolder
+import xyz.kd5ujc.schema.fiber.{FiberContextRoot, ReservedKeys, StateId, StateMachineDefinition, Transition}
+import xyz.kd5ujc.schema.registry.MachineShape
+import xyz.kd5ujc.shared_data.lifecycle.validate.rules.{CommonRules, FiberRules}
+
+/**
+ * Offline, PURE, ADVISORY-ONLY fiber-definition validator (Proposal 01 — fiber-ergonomics/01-authoring-safety).
+ *
+ * Resolves every `{"var":…}` path against the context roots the engine actually injects, rejects misspelled
+ * `_`-directive keys (the F4 killer), checks state reachability, checks internal/shape conformance of state
+ * reads/writes, and surfaces the existing expression-depth cap — all from the definition alone, BEFORE the
+ * message is signed. Returns structured, source-located [[Diagnostic]]s (empty == clean).
+ *
+ * This is tooling, NOT a consensus surface. It MUST NEVER be called from `validateSignedUpdate` or any
+ * combiner (CLAUDE.md rules #2/#3). It reads its vocabulary — the directive set and the context roots — from
+ * [[ReservedKeys]] (the same source `EffectExtractor`/`ContextProvider` dispatch on) so it can never disagree
+ * with the runtime about which `_`-keys are real or which roots exist.
+ */
+object DefinitionLinter {
+
+  sealed trait Severity
+
+  object Severity {
+    case object Error extends Severity
+    case object Warning extends Severity
+    case object Info extends Severity
+  }
+
+  /**
+   * Where a diagnostic points. `transitionIndex` is the 0-based index into `definition.transitions` (None for
+   * definition-level diagnostics like reachability); `field` is "guard" | "effect" | "states" | "definition";
+   * `path` is the offending var-path or map key when applicable.
+   */
+  final case class Location(
+    transitionIndex: Option[Int] = None,
+    field:           String,
+    path:            Option[String] = None
+  )
+
+  final case class Diagnostic(
+    severity: Severity,
+    code:     String,
+    message:  String,
+    location: Location
+  )
+
+  // === Vocabulary, read from ReservedKeys (never hardcoded) ===
+
+  /**
+   * The known effect-output directives, dispatched on in `EffectExtractor` (`_triggers`/`_spawn`/`_scriptCall`/
+   * `_emit`/`_transferAsset`/`_addDependency`/`_setDependencyActive`). Derived from [[FiberDirective]] (the
+   * single source of truth) via `ReservedKeys.directiveKeys`, so it can NEVER drift from the runtime's
+   * directive set — adding a directive is one `FiberDirective` case and every consumer here updates.
+   */
+  private val directives: Set[String] = ReservedKeys.directiveKeys
+
+  /**
+   * `_`-prefixed keys that are RECOGNIZED (so they are never mis-flagged as a typo), even though they are not
+   * effect directives: `_state`/`_result` (script return convention) and `_policy` (the cross-fiber policy
+   * projection). Anything `_`-prefixed outside this set in an effect can only be a typo or an unimplemented
+   * directive — i.e. an Error.
+   */
+  private val recognizedInternalKeys: Set[String] = ReservedKeys.recognizedInternalKeys
+
+  /**
+   * The first-segment roots the engine injects into a state-machine transition context, taken verbatim from
+   * `ContextProvider.buildStateMachineContext`. A `{"var":"…"}` whose first segment is not one of these can
+   * only ever resolve to `null`.
+   */
+  private val knownRoots: Set[String] = FiberContextRoot.keys
+
+  /** Directive names with the leading underscore stripped — the shape a "dropped-underscore" typo takes. */
+  private val directivesNoUnderscore: Set[String] = directives.map(_.stripPrefix("_"))
+
+  /**
+   * Validate a definition. `shape` is an OPTIONAL typed projection: with it, undeclared state/event reads and
+   * undeclared writes become Errors; without it, the validator degrades to internal consistency (a field
+   * written by any transition is treated as a known state field for read checks).
+   *
+   * @return diagnostics, ordered; empty means clean. ADVISORY only — the caller decides whether to block.
+   */
+  def validate(
+    definition: StateMachineDefinition,
+    shape:      Option[MachineShape] = None
+  ): List[Diagnostic] = {
+    // Fields written by ANY transition's effect (internal-consistency knowledge for read checks).
+    val writtenFields: Set[String] =
+      definition.transitions.flatMap(t => effectOutputKeys(t.effect).filterNot(ReservedKeys.isInternal)).toSet
+
+    val declaredStateFields: Set[String] =
+      shape.map(_.stateMessage.fields.map(_.name).toSet).getOrElse(Set.empty)
+
+    val perTransition = definition.transitions.zipWithIndex.flatMap { case (t, idx) =>
+      checkVarPaths(t, idx, writtenFields, declaredStateFields, shape) ++
+      checkDirectives(t, idx) ++
+      checkTransferRecipients(t, idx) ++
+      checkInjectionHazard(t, idx) ++
+      checkWrites(t, idx, shape)
+    }
+
+    perTransition ++ checkReachability(definition) ++ checkDepth(definition)
+  }
+
+  // ==========================================================================
+  // (a) var-path resolution + (d) read conformance
+  // ==========================================================================
+
+  private def checkVarPaths(
+    t:                   Transition,
+    idx:                 Int,
+    writtenFields:       Set[String],
+    declaredStateFields: Set[String],
+    shape:               Option[MachineShape]
+  ): List[Diagnostic] = {
+    def forField(field: String, expr: JsonLogicExpression): List[Diagnostic] =
+      collectVarPaths(expr).distinct.flatMap { path =>
+        resolvePath(path, field, idx, t, writtenFields, declaredStateFields, shape)
+      }
+
+    forField("guard", t.guard) ++ forField("effect", t.effect)
+  }
+
+  private def resolvePath(
+    path:                String,
+    field:               String,
+    idx:                 Int,
+    t:                   Transition,
+    writtenFields:       Set[String],
+    declaredStateFields: Set[String],
+    shape:               Option[MachineShape]
+  ): List[Diagnostic] = {
+    val loc = Location(Some(idx), field, Some(path))
+    val segments = path.split('.').toList
+    segments match {
+      case Nil | "" :: _ =>
+        // empty path == whole-context identity read; nothing to resolve
+        Nil
+
+      case root :: _ if !knownRoots.contains(root) =>
+        List(
+          Diagnostic(
+            Severity.Error,
+            "unknown-root",
+            s"""{"var":"$path"} — unknown context root "$root"; the engine injects no such root, so this """ +
+            s"""read can only resolve to null (known roots: ${knownRoots.toList.sorted.mkString(", ")})""",
+            loc
+          )
+        )
+
+      case root :: sub :: _ if root == ReservedKeys.STATE =>
+        if (declaredStateFields.contains(sub) || writtenFields.contains(sub)) Nil
+        else if (shape.isDefined)
+          List(
+            Diagnostic(
+              Severity.Error,
+              "undeclared-state-read",
+              s"""{"var":"$path"} — "$sub" is not a field of the declared state-shape""",
+              loc
+            )
+          )
+        else
+          List(
+            Diagnostic(
+              Severity.Warning,
+              "undeclared-state-read",
+              s"""{"var":"$path"} — "$sub" is never written by any transition (reads null -> 0/""/[])""",
+              loc
+            )
+          )
+
+      case root :: sub :: _ if root == ReservedKeys.EVENT =>
+        // Event subfields are only checkable against a command shape; without one, accept (always clean).
+        shape.flatMap(_.commands.get(t.eventName)) match {
+          case Some(cmd) if !cmd.fields.exists(_.name == sub) =>
+            List(
+              Diagnostic(
+                Severity.Error,
+                "undeclared-event-read",
+                s"""{"var":"$path"} — "$sub" is not a field of the "${t.eventName}" command shape""",
+                loc
+              )
+            )
+          case _ => Nil
+        }
+
+      case root :: depId :: _ if root == ReservedKeys.MACHINES =>
+        if (t.dependencies.map(_.toString).contains(depId)) Nil
+        else
+          List(
+            Diagnostic(
+              Severity.Warning,
+              "undeclared-dep-read",
+              s"""{"var":"$path"} — "$depId" is not in this transition's declared dependencies """ +
+              s"(machines.<id> resolves to null unless <id> is a declared dependency)",
+              loc
+            )
+          )
+
+      case _ =>
+        // Known root used bare (e.g. machineId, $ordinal) or a root whose sub-tree we do not model
+        // (parent/children/scripts/heldAssets) — accept.
+        Nil
+    }
+  }
+
+  // ==========================================================================
+  // (b) directive-key spelling (the F4 killer)
+  // ==========================================================================
+
+  private def checkDirectives(t: Transition, idx: Int): List[Diagnostic] = {
+    // Unknown `_`-directive: any internal key in the effect tree that is not a recognized reserved key.
+    val unknownDirectives =
+      collectAllMapKeys(t.effect).distinct
+        .filter(k => ReservedKeys.isInternal(k) && !recognizedInternalKeys.contains(k))
+        .map { key =>
+          val suggestion = nearest(key.stripPrefix("_"), directivesNoUnderscore)
+            .map(s => s""" (did you mean "_$s"?)""")
+            .getOrElse("")
+          Diagnostic(
+            Severity.Error,
+            "unknown-directive",
+            s"""effect key "$key" is not a known directive$suggestion""",
+            Location(Some(idx), "effect", Some(key))
+          )
+        }
+
+    // Dropped-underscore: a NON-internal effect-output key one edit from a directive — becomes a junk state
+    // field, and the directive silently never fires.
+    val droppedUnderscore =
+      effectOutputKeys(t.effect)
+        .filterNot(ReservedKeys.isInternal)
+        .toList
+        .filter(k => directivesNoUnderscore.exists(d => editDistance(k, d) <= 1))
+        .map { key =>
+          val suggestion = nearest(key, directivesNoUnderscore).map(s => s""" (did you mean "_$s"?)""").getOrElse("")
+          Diagnostic(
+            Severity.Warning,
+            "likely-dropped-underscore",
+            s"""effect key "$key" looks like a directive missing its underscore$suggestion; """ +
+            s"it will merge into state instead of firing",
+            Location(Some(idx), "effect", Some(key))
+          )
+        }
+
+    unknownDirectives ++ droppedUnderscore
+  }
+
+  // ==========================================================================
+  // (b2) `_transferAsset` recipient shape (object-form-only)
+  // ==========================================================================
+
+  /**
+   * `_transferAsset`'s `recipient` is the canonical AssetHolder OBJECT form ONLY
+   * (`{"Fiber":{"fiberId":..}}` / `{"Wallet":{"address":..}}`); the chain raises `CombineRejected` on anything
+   * else (`EffectExtractor.parseAssetTransfer`). This is the offline shift-left for that — a STATIC check of the
+   * recipient SHAPE (the resolved value is still checked at combine). Advisory: a bare-string recipient (the
+   * removed legacy form) is a Warning; a literal object that can never decode to an AssetHolder is an Error; a
+   * dynamic (`{"var":..}` / computed) recipient is left to the combiner.
+   */
+  private def checkTransferRecipients(t: Transition, idx: Int): List[Diagnostic] =
+    transferRecipientExprs(t.effect).flatMap(recipientDiagnostic(_, idx))
+
+  /** Pull each `_transferAsset` item's `recipient` sub-expression out of an effect (descends if-branch nesting). */
+  private def transferRecipientExprs(expr: JsonLogicExpression): List[JsonLogicExpression] =
+    expr match {
+      case MapExpression(map) =>
+        map.get(ReservedKeys.TRANSFER_ASSET).toList.flatMap(recipientsOfArray) ++
+        map.values.toList.collect { case a: ApplyExpression => a }.flatMap(transferRecipientExprs)
+      case ApplyExpression(_, args) => args.flatMap(transferRecipientExprs)
+      case _                        => Nil
+    }
+
+  private def recipientsOfArray(arr: JsonLogicExpression): List[JsonLogicExpression] =
+    arr match {
+      case ArrayExpression(items) => items.collect { case MapExpression(m) => m.get(ReservedKeys.RECIPIENT) }.flatten
+      case _                      => Nil
+    }
+
+  /**
+   * Classify a recipient sub-expression's STATIC shape (None == well-formed, or dynamic / not statically
+   * checkable). The valid variant/field keys come from [[AssetHolder.WireKeys]] (the single source), never
+   * hardcoded here.
+   */
+  private def recipientDiagnostic(recipient: JsonLogicExpression, idx: Int): Option[Diagnostic] = {
+    val loc = Location(Some(idx), "effect", Some("recipient"))
+    recipient match {
+      // a single-key {<Variant>:{<field>:..}} AssetHolder wrapper (Fiber/Wallet) with its required inner field
+      case MapExpression(m) if m.size == 1 && AssetHolder.WireKeys.variants.contains(m.keys.head) =>
+        val variant = m.keys.head
+        val field = AssetHolder.WireKeys.fieldFor(variant) // Some for every key in `variants`
+        if (field.exists(f => childHasKey(m(variant), f))) None
+        else
+          Some(
+            Diagnostic(
+              Severity.Error,
+              "transfer-recipient-malformed",
+              s"""_transferAsset recipient {"$variant":..} is missing its "${field.getOrElse("")}" field""",
+              loc
+            )
+          )
+      // a literal object that is not an AssetHolder variant wrapper — cannot decode to an AssetHolder
+      case MapExpression(m) =>
+        Some(
+          Diagnostic(
+            Severity.Error,
+            "transfer-recipient-not-holder",
+            s"_transferAsset recipient must be an AssetHolder object " +
+            s"(${AssetHolder.WireKeys.variants.toList.sorted.map(v => s"""{"$v":..}""").mkString(" / ")}); " +
+            s"got keys ${m.keys.toList.sorted.mkString("{", ",", "}")}",
+            loc
+          )
+        )
+      // a literal bare string — the removed legacy form; the chain now rejects it
+      case ConstExpression(StrValue(_)) =>
+        Some(
+          Diagnostic(
+            Severity.Warning,
+            "transfer-recipient-bare-string",
+            "_transferAsset recipient is a bare string; the chain requires the AssetHolder object form and rejects it",
+            loc
+          )
+        )
+      // dynamic ({"var":..} / computed) — shape can't be verified offline; the combiner checks the resolved value
+      case _ => None
+    }
+  }
+
+  private def childHasKey(expr: JsonLogicExpression, key: String): Boolean =
+    expr match {
+      case MapExpression(m)             => m.contains(key)
+      case ConstExpression(MapValue(m)) => m.contains(key)
+      case _                            => false
+    }
+
+  // ==========================================================================
+  // (b3) directive-injection hazard — dynamically-computed TOP-LEVEL effect keys
+  // ==========================================================================
+
+  /**
+   * Reserved `_`-directives are matched by key PREFIX on the evaluated effect RESULT (`EffectExtractor`), not
+   * on the authored expression — so a transition whose effect computes a TOP-LEVEL key from data (a `set` with
+   * a non-literal key, not nested under a state field) can let an attacker-controlled key beginning with `_`
+   * inject a reserved directive (e.g. `_transferAsset`). The combiner's holder/`allowedEffects` gates bound the
+   * damage, but the boundary itself is a string convention. This advisory flags the pattern so an author keeps
+   * top-level effect keys literal (or sets a fail-closed `allowedEffects`). NOTE: nested dynamic keys (the
+   * common `field: {set:[…event.x…]}` accumulator) are NOT flagged — they sit under a state field, never at
+   * the top level the extractor scans.
+   */
+  private def checkInjectionHazard(t: Transition, idx: Int): List[Diagnostic] =
+    if (topLevelDynamicKeyCount(t.effect) > 0)
+      List(
+        Diagnostic(
+          Severity.Warning,
+          "directive-injection-hazard",
+          "effect computes a dynamic TOP-LEVEL key (a `set` with a non-literal key); a data-controlled key " +
+          "beginning with `_` could inject a reserved directive into the effect result. Keep top-level effect " +
+          "keys literal, or set a fail-closed `allowedEffects` policy.",
+          Location(Some(idx), "effect", None)
+        )
+      )
+    else Nil
+
+  /**
+   * Count `set` ops that write a NON-literal key at a TOP-LEVEL effect-result position. Descends only through
+   * the result-shaping ops (`merge`/`if`) and a `set`'s target — never into a `MapExpression`'s values (those
+   * are state-field data, not top-level keys), so a nested dynamic-key write does not false-positive.
+   */
+  private def topLevelDynamicKeyCount(expr: JsonLogicExpression): Int =
+    expr match {
+      case ApplyExpression(JsonLogicOp.MergeOp, args)  => args.map(topLevelDynamicKeyCount).sum
+      case ApplyExpression(JsonLogicOp.IfElseOp, args) => args.map(topLevelDynamicKeyCount).sum
+      case ApplyExpression(JsonLogicOp.SetOp, target :: keyExpr :: _) =>
+        val here = keyExpr match { case ConstExpression(StrValue(_)) => 0; case _ => 1 }
+        here + topLevelDynamicKeyCount(target)
+      case _ => 0
+    }
+
+  // ==========================================================================
+  // (c) reachability
+  // ==========================================================================
+
+  private def checkReachability(definition: StateMachineDefinition): List[Diagnostic] = {
+    val adjacency: Map[StateId, List[StateId]] =
+      definition.transitions.groupBy(_.from).view.mapValues(_.map(_.to)).toMap
+
+    // BFS from initialState.
+    val reached = scala.collection.mutable.Set(definition.initialState)
+    val queue = scala.collection.mutable.Queue(definition.initialState)
+    while (queue.nonEmpty) {
+      val s = queue.dequeue()
+      adjacency.getOrElse(s, Nil).foreach { n =>
+        if (!reached.contains(n)) { reached += n; queue.enqueue(n) }
+      }
+    }
+
+    val unreachable = definition.states.keySet.toList
+      .filterNot(reached.contains)
+      .sortBy(_.value)
+      .map { sid =>
+        Diagnostic(
+          Severity.Error,
+          "unreachable-state",
+          s"""state "${sid.value}" is not reachable from initialState "${definition.initialState.value}"""",
+          Location(None, "states", Some(sid.value))
+        )
+      }
+
+    val statesWithOutgoing = definition.transitions.map(_.from).toSet
+    val deadEnds = definition.states.toList
+      .collect { case (sid, st) if !st.isFinal && !statesWithOutgoing.contains(sid) => sid }
+      .sortBy(_.value)
+      .map { sid =>
+        Diagnostic(
+          Severity.Warning,
+          "dead-end-state",
+          s"""state "${sid.value}" is not final and has no outgoing transition (a stuck state)""",
+          Location(None, "states", Some(sid.value))
+        )
+      }
+
+    unreachable ++ deadEnds
+  }
+
+  // ==========================================================================
+  // (d) write conformance (only meaningful with a shape; internal consistency otherwise)
+  // ==========================================================================
+
+  private def checkWrites(t: Transition, idx: Int, shape: Option[MachineShape]): List[Diagnostic] =
+    shape match {
+      case None => Nil // internal-consistency mode writes are unconstrained
+      case Some(s) =>
+        val declared = s.stateMessage.fields.map(_.name).toSet
+        effectOutputKeys(t.effect)
+          .filterNot(ReservedKeys.isInternal)
+          .toList
+          .sorted
+          .filterNot(declared.contains)
+          .map { key =>
+            Diagnostic(
+              Severity.Error,
+              "undeclared-state-write",
+              s"""effect writes "$key", which is not a field of the declared state-shape """ +
+              s"(${s.stateMessage.typeName})",
+              Location(Some(idx), "effect", Some(key))
+            )
+          }
+    }
+
+  // ==========================================================================
+  // (e) expression depth — reuse the existing FiberRules cap, surfaced as Errors
+  // ==========================================================================
+
+  private val tooDeepLoc = """transition\[(\d+)\]\.(guard|effect)""".r
+
+  private def checkDepth(definition: StateMachineDefinition): List[Diagnostic] =
+    FiberRules.L1
+      .definitionExpressionsWithinDepthLimits[Id](definition)
+      .fold(
+        errs =>
+          errs.toNonEmptyList.toList.map {
+            case e @ CommonRules.Errors.ExpressionTooDeep(fieldName, _, _) =>
+              val loc = fieldName match {
+                case tooDeepLoc(i, f) => Location(Some(i.toInt), f, None)
+                case _                => Location(None, fieldName, None)
+              }
+              Diagnostic(Severity.Error, "expression-too-deep", e.message, loc)
+            case other =>
+              Diagnostic(Severity.Error, "expression-too-deep", other.message, Location(None, "definition", None))
+          },
+        _ => Nil
+      )
+
+  // ==========================================================================
+  // AST helpers
+  // ==========================================================================
+
+  /** Every literal `{"var":"path"}` (Left) string in an expression tree; recurses into computed-key vars. */
+  private def collectVarPaths(expr: JsonLogicExpression): List[String] =
+    expr match {
+      case VarExpression(Left(path), _)    => List(path)
+      case VarExpression(Right(nested), _) => collectVarPaths(nested)
+      case MapExpression(map)              => map.values.toList.flatMap(collectVarPaths)
+      case ApplyExpression(_, args)        => args.flatMap(collectVarPaths)
+      case ArrayExpression(items)          => items.flatMap(collectVarPaths)
+      case _: ConstExpression              => Nil
+    }
+
+  /** Every map key anywhere in an expression tree (both `MapExpression` and literal `ConstExpression(MapValue)`). */
+  private def collectAllMapKeys(expr: JsonLogicExpression): List[String] =
+    expr match {
+      case MapExpression(map)              => map.keys.toList ++ map.values.toList.flatMap(collectAllMapKeys)
+      case ApplyExpression(_, args)        => args.flatMap(collectAllMapKeys)
+      case ArrayExpression(items)          => items.flatMap(collectAllMapKeys)
+      case VarExpression(Right(nested), _) => collectAllMapKeys(nested)
+      case VarExpression(Left(_), _)       => Nil
+      case ConstExpression(value)          => collectValueMapKeys(value)
+    }
+
+  private def collectValueMapKeys(value: JsonLogicValue): List[String] =
+    value match {
+      case MapValue(map)     => map.keys.toList ++ map.values.toList.flatMap(collectValueMapKeys)
+      case ArrayValue(items) => items.flatMap(collectValueMapKeys)
+      case _                 => Nil
+    }
+
+  /**
+   * Keys of the maps in RESULT position of an effect — the maps whose keys are merged into state (directive
+   * keys + state-write keys). A plain `{...}` effect yields its own keys; an `{"if":[c, {A}, {B}]}` yields the
+   * keys of both branches. Field VALUES are not descended into (a nested map value is state data, not a
+   * top-level field).
+   */
+  private def effectOutputKeys(expr: JsonLogicExpression): Set[String] =
+    expr match {
+      case MapExpression(map)           => map.keySet
+      case ConstExpression(MapValue(m)) => m.keySet
+      case ApplyExpression(_, args)     => args.flatMap(effectOutputKeys).toSet
+      case ArrayExpression(items)       => items.flatMap(effectOutputKeys).toSet
+      case _                            => Set.empty
+    }
+
+  // ==========================================================================
+  // String distance
+  // ==========================================================================
+
+  /** The candidate with the smallest edit distance to `s`, if within distance 2 (else None — no suggestion). */
+  private def nearest(s: String, candidates: Set[String]): Option[String] =
+    candidates.toList.map(c => c -> editDistance(s, c)).sortBy(_._2).headOption.collect { case (c, d) if d <= 2 => c }
+
+  /** Standard Levenshtein edit distance. */
+  private def editDistance(a: String, b: String): Int = {
+    val prev = Array.tabulate(b.length + 1)(identity)
+    val curr = new Array[Int](b.length + 1)
+    var i = 1
+    while (i <= a.length) {
+      curr(0) = i
+      var j = 1
+      while (j <= b.length) {
+        val cost = if (a(i - 1) == b(j - 1)) 0 else 1
+        curr(j) = math.min(math.min(curr(j - 1) + 1, prev(j) + 1), prev(j - 1) + cost)
+        j += 1
+      }
+      System.arraycopy(curr, 0, prev, 0, b.length + 1)
+      i += 1
+    }
+    prev(b.length)
+  }
+}

--- a/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/fiber/evaluation/EffectExtractor.scala
+++ b/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/fiber/evaluation/EffectExtractor.scala
@@ -59,35 +59,263 @@ object EffectExtractor {
     extractByKey(effectResult, key).collect { case ArrayValue(items) => items }.getOrElse(List.empty)
 
   /**
-   * Extract ALL side effects from a transition's effect result + expression as a single ordered list
-   * of typed [[FiberEffect]]s. `_triggers` and `_scriptCall` become `Triggered`; `_spawn` directives
-   * become `Spawned`; `_emit` events become `Emitted`; `_transferAsset` directives become `AssetTransferred`.
+   * Extract ALL side effects from a transition's effect EXPRESSION as a single ordered list of typed
+   * [[FiberEffect]]s. `_triggers` and `_scriptCall` become `Triggered`; `_spawn` directives become
+   * `Spawned`; `_emit` events become `Emitted`; `_transferAsset` directives become `AssetTransferred`;
+   * `_addDependency`/`_setDependencyActive` become `DependencyMutated`.
    *
-   * Order matches the prior per-key extraction (triggers, then script call, then spawns, then emitted, then
-   * asset transfers), and gas for payload/args/directive evaluation is charged in that order via
-   * [[MeteredEvaluator]].
+   * SECURITY (directive-injection immunity) — a reserved directive is honoured ONLY when its KEY is
+   * LITERALLY AUTHORED in the signed effect expression (`transition.effect`), never when the key is
+   * COMPUTED from event data. The injection vector this closes: an effect whose top-level key is built
+   * from data — e.g. `{"merge":[{"var":"state"},{"set":[{}, {"var":"event.k"}, {"var":"event.v"}]}]}`
+   * with attacker-sent `event.k = "_transferAsset"` — would, under result-based extraction (reading
+   * `key.startsWith("_")` off the post-evaluation result), forge a `_transferAsset` directive and drain
+   * the fiber's held assets. Here directives are sourced from [[authoredDirectiveResult]], which walks
+   * the AUTHORED AST: a data-computed key is never a literal key in the AST, so it can never become a
+   * directive, and the directive VALUE is evaluated from the authored sub-expression (never substituted
+   * by a `merge`/`set` of attacker data). `_spawn` was already expression-extracted and is unchanged.
+   *
+   * Conditional/merge directives are preserved: [[authoredDirectiveResult]] evaluates `if`-conditions to
+   * pick the taken branch and unions `merge` operands, so a directive authored inside an `if`/`merge`
+   * fires exactly when the surrounding branch would have surfaced it.
+   *
+   * Dispatch is a TYPED, EXHAUSTIVE registry over [[FiberDirective]] ([[handlerFor]]): every directive has a
+   * handler, enforced at compile time, and the emitted order is `FiberDirective.values` (triggers, script
+   * call, spawn, emit, transfer, dependency — unchanged from the prior hand-wired sequence). Gas for
+   * payload/args/directive evaluation is charged in that order via [[MeteredEvaluator]].
    */
   def extractEffects[F[_]: Async, G[_]: Monad](
-    effectResult:  JsonLogicValue,
     effectExpr:    JsonLogicExpression,
     contextData:   JsonLogicValue,
     sourceFiberId: UUID
   )(implicit S: Stateful[G, ExecutionState], A: Ask[G, FiberContext], lift: F ~> G): G[List[FiberEffect]] =
-    for {
-      triggers       <- extractTriggerEvents[F, G](effectResult, contextData, sourceFiberId)
-      scriptCall     <- extractScriptCall[F, G](effectResult, contextData, sourceFiberId)
-      assetTransfers <- extractAssetTransfers[F, G](effectResult, contextData)
-      depMutations   <- extractDependencyMutations[F, G](effectResult, contextData)
-    } yield {
-      val spawns = extractSpawnDirectivesFromExpression(effectExpr)
-      // Fix (1): stamp the EMITTING fiber id into every emitted event at extraction. `sourceFiberId` is the
-      // fiber whose transition produced this effect result — the emitter (distinct from any cross-fiber caller).
-      val emitted = extractEmittedEvents(effectResult, sourceFiberId)
-      (triggers ++ scriptCall.toList).map(FiberEffect.Triggered) ++
-      spawns.map(FiberEffect.Spawned) ++
-      emitted.map(FiberEffect.Emitted) ++
-      assetTransfers ++
-      depMutations
+    authoredDirectiveResult[F, G](effectExpr, contextData).flatMap { authored =>
+      // `authored` = a synthetic MapValue holding ONLY the directive keys LITERALLY authored in the effect
+      // expression, evaluated from their authored sub-expressions. Every result-position handler reads
+      // directives from THIS, never from the raw (injectable) effect result; the `Spawn` handler reads the
+      // effect EXPRESSION directly (already immune).
+      val ctx = EffectContext(effectExpr, authored, contextData, sourceFiberId)
+      FiberDirective.values.toList.flatTraverse(directive => handlerFor[F, G](directive).apply(ctx))
+    }
+
+  /** Everything a directive extractor needs; `authored` is the injection-immune authored directive result. */
+  final case class EffectContext(
+    effectExpr:    JsonLogicExpression,
+    authored:      JsonLogicValue,
+    contextData:   JsonLogicValue,
+    sourceFiberId: UUID
+  )
+
+  /**
+   * The typed directive registry: a TOTAL match over [[FiberDirective]] returning the REAL extractor for that
+   * directive as `EffectContext => G[List[FiberEffect]]`. Because the match is exhaustive over a sealed enum,
+   * introducing a new `FiberDirective` without wiring its handler is a compile error — the exhaustiveness
+   * guard, with real wiring (no stringly-typed indirection).
+   */
+  private def handlerFor[F[_]: Async, G[_]: Monad](
+    directive: FiberDirective
+  )(implicit
+    S:    Stateful[G, ExecutionState],
+    A:    Ask[G, FiberContext],
+    lift: F ~> G
+  ): EffectContext => G[List[FiberEffect]] =
+    directive match {
+      case FiberDirective.Triggers =>
+        ctx =>
+          extractTriggerEvents[F, G](ctx.authored, ctx.contextData, ctx.sourceFiberId).map(
+            _.map(t => FiberEffect.Triggered(t): FiberEffect)
+          )
+
+      case FiberDirective.ScriptCall =>
+        ctx =>
+          extractScriptCall[F, G](ctx.authored, ctx.contextData, ctx.sourceFiberId)
+            .map(_.toList.map(t => FiberEffect.Triggered(t): FiberEffect))
+
+      // Spawn is sourced from the effect EXPRESSION (already injection-immune), not the authored result.
+      case FiberDirective.Spawn =>
+        ctx =>
+          extractSpawnDirectivesFromExpression(ctx.effectExpr).map(d => FiberEffect.Spawned(d): FiberEffect).pure[G]
+
+        // Fix (1): `extractEmittedEvents` stamps the EMITTING fiber id (`sourceFiberId`) into every emitted
+      // event — the emitter, distinct from any cross-fiber caller.
+      case FiberDirective.Emit =>
+        ctx =>
+          extractEmittedEvents(ctx.authored, ctx.sourceFiberId).map(e => FiberEffect.Emitted(e): FiberEffect).pure[G]
+
+      case FiberDirective.Transfer =>
+        ctx => extractAssetTransfers[F, G](ctx.authored, ctx.contextData).map(_.map(x => x: FiberEffect))
+
+      case FiberDirective.Dependency =>
+        ctx => extractDependencyMutations[F, G](ctx.authored, ctx.contextData).map(_.map(x => x: FiberEffect))
+    }
+
+  /**
+   * Reserved directive keys honoured from the effect RESULT position (everything except `_spawn`, which has
+   * its own expression extractor [[extractSpawnDirectivesFromExpression]] and is already immune). Single
+   * source of truth: derived from [[FiberDirective]].
+   */
+  private val resultDirectiveKeys: Set[String] = FiberDirective.resultKeys
+
+  /**
+   * Build the injection-immune "authored result": a [[MapValue]] containing ONLY the reserved directive
+   * keys that are LITERALLY authored in `effectExpr` (in a result-surfacing position), each mapped to the
+   * value obtained by evaluating its AUTHORED sub-expression against `contextData`. A directive key that
+   * only appears in the post-evaluation result because event data flowed into a computed key
+   * (`set`/`merge` with a `{"var":…}` key) is NOT a literal AST key, so it is absent here and never honoured.
+   *
+   * Fast path: if the expression authors no directive key at all (the overwhelmingly common case — pure
+   * state effects), this returns the empty map WITHOUT evaluating anything, so directive-free transitions
+   * stay byte-for-byte gas-neutral.
+   */
+  def authoredDirectiveResult[F[_]: Async, G[_]: Monad](
+    effectExpr:  JsonLogicExpression,
+    contextData: JsonLogicValue
+  )(implicit S: Stateful[G, ExecutionState], A: Ask[G, FiberContext], lift: F ~> G): G[JsonLogicValue] =
+    if (!hasAuthoredDirective(effectExpr)) (MapValue.empty: JsonLogicValue).pure[G]
+    else
+      collectDirectiveEntries[F, G](effectExpr, contextData).map { entries =>
+        val combined = entries
+          .groupBy(_._1)
+          .map { case (k, kvs) => k -> combineDirectiveValues(kvs.map(_._2)) }
+        MapValue(combined): JsonLogicValue
+      }
+
+  /**
+   * Pure static scan mirroring the result-surfacing positions of [[collectDirectiveEntries]]: does
+   * `expr` literally author any reserved directive key that could surface as a top-level result key?
+   * Used purely to keep directive-free effects from paying for the evaluating walker.
+   */
+  private def hasAuthoredDirective(expr: JsonLogicExpression): Boolean =
+    expr match {
+      case MapExpression(m)                            => m.keys.exists(resultDirectiveKeys)
+      case ConstExpression(MapValue(m))                => m.keys.exists(resultDirectiveKeys)
+      case ApplyExpression(JsonLogicOp.MergeOp, args)  => args.exists(hasAuthoredDirective)
+      case ApplyExpression(JsonLogicOp.IfElseOp, args) => args.exists(hasAuthoredDirective)
+      case ApplyExpression(JsonLogicOp.SetOp, obj :: keyExpr :: _ :: Nil) =>
+        hasAuthoredDirective(obj) || (keyExpr match {
+          case ConstExpression(StrValue(k)) => resultDirectiveKeys(k)
+          case _                            => false
+        })
+      case ArrayExpression(elems)             => elems.exists(tupleDirectiveKey(_).isDefined)
+      case ConstExpression(ArrayValue(elems)) => elems.exists(constTupleDirectiveKey(_).isDefined)
+      case _                                  => false
+    }
+
+  /**
+   * Walk the AUTHORED effect expression and collect `(directiveKey, evaluatedValue)` pairs from every
+   * result-surfacing position, evaluating each authored directive value sub-expression against `contextData`:
+   *   - [[MapExpression]] / literal map: a LITERAL directive key → evaluate its value sub-expression.
+   *   - `merge`: union of operands → recurse into every operand.
+   *   - `if`: result is the taken branch → evaluate the conditions, recurse into the selected branch ONLY
+   *     (so a directive in a not-taken branch never fires — matching the old result-based semantics).
+   *   - `set`: a LITERAL string directive key arg is honoured (recurse the base object too); a COMPUTED
+   *     key arg (the injection vector) contributes nothing.
+   *   - `[[key, value], …]` tuple-update forms (the `ArrayValue` effect shape): literal directive keys only.
+   * Anything else (a bare `var`, an arbitrary op, …) surfaces no authored directive.
+   */
+  private def collectDirectiveEntries[F[_]: Async, G[_]: Monad](
+    expr:        JsonLogicExpression,
+    contextData: JsonLogicValue
+  )(implicit S: Stateful[G, ExecutionState], A: Ask[G, FiberContext], lift: F ~> G): G[List[(String, JsonLogicValue)]] =
+    expr match {
+      case MapExpression(m) =>
+        m.toList.flatTraverse {
+          case (k, vExpr) if resultDirectiveKeys(k) => evalDirectiveValue[F, G](k, vExpr, contextData)
+          case _                                    => List.empty[(String, JsonLogicValue)].pure[G]
+        }
+
+      case ConstExpression(MapValue(m)) =>
+        m.toList.collect { case (k, v) if resultDirectiveKeys(k) => k -> v }.pure[G]
+
+      case ApplyExpression(JsonLogicOp.MergeOp, args) =>
+        args.flatTraverse(collectDirectiveEntries[F, G](_, contextData))
+
+      case ApplyExpression(JsonLogicOp.IfElseOp, args) =>
+        selectIfBranch[F, G](args, contextData).flatMap {
+          case Some(branch) => collectDirectiveEntries[F, G](branch, contextData)
+          case None         => List.empty[(String, JsonLogicValue)].pure[G]
+        }
+
+      case ApplyExpression(JsonLogicOp.SetOp, obj :: keyExpr :: valExpr :: Nil) =>
+        for {
+          base <- collectDirectiveEntries[F, G](obj, contextData)
+          extra <- keyExpr match {
+            case ConstExpression(StrValue(k)) if resultDirectiveKeys(k) =>
+              evalDirectiveValue[F, G](k, valExpr, contextData)
+            case _ => List.empty[(String, JsonLogicValue)].pure[G]
+          }
+        } yield base ++ extra
+
+      case ArrayExpression(elems) =>
+        elems.flatTraverse { elem =>
+          tupleDirectiveKey(elem) match {
+            case Some((k, vExpr)) => evalDirectiveValue[F, G](k, vExpr, contextData)
+            case None             => List.empty[(String, JsonLogicValue)].pure[G]
+          }
+        }
+
+      case ConstExpression(ArrayValue(elems)) =>
+        elems.flatMap(constTupleDirectiveKey).pure[G]
+
+      case _ => List.empty[(String, JsonLogicValue)].pure[G]
+    }
+
+  /** Evaluate one authored directive value sub-expression; a failed/dropped eval yields no entry. */
+  private def evalDirectiveValue[F[_]: Async, G[_]: Monad](
+    key:         String,
+    valueExpr:   JsonLogicExpression,
+    contextData: JsonLogicValue
+  )(implicit S: Stateful[G, ExecutionState], A: Ask[G, FiberContext], lift: F ~> G): G[List[(String, JsonLogicValue)]] =
+    MeteredEvaluator
+      .evalOpt[F, G](valueExpr, contextData, GasExhaustionPhase.Effect)
+      .map(_.map(key -> _).toList)
+
+  /**
+   * Replicate metakit's `if` branch selection over the AUTHORED condition expressions: walk `(cond, branch)`
+   * pairs, evaluate each condition against `contextData`, return the first truthy branch, else the trailing
+   * `else`. A condition that fails to evaluate is treated as not-taken (graceful), and a malformed (even)
+   * arg list yields no branch — such an effect would already have aborted in the main effect evaluation.
+   */
+  private def selectIfBranch[F[_]: Async, G[_]: Monad](
+    args:        List[JsonLogicExpression],
+    contextData: JsonLogicValue
+  )(implicit S: Stateful[G, ExecutionState], A: Ask[G, FiberContext], lift: F ~> G): G[Option[JsonLogicExpression]] =
+    args match {
+      case cond :: branch :: rest =>
+        MeteredEvaluator.evalOpt[F, G](cond, contextData, GasExhaustionPhase.Effect).flatMap {
+          case Some(v) if v.isTruthy => (Some(branch): Option[JsonLogicExpression]).pure[G]
+          case _                     => selectIfBranch[F, G](rest, contextData)
+        }
+      case lastElse :: Nil => (Some(lastElse): Option[JsonLogicExpression]).pure[G]
+      case Nil             => (None: Option[JsonLogicExpression]).pure[G]
+    }
+
+  /** A literal `[directiveKey, valueExpr]` tuple in the array-update effect form, or `None`. */
+  private def tupleDirectiveKey(elem: JsonLogicExpression): Option[(String, JsonLogicExpression)] =
+    elem match {
+      case ArrayExpression(ConstExpression(StrValue(k)) :: valExpr :: Nil) if resultDirectiveKeys(k) =>
+        Some(k -> valExpr)
+      case _ => None
+    }
+
+  /** A literal `[directiveKey, value]` tuple in a fully-constant array-update effect, or `None`. */
+  private def constTupleDirectiveKey(elem: JsonLogicValue): Option[(String, JsonLogicValue)] =
+    elem match {
+      case ArrayValue(StrValue(k) :: v :: Nil) if resultDirectiveKeys(k) => Some(k -> v)
+      case _                                                             => None
+    }
+
+  /**
+   * Combine the values collected for a single directive key across multiple surfacing positions (e.g. a
+   * `merge` of two maps that each author `_triggers`). Array directives concatenate (preserving authored
+   * order); a non-array directive (`_scriptCall`) takes the last, matching `merge`'s last-wins for maps.
+   */
+  private def combineDirectiveValues(values: List[JsonLogicValue]): JsonLogicValue =
+    values match {
+      case single :: Nil => single
+      case many if many.forall(_.isInstanceOf[ArrayValue]) =>
+        ArrayValue(many.flatMap { case ArrayValue(items) => items; case _ => List.empty })
+      case many => many.lastOption.getOrElse(NullValue)
     }
 
   /**

--- a/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/fiber/evaluation/FiberEvaluator.scala
+++ b/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/fiber/evaluation/FiberEvaluator.scala
@@ -302,7 +302,7 @@ object FiberEvaluator {
           fiberGasConfig <- A.reader(_.fiberGasConfig)
           limits         <- ExecutionOps.askLimits[G]
 
-          effects <- EffectExtractor.extractEffects[F, G](effectResult, transition.effect, contextData, fiberId)
+          effects <- EffectExtractor.extractEffects[F, G](transition.effect, contextData, fiberId)
           allTriggers = effects.collect { case FiberEffect.Triggered(t) => t }
           spawnMachines = effects.collect { case FiberEffect.Spawned(d) => d }
           emittedEvents = effects.collect { case FiberEffect.Emitted(ev) => ev }

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/DefinitionLinterSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/DefinitionLinterSuite.scala
@@ -1,0 +1,322 @@
+package xyz.kd5ujc.shared_data
+
+import java.io.{File, FilenameFilter}
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+
+import cats.effect.IO
+
+import xyz.kd5ujc.schema.fiber.StateMachineDefinition
+import xyz.kd5ujc.schema.registry.{FieldShape, MachineShape, MessageShape}
+import xyz.kd5ujc.shared_data.fiber.DefinitionLinter
+import xyz.kd5ujc.shared_data.fiber.DefinitionLinter.{Diagnostic, Severity}
+
+import io.circe.parser.decode
+import weaver.SimpleIOSuite
+
+/**
+ * Tests for the offline, advisory [[DefinitionLinter]] (Proposal 01 — fiber-ergonomics/01-authoring-safety):
+ *   - every shipped riverdale definition lints clean of Errors (read from disk when present, plus an embedded
+ *     copy so the property is asserted even without file access);
+ *   - a misspelled `_triger` directive is a hard `unknown-directive` Error (the F4 killer);
+ *   - a read of a never-written `state.X` with no shape is an `undeclared-state-read` Warning;
+ *   - a state unreachable from `initialState` is an `unreachable-state` Error.
+ */
+object DefinitionLinterSuite extends SimpleIOSuite {
+
+  private def parseDef(s: String): StateMachineDefinition =
+    decode[StateMachineDefinition](s).fold(e => throw new RuntimeException(s"parse def: $e"), identity)
+
+  private def errorsOf(ds:   List[Diagnostic]): List[Diagnostic] = ds.filter(_.severity == Severity.Error)
+  private def warningsOf(ds: List[Diagnostic]): List[Diagnostic] = ds.filter(_.severity == Severity.Warning)
+
+  private def renderErrors(ds: List[Diagnostic]): String =
+    errorsOf(ds).map(d => s"${d.code} @ ${d.location} :: ${d.message}").mkString(" | ")
+
+  // ---------------------------------------------------------------------------
+  // riverdale definitions lint clean (no Errors)
+  // ---------------------------------------------------------------------------
+
+  /** Walk up from the JVM working directory to find the shipped riverdale example definitions. */
+  private def riverdaleDir: Option[File] = {
+    val rel = "e2e-test/examples/riverdale-economy"
+    LazyList
+      .iterate(Option(new File(System.getProperty("user.dir")).getAbsoluteFile))(
+        _.flatMap(f => Option(f.getParentFile))
+      )
+      .takeWhile(_.isDefined)
+      .flatten
+      .take(8)
+      .map(base => new File(base, rel))
+      .find(_.isDirectory)
+  }
+
+  riverdaleDir match {
+    case Some(dir) =>
+      val jsonFilter: FilenameFilter = (_, name) => name.endsWith(".definition.json")
+      val files = Option(dir.listFiles(jsonFilter)).getOrElse(Array.empty[File]).toList.sortBy(_.getName)
+      files.foreach { f =>
+        test(s"riverdale ${f.getName} lints clean (no Errors)") {
+          val src = new String(Files.readAllBytes(f.toPath), StandardCharsets.UTF_8)
+          val diags = DefinitionLinter.validate(parseDef(src))
+          IO.pure(
+            if (errorsOf(diags).isEmpty) success
+            else failure(s"${f.getName} produced Errors: ${renderErrors(diags)}")
+          )
+        }
+      }
+    case None =>
+      // The embedded manufacturer test below still asserts the clean-definition property, so a missing
+      // examples directory (e.g. an unusual working dir) is non-fatal — record it without failing.
+      pureTest("riverdale example directory not located — relying on embedded definition")(success)
+  }
+
+  // An embedded, verbatim copy of manufacturer.definition.json — guarantees the "clean" property is asserted
+  // even when file IO is unavailable. Uses _triggers / _transferAsset directives and state reads/writes.
+  private val manufacturerJson =
+    """
+    {
+      "states": {
+        "stocked": { "id": "stocked", "isFinal": false },
+        "shipped": { "id": "shipped", "isFinal": false }
+      },
+      "initialState": "stocked",
+      "transitions": [
+        {
+          "from": "stocked",
+          "to": "shipped",
+          "eventName": "fulfill_order",
+          "guard": { ">=": [{ "var": "state.inventory" }, { "var": "event.quantity" }] },
+          "effect": {
+            "_triggers": [
+              {
+                "targetMachineId": { "var": "event.retailerId" },
+                "eventName": "receive_shipment",
+                "payload": { "quantity": { "var": "event.quantity" } }
+              }
+            ],
+            "_transferAsset": [
+              { "assetId": { "var": "event.goodsAssetId" }, "recipient": { "var": "event.retailerId" } }
+            ],
+            "status": "shipped",
+            "inventory": { "-": [{ "var": "state.inventory" }, { "var": "event.quantity" }] }
+          },
+          "dependencies": []
+        },
+        {
+          "from": "shipped",
+          "to": "shipped",
+          "eventName": "pay_taxes",
+          "guard": { "==": [1, 1] },
+          "effect": {
+            "taxesPaid": { "+": [{ "var": "state.taxesPaid" }, { "var": "event.taxAmount" }] }
+          },
+          "dependencies": []
+        }
+      ]
+    }
+    """
+
+  test("embedded manufacturer definition lints clean (no Errors)") {
+    val diags = DefinitionLinter.validate(parseDef(manufacturerJson))
+    IO.pure(
+      if (errorsOf(diags).isEmpty) success
+      else failure(s"unexpected Errors: ${renderErrors(diags)}")
+    )
+  }
+
+  // ---------------------------------------------------------------------------
+  // (b) a typo'd `_`-directive is a hard Error (kills F4)
+  // ---------------------------------------------------------------------------
+
+  private val typoDirectiveJson =
+    """
+    {
+      "states": { "a": { "id": "a", "isFinal": false }, "b": { "id": "b", "isFinal": true } },
+      "initialState": "a",
+      "transitions": [
+        {
+          "from": "a", "to": "b", "eventName": "go",
+          "guard": { "==": [1, 1] },
+          "effect": {
+            "_triger": [
+              { "targetMachineId": "00000000-0000-0000-0000-000000000001", "eventName": "x", "payload": {} }
+            ],
+            "status": "b"
+          },
+          "dependencies": []
+        }
+      ]
+    }
+    """
+
+  test("a typo'd `_triger` directive produces an unknown-directive Error") {
+    val diags = DefinitionLinter.validate(parseDef(typoDirectiveJson))
+    val unknown = diags.filter(d => d.code == "unknown-directive" && d.severity == Severity.Error)
+    IO.pure(
+      expect(unknown.nonEmpty) and
+      expect(unknown.exists(_.message.contains("_triggers"))) // nearest-directive suggestion
+    )
+  }
+
+  // ---------------------------------------------------------------------------
+  // (a)/(d) a read of a never-written `state.X` with no shape is a Warning
+  // ---------------------------------------------------------------------------
+
+  private val unseededReadJson =
+    """
+    {
+      "states": { "a": { "id": "a", "isFinal": false }, "b": { "id": "b", "isFinal": true } },
+      "initialState": "a",
+      "transitions": [
+        {
+          "from": "a", "to": "b", "eventName": "go",
+          "guard": { ">": [{ "var": "state.unseeded" }, 0] },
+          "effect": { "status": "b" },
+          "dependencies": []
+        }
+      ]
+    }
+    """
+
+  test("a read of a never-written state field (no shape) is an undeclared-state-read Warning") {
+    val diags = DefinitionLinter.validate(parseDef(unseededReadJson))
+    val warns = warningsOf(diags).filter(d => d.code == "undeclared-state-read")
+    IO.pure(
+      expect(errorsOf(diags).isEmpty) and
+      expect(warns.exists(_.location.path.contains("state.unseeded")))
+    )
+  }
+
+  // ---------------------------------------------------------------------------
+  // (c) an unreachable state is an Error
+  // ---------------------------------------------------------------------------
+
+  private val unreachableJson =
+    """
+    {
+      "states": {
+        "a": { "id": "a", "isFinal": false },
+        "b": { "id": "b", "isFinal": false },
+        "orphan": { "id": "orphan", "isFinal": false }
+      },
+      "initialState": "a",
+      "transitions": [
+        {
+          "from": "a", "to": "b", "eventName": "go",
+          "guard": { "==": [1, 1] },
+          "effect": { "status": "b" },
+          "dependencies": []
+        }
+      ]
+    }
+    """
+
+  test("a state unreachable from initialState produces an unreachable-state Error") {
+    val diags = DefinitionLinter.validate(parseDef(unreachableJson))
+    val unreachable = diags.filter(d => d.code == "unreachable-state" && d.severity == Severity.Error)
+    IO.pure(
+      expect(unreachable.nonEmpty) and
+      expect(unreachable.exists(_.location.path.contains("orphan")))
+    )
+  }
+
+  // ---------------------------------------------------------------------------
+  // (d) WITH a shape: undeclared read/write become Errors
+  // ---------------------------------------------------------------------------
+
+  private val shape: MachineShape =
+    MachineShape(
+      stateMessage = MessageShape(
+        "App.State",
+        List(FieldShape("status", 1, "string", repeated = false, optional = false))
+      ),
+      commands = scala.collection.immutable.SortedMap.empty
+    )
+
+  test("with a shape, an undeclared state read and write are Errors") {
+    val diags = DefinitionLinter.validate(parseDef(unseededReadJson), Some(shape))
+    val readErr = diags.filter(d => d.code == "undeclared-state-read" && d.severity == Severity.Error)
+    // The unseeded def only writes the declared `status`, so no write error there — assert the read flips to Error.
+    IO.pure(expect(readErr.nonEmpty))
+  }
+
+  // ---------------------------------------------------------------------------
+  // (b2) _transferAsset recipient shape (object-form-only)
+  // ---------------------------------------------------------------------------
+
+  private def transferDef(recipientJson: String): String =
+    s"""
+    {
+      "states": { "s0": { "id": "s0", "isFinal": false }, "s1": { "id": "s1", "isFinal": true } },
+      "initialState": "s0",
+      "transitions": [
+        {
+          "from": "s0", "to": "s1", "eventName": "go", "guard": true,
+          "effect": { "_transferAsset": [ { "assetId": { "var": "event.aid" }, "recipient": $recipientJson } ], "done": true },
+          "dependencies": []
+        }
+      ]
+    }
+    """
+
+  test("a well-formed object-form _transferAsset recipient produces no recipient diagnostic") {
+    val diags =
+      DefinitionLinter.validate(parseDef(transferDef("""{ "Fiber": { "fiberId": { "var": "event.to" } } }""")))
+    IO.pure(expect(diags.forall(!_.code.startsWith("transfer-recipient"))))
+  }
+
+  test("a bare-string _transferAsset recipient is a transfer-recipient-bare-string Warning") {
+    val diags = DefinitionLinter.validate(parseDef(transferDef(""" "DAGsomeBareRecipientAddress" """)))
+    val warns = warningsOf(diags).filter(_.code == "transfer-recipient-bare-string")
+    IO.pure(expect(warns.nonEmpty) and expect(warns.forall(_.location.path.contains("recipient"))))
+  }
+
+  test("a malformed object _transferAsset recipient is a transfer-recipient Error") {
+    val missingField =
+      DefinitionLinter.validate(parseDef(transferDef("""{ "Fiber": { "nope": { "var": "event.to" } } }""")))
+    val wrongVariant = DefinitionLinter.validate(parseDef(transferDef("""{ "Holder": { "id": "x" } }""")))
+    IO.pure(
+      expect(errorsOf(missingField).exists(_.code == "transfer-recipient-malformed")) and
+      expect(errorsOf(wrongVariant).exists(_.code == "transfer-recipient-not-holder"))
+    )
+  }
+
+  // ---------------------------------------------------------------------------
+  // (b3) directive-injection hazard: dynamic TOP-LEVEL effect keys
+  // ---------------------------------------------------------------------------
+
+  private def effectDef(effectJson: String): String =
+    s"""
+    {
+      "states": { "s0": { "id": "s0", "isFinal": false }, "s1": { "id": "s1", "isFinal": true } },
+      "initialState": "s0",
+      "transitions": [
+        { "from": "s0", "to": "s1", "eventName": "go", "guard": true, "effect": $effectJson, "dependencies": [] }
+      ]
+    }
+    """
+
+  test("a top-level dynamic effect key (set with a non-literal key) is a directive-injection-hazard Warning") {
+    val danger =
+      effectDef(
+        """{ "merge": [ { "var": "state" }, { "set": [ {}, { "var": "event.k" }, { "var": "event.v" } ] } ] }"""
+      )
+    val warns = warningsOf(DefinitionLinter.validate(parseDef(danger))).filter(_.code == "directive-injection-hazard")
+    IO.pure(expect(warns.nonEmpty))
+  }
+
+  test("a NESTED dynamic key (accumulator under a state field) is NOT an injection hazard") {
+    val safe = effectDef(
+      """{ "merge": [ { "var": "state" }, { "tally": { "set": [ { "var": "state.tally" }, { "var": "event.k" }, true ] } } ] }"""
+    )
+    val diags = DefinitionLinter.validate(parseDef(safe))
+    IO.pure(expect(diags.forall(_.code != "directive-injection-hazard")))
+  }
+
+  test("a literal-key set is NOT an injection hazard") {
+    val lit = effectDef("""{ "set": [ { "var": "state" }, "status", "done" ] }""")
+    val diags = DefinitionLinter.validate(parseDef(lit))
+    IO.pure(expect(diags.forall(_.code != "directive-injection-hazard")))
+  }
+}

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/DirectiveInjectionHardeningSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/DirectiveInjectionHardeningSuite.scala
@@ -1,0 +1,485 @@
+package xyz.kd5ujc.shared_data
+
+import java.util.UUID
+
+import cats.effect.IO
+
+import scala.collection.immutable.SortedMap
+
+import io.constellationnetwork.currency.dataApplication.{DataState, L0NodeContext}
+import io.constellationnetwork.metagraph_sdk.json_logic._
+import io.constellationnetwork.metagraph_sdk.std.JsonBinaryHasher.HasherOps
+import io.constellationnetwork.schema.SnapshotOrdinal
+import io.constellationnetwork.schema.address.Address
+import io.constellationnetwork.security.SecurityProvider
+import io.constellationnetwork.security.hash.Hash
+import io.constellationnetwork.security.signature.Signed
+
+import xyz.kd5ujc.schema.Records.AssetRecord
+import xyz.kd5ujc.schema.asset.{AssetHolder, TokenBehavior}
+import xyz.kd5ujc.schema.fiber._
+import xyz.kd5ujc.schema.registry.{RegistryName, SchemaBinding, SemVer}
+import xyz.kd5ujc.schema.{CalculatedState, OnChain, Records, Updates}
+import xyz.kd5ujc.shared_data.lifecycle.Combiner
+import xyz.kd5ujc.shared_test.Participant._
+import xyz.kd5ujc.shared_test.TestFixture
+
+import io.circe.parser._
+import weaver.SimpleIOSuite
+
+/**
+ * Directive-injection hardening (`EffectExtractor.authoredDirectiveResult`). Proves the reserved-`_`-directive
+ * channel is INJECTION-IMMUNE: a directive is honoured ONLY when its KEY is LITERALLY AUTHORED in the signed
+ * effect expression, never when the key is COMPUTED from event data.
+ *
+ *   (1) REGRESSION (the vector closed) — a transition whose effect computes a TOP-LEVEL key from event data
+ *       (`{"merge":[{"var":"state"},{"set":[{}, {"var":"event.k"}, {"var":"event.v"}]}]}`) with an attacker
+ *       supplying `event.k = "_transferAsset"` and `event.v = [a fully-valid transfer to the attacker's
+ *       wallet]`. Under the OLD result-based extraction this drains the fiber's held asset; here the injected
+ *       directive is IGNORED (a clean no-op) — the asset never moves, and there is no rejection.
+ *   (2) CONTROL — the SAME machine shape with the directive key LITERALLY authored DOES move the asset
+ *       (proves the channel still works; the regression is not passing because transfers are broken).
+ *   (3)/(4) CONDITIONAL `_transferAsset` inside an `if` — fires iff the branch is taken (proves authored
+ *       conditional directives are preserved, not regressed by the move off result-based extraction).
+ *   (5)/(6) CONDITIONAL `_triggers` inside an `if` — the cross-fiber trigger fires iff the branch is taken.
+ */
+object DirectiveInjectionHardeningSuite extends SimpleIOSuite {
+
+  private val binding: SchemaBinding =
+    SchemaBinding(RegistryName.unsafe("gold.asset"), SemVer(1, 0, 0), Hash("schema-1.0.0"), Hash("logic-1.0.0"))
+
+  private def heldAsset(assetId: UUID, holder: UUID, ordinal: SnapshotOrdinal): AssetRecord =
+    AssetRecord(
+      assetId = assetId,
+      schemaBinding = binding,
+      behavior = TokenBehavior.Fungible,
+      holder = AssetHolder.Fiber(holder),
+      amount = 100L,
+      sequenceNumber = FiberOrdinal.MinValue,
+      creationOrdinal = ordinal,
+      latestUpdateOrdinal = ordinal
+    )
+
+  // Object-form AssetHolder recipient literal (canonical post-#193 form) for embedding in `_transferAsset`.
+  private def walletHolderJson(address: String): String = s"""{ "Wallet": { "address": "$address" } }"""
+
+  private def buildMachine(
+    fiberId:   UUID,
+    json:      String,
+    state:     MapValue,
+    initState: String,
+    ordinal:   SnapshotOrdinal
+  ): IO[Records.StateMachineFiberRecord] =
+    for {
+      definition <- IO.fromEither(decode[StateMachineDefinition](json))
+      hash       <- (state: JsonLogicValue).computeDigest
+    } yield Records.StateMachineFiberRecord(
+      fiberId = fiberId,
+      creationOrdinal = ordinal,
+      previousUpdateOrdinal = ordinal,
+      latestUpdateOrdinal = ordinal,
+      definition = definition,
+      currentState = StateId(initState),
+      stateData = state,
+      stateDataHash = hash,
+      sequenceNumber = FiberOrdinal.MinValue,
+      owners = Set.empty,
+      status = FiberStatus.Active
+    )
+
+  private def rejectionReasons(state: DataState[OnChain, CalculatedState]): List[String] =
+    state.onChain.latestLogs.values.flatten.collect { case r: FiberLogEntry.RejectionReceipt => r.reason }.toList
+
+  // ── (1) REGRESSION: a directive whose KEY is computed from event data is NEVER honoured ─────────────
+
+  // The effect writes a top-level key COMPUTED from event data: `state ∪ { event.k : event.v }`. An honest app
+  // author intends dynamic STATE keys, but the same shape lets an attacker pick `event.k = "_transferAsset"`.
+  private val computedKeyEffectJson: String =
+    s"""
+    {
+      "states": {
+        "HOLDING":  { "id": "HOLDING",  "isFinal": false },
+        "RELEASED": { "id": "RELEASED", "isFinal": true }
+      },
+      "initialState": "HOLDING",
+      "transitions": [
+        {
+          "from": "HOLDING",
+          "to": "RELEASED",
+          "eventName": "poke",
+          "guard": true,
+          "effect": {
+            "merge": [
+              { "var": "state" },
+              { "set": [ {}, { "var": "event.k" }, { "var": "event.v" } ] }
+            ]
+          },
+          "dependencies": []
+        }
+      ]
+    }
+    """
+
+  test("REGRESSION: an injected _transferAsset (computed top-level key) is ignored — the asset is NOT drained") {
+    TestFixture.resource(Set(Alice, Bob)).use { fixture =>
+      implicit val sp: SecurityProvider[IO] = fixture.securityProvider
+      implicit val l0: L0NodeContext[IO] = fixture.l0Context
+      val combiner = Combiner.make[IO]()
+
+      val victimId = UUID.fromString("17150000-0000-4000-8000-000000000001")
+      val assetId = UUID.fromString("a55e7000-0000-4000-8000-0000000000f1")
+      val attacker: Address = fixture.registry.addresses(Bob) // the would-be thief's wallet
+
+      // event.v is a FULLY VALID `_transferAsset` array (object-form recipient) — so the ONLY thing stopping
+      // the drain is the authored-key hardening, not a malformed directive.
+      val maliciousPayload = MapValue(
+        Map(
+          "k" -> StrValue(ReservedKeys.TRANSFER_ASSET),
+          "v" -> ArrayValue(
+            List(
+              MapValue(
+                Map(
+                  "assetId"   -> StrValue(assetId.toString),
+                  "recipient" -> MapValue(Map("Wallet" -> MapValue(Map("address" -> StrValue(attacker.value.value)))))
+                )
+              )
+            )
+          )
+        )
+      )
+
+      for {
+        victim <- buildMachine(victimId, computedKeyEffectJson, MapValue(Map.empty), "HOLDING", fixture.ordinal)
+        asset = heldAsset(assetId, victimId, fixture.ordinal)
+        genesis = DataState(
+          OnChain.genesis,
+          CalculatedState.genesis.copy(
+            stateMachines = SortedMap(victimId -> victim),
+            assets = SortedMap(assetId -> asset)
+          )
+        )
+        poke = Updates.TransitionStateMachine(victimId, "poke", maliciousPayload, FiberOrdinal.MinValue)
+        pr    <- fixture.registry.generateProofs(poke, Set(Alice))
+        after <- combiner.insert(genesis, Signed(poke, pr))
+
+        assetAfter = after.calculated.assets.get(assetId)
+      } yield
+      // the injected directive is a clean no-op: no graceful reject, the transition still advances
+      expect(rejectionReasons(after).isEmpty) and
+      expect(after.calculated.stateMachines.get(victimId).map(_.currentState).contains(StateId("RELEASED"))) and
+      // and CRUCIALLY the asset never moved — still fiber-held by the victim at the original sequence
+      expect(assetAfter.map(_.holder).contains(AssetHolder.Fiber(victimId))) and
+      expect(assetAfter.map(_.sequenceNumber).contains(FiberOrdinal.MinValue)) and
+      expect(after.onChain.assetCommits.get(assetId).isEmpty)
+    }
+  }
+
+  // ── (2) CONTROL: the SAME shape with a LITERAL directive key DOES transfer ───────────────────────────
+
+  private def literalTransferJson(assetId: UUID, recipientJson: String): String =
+    s"""
+    {
+      "states": {
+        "HOLDING":  { "id": "HOLDING",  "isFinal": false },
+        "RELEASED": { "id": "RELEASED", "isFinal": true }
+      },
+      "initialState": "HOLDING",
+      "transitions": [
+        {
+          "from": "HOLDING",
+          "to": "RELEASED",
+          "eventName": "poke",
+          "guard": true,
+          "effect": {
+            "_transferAsset": [ { "assetId": "$assetId", "recipient": $recipientJson } ],
+            "released": true
+          },
+          "dependencies": []
+        }
+      ]
+    }
+    """
+
+  test("CONTROL: a LITERALLY-authored _transferAsset still moves the asset (the channel works)") {
+    TestFixture.resource(Set(Alice, Bob)).use { fixture =>
+      implicit val sp: SecurityProvider[IO] = fixture.securityProvider
+      implicit val l0: L0NodeContext[IO] = fixture.l0Context
+      val combiner = Combiner.make[IO]()
+
+      val escrowId = UUID.fromString("17150000-0000-4000-8000-000000000002")
+      val assetId = UUID.fromString("a55e7000-0000-4000-8000-0000000000f2")
+      val bob: Address = fixture.registry.addresses(Bob)
+
+      for {
+        escrow <- buildMachine(
+          escrowId,
+          literalTransferJson(assetId, walletHolderJson(bob.value.value)),
+          MapValue(Map("released" -> BoolValue(false))),
+          "HOLDING",
+          fixture.ordinal
+        )
+        asset = heldAsset(assetId, escrowId, fixture.ordinal)
+        genesis = DataState(
+          OnChain.genesis,
+          CalculatedState.genesis.copy(
+            stateMachines = SortedMap(escrowId -> escrow),
+            assets = SortedMap(assetId -> asset)
+          )
+        )
+        poke = Updates.TransitionStateMachine(escrowId, "poke", MapValue(Map.empty), FiberOrdinal.MinValue)
+        pr    <- fixture.registry.generateProofs(poke, Set(Alice))
+        after <- combiner.insert(genesis, Signed(poke, pr))
+      } yield expect(rejectionReasons(after).isEmpty) and
+      expect(after.calculated.assets.get(assetId).map(_.holder).contains(AssetHolder.Wallet(bob)))
+    }
+  }
+
+  // ── (3)/(4) CONDITIONAL _transferAsset inside an `if` — fires iff the branch is taken ────────────────
+
+  private def conditionalTransferJson(assetId: UUID, recipientJson: String): String =
+    s"""
+    {
+      "states": {
+        "HOLDING":  { "id": "HOLDING",  "isFinal": false },
+        "RELEASED": { "id": "RELEASED", "isFinal": true }
+      },
+      "initialState": "HOLDING",
+      "transitions": [
+        {
+          "from": "HOLDING",
+          "to": "RELEASED",
+          "eventName": "maybe_release",
+          "guard": true,
+          "effect": {
+            "if": [
+              { "var": "event.doTransfer" },
+              {
+                "_transferAsset": [ { "assetId": "$assetId", "recipient": $recipientJson } ],
+                "released": true
+              },
+              { "released": false }
+            ]
+          },
+          "dependencies": []
+        }
+      ]
+    }
+    """
+
+  private def runConditionalTransfer(doTransfer: Boolean): IO[(Boolean, Boolean, List[String])] =
+    TestFixture.resource(Set(Alice, Bob)).use { fixture =>
+      implicit val sp: SecurityProvider[IO] = fixture.securityProvider
+      implicit val l0: L0NodeContext[IO] = fixture.l0Context
+      val combiner = Combiner.make[IO]()
+
+      val escrowId = UUID.fromString("17150000-0000-4000-8000-000000000003")
+      val assetId = UUID.fromString("a55e7000-0000-4000-8000-0000000000f3")
+      val bob: Address = fixture.registry.addresses(Bob)
+
+      for {
+        escrow <- buildMachine(
+          escrowId,
+          conditionalTransferJson(assetId, walletHolderJson(bob.value.value)),
+          MapValue(Map("released" -> BoolValue(false))),
+          "HOLDING",
+          fixture.ordinal
+        )
+        asset = heldAsset(assetId, escrowId, fixture.ordinal)
+        genesis = DataState(
+          OnChain.genesis,
+          CalculatedState.genesis.copy(
+            stateMachines = SortedMap(escrowId -> escrow),
+            assets = SortedMap(assetId -> asset)
+          )
+        )
+        payload = MapValue(Map("doTransfer" -> BoolValue(doTransfer)))
+        ev = Updates.TransitionStateMachine(escrowId, "maybe_release", payload, FiberOrdinal.MinValue)
+        pr    <- fixture.registry.generateProofs(ev, Set(Alice))
+        after <- combiner.insert(genesis, Signed(ev, pr))
+        movedToWallet = after.calculated.assets.get(assetId).map(_.holder).contains(AssetHolder.Wallet(bob))
+        advanced = after.calculated.stateMachines.get(escrowId).map(_.currentState).contains(StateId("RELEASED"))
+      } yield (movedToWallet, advanced, rejectionReasons(after))
+    }
+
+  test("CONDITIONAL transfer: the `if`-true branch FIRES the authored _transferAsset") {
+    runConditionalTransfer(doTransfer = true).map { case (moved, advanced, rejects) =>
+      expect(rejects.isEmpty) and expect(advanced) and expect(moved)
+    }
+  }
+
+  test("CONDITIONAL transfer: the `if`-false branch does NOT fire the _transferAsset (asset untouched)") {
+    runConditionalTransfer(doTransfer = false).map { case (moved, advanced, rejects) =>
+      expect(rejects.isEmpty) and expect(advanced) and expect(!moved)
+    }
+  }
+
+  // ── (5)/(6) CONDITIONAL _triggers inside an `if` — cross-fiber trigger fires iff the branch is taken ──
+
+  private def conditionalTriggerJson(targetId: UUID): String =
+    s"""
+    {
+      "states": {
+        "idle":    { "id": "idle",    "isFinal": false },
+        "decided": { "id": "decided", "isFinal": false }
+      },
+      "initialState": "idle",
+      "transitions": [
+        {
+          "from": "idle",
+          "to": "decided",
+          "eventName": "decide",
+          "guard": true,
+          "effect": {
+            "if": [
+              { "var": "event.fire" },
+              {
+                "_triggers": [
+                  { "targetMachineId": "$targetId", "eventName": "activate", "payload": {} }
+                ],
+                "status": "fired"
+              },
+              { "status": "skipped" }
+            ]
+          },
+          "dependencies": []
+        }
+      ]
+    }
+    """
+
+  private val triggerTargetJson: String =
+    """
+    {
+      "states": {
+        "inactive": { "id": "inactive", "isFinal": false },
+        "ACTIVE":   { "id": "ACTIVE",   "isFinal": false }
+      },
+      "initialState": "inactive",
+      "transitions": [
+        {
+          "from": "inactive",
+          "to": "ACTIVE",
+          "eventName": "activate",
+          "guard": true,
+          "effect": { "status": "ACTIVE" },
+          "dependencies": []
+        }
+      ]
+    }
+    """
+
+  private def runConditionalTrigger(fire: Boolean): IO[(Boolean, Boolean, List[String])] =
+    TestFixture.resource(Set(Alice)).use { fixture =>
+      implicit val sp: SecurityProvider[IO] = fixture.securityProvider
+      implicit val l0: L0NodeContext[IO] = fixture.l0Context
+      val combiner = Combiner.make[IO]()
+
+      val initiatorId = UUID.fromString("17150000-0000-4000-8000-000000000005")
+      val targetId = UUID.fromString("17150000-0000-4000-8000-000000000006")
+
+      for {
+        initiator <- buildMachine(
+          initiatorId,
+          conditionalTriggerJson(targetId),
+          MapValue(Map("status" -> StrValue("idle"))),
+          "idle",
+          fixture.ordinal
+        )
+        target <- buildMachine(
+          targetId,
+          triggerTargetJson,
+          MapValue(Map("status" -> StrValue("inactive"))),
+          "inactive",
+          fixture.ordinal
+        )
+        genesis = DataState(
+          OnChain.genesis,
+          CalculatedState.genesis.copy(
+            stateMachines = SortedMap(initiatorId -> initiator, targetId -> target)
+          )
+        )
+        payload = MapValue(Map("fire" -> BoolValue(fire)))
+        ev = Updates.TransitionStateMachine(initiatorId, "decide", payload, FiberOrdinal.MinValue)
+        pr    <- fixture.registry.generateProofs(ev, Set(Alice))
+        after <- combiner.insert(genesis, Signed(ev, pr))
+        targetActivated = after.calculated.stateMachines.get(targetId).map(_.currentState).contains(StateId("ACTIVE"))
+        initiatorAdvanced =
+          after.calculated.stateMachines.get(initiatorId).map(_.currentState).contains(StateId("decided"))
+      } yield (targetActivated, initiatorAdvanced, rejectionReasons(after))
+    }
+
+  test("CONDITIONAL trigger: the `if`-true branch FIRES the cross-fiber _triggers (target activates)") {
+    runConditionalTrigger(fire = true).map { case (targetActivated, advanced, rejects) =>
+      expect(rejects.isEmpty) and expect(advanced) and expect(targetActivated)
+    }
+  }
+
+  test("CONDITIONAL trigger: the `if`-false branch does NOT fire the _triggers (target stays inactive)") {
+    runConditionalTrigger(fire = false).map { case (targetActivated, advanced, rejects) =>
+      expect(rejects.isEmpty) and expect(advanced) and expect(!targetActivated)
+    }
+  }
+
+  // ── (7) MERGE-nested directive — the staked-oracle-pool PRODUCTION shape ─────────────────────────────
+
+  // `effect: { "merge": [ { "var": "state" }, { "_addDependency": [..] } ] }` — the directive is authored
+  // INSIDE a top-level `merge`, NOT as a literal top-level key. A top-level-only walker would silently DROP
+  // it; the merge-recursion must honour it. This is byte-for-byte the shape of
+  // e2e-test/examples/staked-oracle-pool/definition.json (`bind_registry`), so this locks in that e2e lane.
+  private def mergeNestedDependencyJson(depId: UUID): String =
+    s"""
+    {
+      "states": {
+        "init":  { "id": "init",  "isFinal": false },
+        "bound": { "id": "bound", "isFinal": false }
+      },
+      "initialState": "init",
+      "transitions": [
+        {
+          "from": "init",
+          "to": "bound",
+          "eventName": "bind",
+          "guard": true,
+          "effect": {
+            "merge": [
+              { "var": "state" },
+              { "_addDependency": [ { "fiberId": "$depId" } ] }
+            ]
+          },
+          "dependencies": []
+        }
+      ]
+    }
+    """
+
+  test("MERGE-nested: an _addDependency authored inside a top-level `merge` is honoured (staked-oracle shape)") {
+    TestFixture.resource(Set(Alice)).use { fixture =>
+      implicit val sp: SecurityProvider[IO] = fixture.securityProvider
+      implicit val l0: L0NodeContext[IO] = fixture.l0Context
+      val combiner = Combiner.make[IO]()
+
+      val consumerId = UUID.fromString("17150000-0000-4000-8000-000000000007")
+      val depId = UUID.fromString("17150000-0000-4000-8000-000000000008")
+
+      for {
+        consumer <- buildMachine(
+          consumerId,
+          mergeNestedDependencyJson(depId),
+          MapValue(Map("seen" -> IntValue(0))),
+          "init",
+          fixture.ordinal
+        )
+        genesis = DataState(
+          OnChain.genesis,
+          CalculatedState.genesis.copy(stateMachines = SortedMap(consumerId -> consumer))
+        )
+        bind = Updates.TransitionStateMachine(consumerId, "bind", MapValue(Map.empty), FiberOrdinal.MinValue)
+        pr    <- fixture.registry.generateProofs(bind, Set(Alice))
+        after <- combiner.insert(genesis, Signed(bind, pr))
+        bound = after.calculated.stateMachines.get(consumerId).collect { case r: Records.StateMachineFiberRecord => r }
+      } yield expect(rejectionReasons(after).isEmpty) and
+      expect(bound.map(_.currentState).contains(StateId("bound"))) and
+      expect(bound.exists(_.dynamicDependencies.exists(d => d.fiberId == depId && d.active)))
+    }
+  }
+}

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/FiberVocabularySuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/FiberVocabularySuite.scala
@@ -1,0 +1,45 @@
+package xyz.kd5ujc.shared_data
+
+import java.util.UUID
+
+import cats.effect.IO
+
+import xyz.kd5ujc.schema.asset.AssetHolder
+import xyz.kd5ujc.schema.fiber.{FiberDirective, ReservedKeys}
+import xyz.kd5ujc.shared_test.Participant._
+import xyz.kd5ujc.shared_test.TestFixture
+
+import io.circe.syntax._
+import weaver.SimpleIOSuite
+
+/**
+ * Invariants over the fiber VOCABULARY single-sources, so the derived sets / tooling can never drift from the
+ * runtime: [[FiberDirective]] is the one directive list (`ReservedKeys.directiveKeys` derives from it), and
+ * [[AssetHolder.WireKeys]] is pinned to what the magnolia codec actually emits (so the DefinitionLinter's
+ * recipient-shape check can't go stale).
+ */
+object FiberVocabularySuite extends SimpleIOSuite {
+
+  pureTest("ReservedKeys.directiveKeys derives from FiberDirective (single source)") {
+    expect(ReservedKeys.directiveKeys == FiberDirective.values.flatMap(_.keys).toSet) and
+    expect(ReservedKeys.directiveKeys.forall(_.startsWith("_")))
+  }
+
+  test("AssetHolder.WireKeys match the magnolia codec output (drift guard)") {
+    TestFixture.resource(Set(Bob)).use { fixture =>
+      val fiberJson = (AssetHolder.Fiber(UUID.fromString("acc70000-0000-4000-8000-000000000001")): AssetHolder).asJson
+      val walletJson = (AssetHolder.Wallet(fixture.registry.addresses(Bob)): AssetHolder).asJson
+
+      def topKeys(j: io.circe.Json): Set[String] = j.asObject.map(_.keys.toSet).getOrElse(Set.empty)
+      def innerKeys(j: io.circe.Json, variant: String): Set[String] =
+        j.hcursor.downField(variant).keys.map(_.toSet).getOrElse(Set.empty)
+
+      IO.pure(
+        expect(topKeys(fiberJson) == Set(AssetHolder.WireKeys.FiberVariant)) and
+        expect(topKeys(walletJson) == Set(AssetHolder.WireKeys.WalletVariant)) and
+        expect(innerKeys(fiberJson, AssetHolder.WireKeys.FiberVariant) == Set(AssetHolder.WireKeys.FiberIdField)) and
+        expect(innerKeys(walletJson, AssetHolder.WireKeys.WalletVariant) == Set(AssetHolder.WireKeys.AddressField))
+      )
+    }
+  }
+}


### PR DESCRIPTION
## The vector

Reserved `_`-directives (`_triggers` / `_scriptCall` / `_transferAsset` / `_addDependency` / `_setDependencyActive` / `_emit`) were extracted by matching `key.startsWith("_")` on the **post-evaluation effect RESULT** (`EffectExtractor.extractEffects` read them off the `JsonLogicValue` the effect produced).

A transition whose effect computes a **top-level key from event data** therefore forged directives:

```json
{ "merge": [ { "var": "state" }, { "set": [ {}, { "var": "event.k" }, { "var": "event.v" } ] } ] }
```

With attacker-sent `event.k = "_transferAsset"` and `event.v = [{ "assetId": <a fiber-held asset>, "recipient": <attacker wallet> }]`, the evaluated result contains a top-level `_transferAsset`, the extractor honoured it, and the fiber's held assets drained. The `_`-prefix was a **string convention on runtime data, not a typed boundary**. (The combiner's R1 holder check bounds the blast radius — the *emitting* fiber must hold the asset — and `allowedEffects` is fail-closed *when set*, but both are downstream; this removes the injection vector itself.)

`_spawn` was already immune — extracted from the **expression** AST via `extractSpawnDirectivesFromExpression`, not the result.

## Approach chosen: (A) expression-based extraction — and why NOT (B)

The brief leaned toward **(B) hybrid authored-key guard** (keep result-based extraction; drop any result directive key not literally authored). I evaluated it and found it is **not** provably injection-immune: it gates on the KEY but the VALUE still comes from the result, so a **`merge`-collision** bypasses it. If an author *both* literally authors a directive `K` *and* exposes a dynamic-key writer, an attacker can hit it with key `K`; `merge`'s last-wins (`_ ++ _`, confirmed in metakit `handleMergeOp`) overwrites the authored value with the attacker's:

```json
{ "merge": [ { "_transferAsset": [<legit>], "x": 1 }, { "set": [ {}, { "var": "event.k" }, { "var": "event.v" } ] } ] }
```

`_transferAsset` is authored (so B allows the key) but the honoured value is the attacker's. **B does not guarantee "a directive whose key is computed from data is never executed."**

**(A) is provably immune**: directives are sourced from `EffectExtractor.authoredDirectiveResult`, which walks the **authored, signed AST** and honours a directive only where its KEY is a literal AST node in a result-surfacing position, evaluating the inner VALUE from the **authored sub-expression**. A data-computed key is never a literal AST node, and the value can never be substituted by a `merge`/`set` of attacker data — closing the merge-collision too.

## Conditional / merge handling (A's main risk)

Result-based extraction got conditionals for free. The expression walker reproduces it:

- **`if`** → `selectIfBranch` evaluates the authored conditions and recurses into the **taken** branch only, so a directive in a not-taken branch never fires (matches old semantics). `_spawn`'s current top-level-only behaviour is left unchanged.
- **`merge`** → recurse all operands and union (this is **load-bearing**: `e2e-test/examples/staked-oracle-pool/definition.json` authors `_addDependency` *inside* a top-level `merge`; a top-level-only walker would silently drop it).
- **`set`** → a literal directive key is honoured; a computed key (`{"var":...}`) contributes nothing (the injection vector).
- Directive-free effects take a pure static fast-path → **byte-for-byte gas-neutral**.

## Typed exhaustive dispatch

`extractEffects` now drives a typed registry — `handlerFor` is a **total match over a new `FiberDirective` enum**, so adding a directive without wiring its handler is a compile error (real wiring, no stringly-typed indirection — replaces the `Map[FiberDirective, String]` placeholder removed in #195). `FiberDirective` is also the single source of truth for the reserved-key set and the effect-emission order (unchanged).

## Regression proof

`DirectiveInjectionHardeningSuite` (end-to-end through `Combiner.insert`, mirroring `AssetFiberTransferSuite`):

- **REGRESSION** — the `merge`+`set` computed-key effect with a *fully-valid* `_transferAsset` to the attacker in `event.v`: the asset is **NOT** drained (still fiber-held, sequence unchanged, no asset commit), the injected directive is a clean no-op (no rejection), the transition still advances. The only thing stopping the drain is the hardening.
- **CONTROL** — the same machine with a *literal* `_transferAsset` still moves the asset (the channel works).
- **CONDITIONAL `_transferAsset` / `_triggers`** inside an `if` — fire iff the branch is taken (true → fires, false → no-op), proving authored conditional directives are preserved.
- **MERGE-nested `_addDependency`** — the exact staked-oracle-pool production shape is honoured (locks in that e2e lane).

```
+ REGRESSION: an injected _transferAsset (computed top-level key) is ignored — the asset is NOT drained
+ CONTROL: a LITERALLY-authored _transferAsset still moves the asset (the channel works)
+ CONDITIONAL transfer: the `if`-true branch FIRES the authored _transferAsset
+ CONDITIONAL transfer: the `if`-false branch does NOT fire the _transferAsset (asset untouched)
+ CONDITIONAL trigger: the `if`-true branch FIRES the cross-fiber _triggers (target activates)
+ CONDITIONAL trigger: the `if`-false branch does NOT fire the _triggers (target stays inactive)
+ MERGE-nested: an _addDependency authored inside a top-level `merge` is honoured (staked-oracle shape)
```

Full `sharedData/test`: **579 passed, 0 failed**. `scalafmtCheckAll` clean. `currencyL0` / `dataL1` / `currencyL1` compile.

## CLAUDE.md mapping

Combiner/evaluator-only change. The effect directives are **not** signed-message fields, so the **signed canonical is unaffected** (rule #1 — `PublishVersionSigningCanonicalSuite` untouched). No `validateSignedUpdate` change and **no `CalculatedState.registry` lineage read** (rules #2 / #3). All directive handling stays on the deterministic combiner apply path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R5TUSJPD8FCtJagf7siXgt