### PR TITLE
feat(openapi): publish spec (json+yaml) as release artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,25 +110,27 @@ jobs:
           PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
           REPO: ${{ github.repository }}
         run: |
-          # GenerateOpenApi writes docs/openapi.json AND its docs/openapi.yaml sibling.
-          sbt "currencyL0/runMain xyz.kd5ujc.metagraph_l0.openapi.GenerateOpenApi docs/openapi.json"
-          if git diff --quiet -- docs/openapi.json docs/openapi.yaml; then
-            echo "docs/openapi.{json,yaml} are in sync."
+          # GenerateOpenApi writes one contract per layer into docs/:
+          #   docs/openapi-ml0.{json,yaml} + docs/openapi-dl1.{json,yaml}
+          sbt "currencyL0/runMain xyz.kd5ujc.metagraph_l0.openapi.GenerateOpenApi docs"
+          SPECS="docs/openapi-ml0.json docs/openapi-ml0.yaml docs/openapi-dl1.json docs/openapi-dl1.yaml"
+          if git diff --quiet -- $SPECS; then
+            echo "OpenAPI contracts are in sync."
             exit 0
           fi
           if [ "$EVENT_NAME" = "pull_request" ] && [ "$PR_HEAD_REPO" = "$REPO" ]; then
             git config user.name "github-actions[bot]"
             git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-            git add docs/openapi.json docs/openapi.yaml
-            git commit -m "chore: sync docs/openapi.{json,yaml}"
+            git add $SPECS
+            git commit -m "chore: sync OpenAPI contracts (ml0 + dl1)"
             if git push origin "HEAD:$HEAD_REF"; then
-              echo "::notice::OpenAPI contract drifted; regenerated + committed to the PR branch. CI will re-run and pass."
+              echo "::notice::OpenAPI contracts drifted; regenerated + committed to the PR branch. CI will re-run and pass."
             else
-              echo "::error::docs/openapi.{json,yaml} are stale and the auto-commit push failed (branch protection or a read-only Actions token). Run: sbt \"currencyL0/runMain xyz.kd5ujc.metagraph_l0.openapi.GenerateOpenApi docs/openapi.json\" and commit them."
+              echo "::error::OpenAPI contracts are stale and the auto-commit push failed (branch protection or a read-only Actions token). Run: sbt \"currencyL0/runMain xyz.kd5ujc.metagraph_l0.openapi.GenerateOpenApi docs\" and commit them."
               exit 1
             fi
           else
-            echo "::error::docs/openapi.{json,yaml} are stale. Run: sbt \"currencyL0/runMain xyz.kd5ujc.metagraph_l0.openapi.GenerateOpenApi docs/openapi.json\" and commit them."
+            echo "::error::OpenAPI contracts are stale. Run: sbt \"currencyL0/runMain xyz.kd5ujc.metagraph_l0.openapi.GenerateOpenApi docs\" and commit them."
             exit 1
           fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,24 +110,25 @@ jobs:
           PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
           REPO: ${{ github.repository }}
         run: |
+          # GenerateOpenApi writes docs/openapi.json AND its docs/openapi.yaml sibling.
           sbt "currencyL0/runMain xyz.kd5ujc.metagraph_l0.openapi.GenerateOpenApi docs/openapi.json"
-          if git diff --quiet -- docs/openapi.json; then
-            echo "docs/openapi.json is in sync."
+          if git diff --quiet -- docs/openapi.json docs/openapi.yaml; then
+            echo "docs/openapi.{json,yaml} are in sync."
             exit 0
           fi
           if [ "$EVENT_NAME" = "pull_request" ] && [ "$PR_HEAD_REPO" = "$REPO" ]; then
             git config user.name "github-actions[bot]"
             git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-            git add docs/openapi.json
-            git commit -m "chore: sync docs/openapi.json"
+            git add docs/openapi.json docs/openapi.yaml
+            git commit -m "chore: sync docs/openapi.{json,yaml}"
             if git push origin "HEAD:$HEAD_REF"; then
-              echo "::notice::docs/openapi.json drifted; regenerated + committed to the PR branch. CI will re-run and pass."
+              echo "::notice::OpenAPI contract drifted; regenerated + committed to the PR branch. CI will re-run and pass."
             else
-              echo "::error::docs/openapi.json is stale and the auto-commit push failed (branch protection or a read-only Actions token). Run: sbt \"currencyL0/runMain xyz.kd5ujc.metagraph_l0.openapi.GenerateOpenApi docs/openapi.json\" and commit it."
+              echo "::error::docs/openapi.{json,yaml} are stale and the auto-commit push failed (branch protection or a read-only Actions token). Run: sbt \"currencyL0/runMain xyz.kd5ujc.metagraph_l0.openapi.GenerateOpenApi docs/openapi.json\" and commit them."
               exit 1
             fi
           else
-            echo "::error::docs/openapi.json is stale. Run: sbt \"currencyL0/runMain xyz.kd5ujc.metagraph_l0.openapi.GenerateOpenApi docs/openapi.json\" and commit it."
+            echo "::error::docs/openapi.{json,yaml} are stale. Run: sbt \"currencyL0/runMain xyz.kd5ujc.metagraph_l0.openapi.GenerateOpenApi docs/openapi.json\" and commit them."
             exit 1
           fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,32 +84,35 @@ jobs:
 
           ls -la release-jars/
 
-      - name: Generate OpenAPI spec
+      - name: Generate OpenAPI specs
         run: |
           VERSION="${{ steps.version.outputs.VERSION }}"
           mkdir -p release-jars
 
-          # Regenerate the tapir contract from the *tagged* source so the attached spec is
-          # guaranteed to match this release's code — not just whatever docs/openapi.{json,yaml} was
-          # last committed. sbt is already warm from `assembly`, so this only runs the compiled
-          # generator (same command the CI drift gate uses). It emits JSON and its YAML sibling.
-          sbt "currencyL0/runMain xyz.kd5ujc.metagraph_l0.openapi.GenerateOpenApi release-jars/openapi-${VERSION}.json"
+          # Regenerate the tapir contracts from the *tagged* source so the attached specs are
+          # guaranteed to match this release's code — not just whatever docs/openapi-*.{json,yaml}
+          # was last committed. sbt is already warm from `assembly`, so this only runs the compiled
+          # generator (same command the CI drift gate uses). One contract PER LAYER (ml0 + dl1),
+          # each as JSON and YAML → release-jars/openapi-{ml0,dl1}.{json,yaml}.
+          sbt "currencyL0/runMain xyz.kd5ujc.metagraph_l0.openapi.GenerateOpenApi release-jars"
 
-          # Stable-named copies for consumers that always want "the spec for this tag".
-          cp "release-jars/openapi-${VERSION}.json" release-jars/openapi.json
-          cp "release-jars/openapi-${VERSION}.yaml" release-jars/openapi.yaml
+          for layer in ml0 dl1; do
+            # Version-stamped copies tie each contract to this release's jars.
+            cp "release-jars/openapi-${layer}.json" "release-jars/openapi-${layer}-${VERSION}.json"
+            cp "release-jars/openapi-${layer}.yaml" "release-jars/openapi-${layer}-${VERSION}.yaml"
 
-          # Sanity: valid JSON carrying a contract version (info.version is the deliberately
-          # decoupled contractVersion, NOT the build version — the filename carries the build tie).
-          CONTRACT=$(jq -r '.info.version' release-jars/openapi.json)
-          echo "✅ OpenAPI spec generated (contract version: ${CONTRACT}) for release v${VERSION} — JSON + YAML"
+            # Sanity: valid JSON carrying a contract version (info.version is the deliberately
+            # decoupled contractVersion, NOT the build version — the filename carries the build tie).
+            CONTRACT=$(jq -r '.info.version' "release-jars/openapi-${layer}.json")
+            echo "✅ ${layer} OpenAPI generated (contract version: ${CONTRACT}) for release v${VERSION} — JSON + YAML"
 
-          # Belt-and-suspenders: the committed contract should already match (the CI drift gate
-          # enforces this on every merge to main). Warn — don't fail the release — if a tag was
-          # somehow cut off-sync.
-          if [ -f docs/openapi.json ] && ! diff -q docs/openapi.json release-jars/openapi.json >/dev/null; then
-            echo "::warning::Regenerated OpenAPI differs from committed docs/openapi.json — the tag may predate a drift-gate sync."
-          fi
+            # Belt-and-suspenders: the committed contract should already match (the CI drift gate
+            # enforces this on every merge to main). Warn — don't fail the release — if a tag was
+            # somehow cut off-sync.
+            if [ -f "docs/openapi-${layer}.json" ] && ! diff -q "docs/openapi-${layer}.json" "release-jars/openapi-${layer}.json" >/dev/null; then
+              echo "::warning::Regenerated openapi-${layer} differs from committed docs/openapi-${layer}.json — the tag may predate a drift-gate sync."
+            fi
+          done
 
       - name: Generate changelog
         run: |
@@ -133,7 +136,8 @@ jobs:
           echo "- \`metagraph-l0-${{ steps.version.outputs.VERSION }}.jar\` - Metagraph L0 layer" >> CHANGELOG.md
           echo "- \`currency-l1-${{ steps.version.outputs.VERSION }}.jar\` - Currency L1 layer" >> CHANGELOG.md
           echo "- \`data-l1-${{ steps.version.outputs.VERSION }}.jar\` - Data L1 layer" >> CHANGELOG.md
-          echo "- \`openapi-${{ steps.version.outputs.VERSION }}.json\` / \`.yaml\` - OpenAPI 3.1 contract (tapir-generated; also attached as \`openapi.json\` / \`openapi.yaml\`)" >> CHANGELOG.md
+          echo "- \`openapi-ml0-${{ steps.version.outputs.VERSION }}.json\` / \`.yaml\` - OpenAPI 3.1 contract for the ML0 layer (also \`openapi-ml0.json\` / \`.yaml\`)" >> CHANGELOG.md
+          echo "- \`openapi-dl1-${{ steps.version.outputs.VERSION }}.json\` / \`.yaml\` - OpenAPI 3.1 contract for the Data-L1 layer (also \`openapi-dl1.json\` / \`.yaml\`)" >> CHANGELOG.md
 
       - name: Create Release and Upload JARs
         uses: softprops/action-gh-release@v3
@@ -143,10 +147,14 @@ jobs:
             release-jars/metagraph-l0-${{ steps.version.outputs.VERSION }}.jar
             release-jars/currency-l1-${{ steps.version.outputs.VERSION }}.jar
             release-jars/data-l1-${{ steps.version.outputs.VERSION }}.jar
-            release-jars/openapi-${{ steps.version.outputs.VERSION }}.json
-            release-jars/openapi-${{ steps.version.outputs.VERSION }}.yaml
-            release-jars/openapi.json
-            release-jars/openapi.yaml
+            release-jars/openapi-ml0-${{ steps.version.outputs.VERSION }}.json
+            release-jars/openapi-ml0-${{ steps.version.outputs.VERSION }}.yaml
+            release-jars/openapi-ml0.json
+            release-jars/openapi-ml0.yaml
+            release-jars/openapi-dl1-${{ steps.version.outputs.VERSION }}.json
+            release-jars/openapi-dl1-${{ steps.version.outputs.VERSION }}.yaml
+            release-jars/openapi-dl1.json
+            release-jars/openapi-dl1.yaml
           body_path: CHANGELOG.md
           prerelease: ${{ contains(steps.version.outputs.VERSION, 'alpha') || contains(steps.version.outputs.VERSION, 'beta') || contains(steps.version.outputs.VERSION, 'rc') }}
           generate_release_notes: false
@@ -170,5 +178,5 @@ jobs:
           echo "- **Version:** v${{ steps.version.outputs.VERSION }}" >> $GITHUB_STEP_SUMMARY
           echo "- **Tag:** ${{ github.ref_name }}" >> $GITHUB_STEP_SUMMARY
           echo "- **JARs:** 3 artifacts uploaded" >> $GITHUB_STEP_SUMMARY
-          echo "- **OpenAPI:** \`openapi-${{ steps.version.outputs.VERSION }}.{json,yaml}\` (+ stable \`openapi.{json,yaml}\`)" >> $GITHUB_STEP_SUMMARY
+          echo "- **OpenAPI:** \`openapi-{ml0,dl1}-${{ steps.version.outputs.VERSION }}.{json,yaml}\` (+ stable \`openapi-{ml0,dl1}.{json,yaml}\`)" >> $GITHUB_STEP_SUMMARY
           echo "- **Deploy notification:** Sent to ottochain-deploy" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,6 +84,33 @@ jobs:
 
           ls -la release-jars/
 
+      - name: Generate OpenAPI spec
+        run: |
+          VERSION="${{ steps.version.outputs.VERSION }}"
+          mkdir -p release-jars
+
+          # Regenerate the tapir contract from the *tagged* source so the attached spec is
+          # guaranteed to match this release's code — not just whatever docs/openapi.{json,yaml} was
+          # last committed. sbt is already warm from `assembly`, so this only runs the compiled
+          # generator (same command the CI drift gate uses). It emits JSON and its YAML sibling.
+          sbt "currencyL0/runMain xyz.kd5ujc.metagraph_l0.openapi.GenerateOpenApi release-jars/openapi-${VERSION}.json"
+
+          # Stable-named copies for consumers that always want "the spec for this tag".
+          cp "release-jars/openapi-${VERSION}.json" release-jars/openapi.json
+          cp "release-jars/openapi-${VERSION}.yaml" release-jars/openapi.yaml
+
+          # Sanity: valid JSON carrying a contract version (info.version is the deliberately
+          # decoupled contractVersion, NOT the build version — the filename carries the build tie).
+          CONTRACT=$(jq -r '.info.version' release-jars/openapi.json)
+          echo "✅ OpenAPI spec generated (contract version: ${CONTRACT}) for release v${VERSION} — JSON + YAML"
+
+          # Belt-and-suspenders: the committed contract should already match (the CI drift gate
+          # enforces this on every merge to main). Warn — don't fail the release — if a tag was
+          # somehow cut off-sync.
+          if [ -f docs/openapi.json ] && ! diff -q docs/openapi.json release-jars/openapi.json >/dev/null; then
+            echo "::warning::Regenerated OpenAPI differs from committed docs/openapi.json — the tag may predate a drift-gate sync."
+          fi
+
       - name: Generate changelog
         run: |
           # Get previous tag for changelog
@@ -106,6 +133,7 @@ jobs:
           echo "- \`metagraph-l0-${{ steps.version.outputs.VERSION }}.jar\` - Metagraph L0 layer" >> CHANGELOG.md
           echo "- \`currency-l1-${{ steps.version.outputs.VERSION }}.jar\` - Currency L1 layer" >> CHANGELOG.md
           echo "- \`data-l1-${{ steps.version.outputs.VERSION }}.jar\` - Data L1 layer" >> CHANGELOG.md
+          echo "- \`openapi-${{ steps.version.outputs.VERSION }}.json\` / \`.yaml\` - OpenAPI 3.1 contract (tapir-generated; also attached as \`openapi.json\` / \`openapi.yaml\`)" >> CHANGELOG.md
 
       - name: Create Release and Upload JARs
         uses: softprops/action-gh-release@v3
@@ -115,6 +143,10 @@ jobs:
             release-jars/metagraph-l0-${{ steps.version.outputs.VERSION }}.jar
             release-jars/currency-l1-${{ steps.version.outputs.VERSION }}.jar
             release-jars/data-l1-${{ steps.version.outputs.VERSION }}.jar
+            release-jars/openapi-${{ steps.version.outputs.VERSION }}.json
+            release-jars/openapi-${{ steps.version.outputs.VERSION }}.yaml
+            release-jars/openapi.json
+            release-jars/openapi.yaml
           body_path: CHANGELOG.md
           prerelease: ${{ contains(steps.version.outputs.VERSION, 'alpha') || contains(steps.version.outputs.VERSION, 'beta') || contains(steps.version.outputs.VERSION, 'rc') }}
           generate_release_notes: false
@@ -138,4 +170,5 @@ jobs:
           echo "- **Version:** v${{ steps.version.outputs.VERSION }}" >> $GITHUB_STEP_SUMMARY
           echo "- **Tag:** ${{ github.ref_name }}" >> $GITHUB_STEP_SUMMARY
           echo "- **JARs:** 3 artifacts uploaded" >> $GITHUB_STEP_SUMMARY
+          echo "- **OpenAPI:** \`openapi-${{ steps.version.outputs.VERSION }}.{json,yaml}\` (+ stable \`openapi.{json,yaml}\`)" >> $GITHUB_STEP_SUMMARY
           echo "- **Deploy notification:** Sent to ottochain-deploy" >> $GITHUB_STEP_SUMMARY

--- a/build.sbt
+++ b/build.sbt
@@ -121,7 +121,8 @@ lazy val currencyL0 = (project in file("modules/l0"))
       Libraries.tapirJsonCirce,
       Libraries.tapirHttp4sServer,
       Libraries.tapirOpenApiDocs,
-      Libraries.sttpOpenApiCirce
+      Libraries.sttpOpenApiCirce,
+      Libraries.sttpOpenApiCirceYaml
     )
   )
 

--- a/docs/openapi-dl1.json
+++ b/docs/openapi-dl1.json
@@ -1,0 +1,216 @@
+{
+  "openapi" : "3.1.0",
+  "info" : {
+    "title" : "OttoChain Data L1 API",
+    "version" : "1.0.0"
+  },
+  "paths" : {
+    "/data-application/v1/version" : {
+      "get" : {
+        "tags" : [
+          "meta",
+          "dl1"
+        ],
+        "summary" : "Service identity + build metadata",
+        "operationId" : "getData-applicationV1Version",
+        "responses" : {
+          "200" : {
+            "description" : "",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/VersionInfo"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/data-application/v1/util/hash" : {
+      "post" : {
+        "tags" : [
+          "meta",
+          "dl1"
+        ],
+        "summary" : "Canonical hash of a signed message",
+        "operationId" : "postData-applicationV1UtilHash",
+        "requestBody" : {
+          "description" : "Signed[OttochainMessage]",
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "HashResult: { \"messageHash\": <hash>, \"message\": <message> }",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Invalid value for: body",
+            "content" : {
+              "text/plain" : {
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/data-application/v1/onchain" : {
+      "get" : {
+        "tags" : [
+          "state",
+          "dl1"
+        ],
+        "summary" : "Current on-chain state",
+        "operationId" : "getData-applicationV1Onchain",
+        "responses" : {
+          "200" : {
+            "description" : "",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OnChain"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components" : {
+    "schemas" : {
+      "AssetCommit" : {
+        "title" : "AssetCommit",
+        "type" : "object",
+        "required" : [
+          "behavior",
+          "sequenceNumber",
+          "recordHash"
+        ],
+        "properties" : {
+          "behavior" : {
+            "type" : "integer",
+            "format" : "int32"
+          },
+          "sequenceNumber" : {
+            "type" : "integer",
+            "format" : "int64"
+          },
+          "recordHash" : {
+            "type" : "string"
+          },
+          "origin" : {
+            "type" : "string"
+          }
+        }
+      },
+      "FiberCommit" : {
+        "title" : "FiberCommit",
+        "type" : "object",
+        "required" : [
+          "recordHash",
+          "sequenceNumber"
+        ],
+        "properties" : {
+          "recordHash" : {
+            "type" : "string"
+          },
+          "stateDataHash" : {
+            "type" : "string"
+          },
+          "sequenceNumber" : {
+            "type" : "integer",
+            "format" : "int64"
+          }
+        }
+      },
+      "Map_V" : {
+        "title" : "Map_V",
+        "type" : "object",
+        "additionalProperties" : {
+          "$ref" : "#/components/schemas/FiberCommit"
+        }
+      },
+      "OnChain" : {
+        "title" : "OnChain",
+        "type" : "object",
+        "required" : [
+          "fiberCommits",
+          "latestLogs",
+          "registryCommits",
+          "assetCommits"
+        ],
+        "properties" : {
+          "fiberCommits" : {
+            "$ref" : "#/components/schemas/Map_V"
+          },
+          "latestLogs" : {
+            "$ref" : "#/components/schemas/Map_V"
+          },
+          "registryCommits" : {
+            "$ref" : "#/components/schemas/Map_V"
+          },
+          "assetCommits" : {
+            "$ref" : "#/components/schemas/Map_V"
+          }
+        }
+      },
+      "VersionInfo" : {
+        "title" : "VersionInfo",
+        "type" : "object",
+        "required" : [
+          "service",
+          "version",
+          "name",
+          "scalaVersion",
+          "sbtVersion",
+          "gitCommit",
+          "buildTime",
+          "tessellationVersion"
+        ],
+        "properties" : {
+          "service" : {
+            "type" : "string"
+          },
+          "version" : {
+            "type" : "string"
+          },
+          "name" : {
+            "type" : "string"
+          },
+          "scalaVersion" : {
+            "type" : "string"
+          },
+          "sbtVersion" : {
+            "type" : "string"
+          },
+          "gitCommit" : {
+            "type" : "string"
+          },
+          "buildTime" : {
+            "type" : "string"
+          },
+          "tessellationVersion" : {
+            "type" : "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/docs/openapi-dl1.yaml
+++ b/docs/openapi-dl1.yaml
@@ -1,0 +1,144 @@
+openapi: 3.1.0
+info:
+  title: OttoChain Data L1 API
+  version: 1.0.0
+paths:
+  /data-application/v1/version:
+    get:
+      tags:
+      - meta
+      - dl1
+      summary: Service identity + build metadata
+      operationId: getData-applicationV1Version
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VersionInfo'
+  /data-application/v1/util/hash:
+    post:
+      tags:
+      - meta
+      - dl1
+      summary: Canonical hash of a signed message
+      operationId: postData-applicationV1UtilHash
+      requestBody:
+        description: Signed[OttochainMessage]
+        content:
+          application/json:
+            schema: {}
+        required: true
+      responses:
+        '200':
+          description: 'HashResult: { "messageHash": <hash>, "message": <message>
+            }'
+          content:
+            application/json:
+              schema: {}
+        '400':
+          description: 'Invalid value for: body'
+          content:
+            text/plain:
+              schema:
+                type: string
+  /data-application/v1/onchain:
+    get:
+      tags:
+      - state
+      - dl1
+      summary: Current on-chain state
+      operationId: getData-applicationV1Onchain
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OnChain'
+components:
+  schemas:
+    AssetCommit:
+      title: AssetCommit
+      type: object
+      required:
+      - behavior
+      - sequenceNumber
+      - recordHash
+      properties:
+        behavior:
+          type: integer
+          format: int32
+        sequenceNumber:
+          type: integer
+          format: int64
+        recordHash:
+          type: string
+        origin:
+          type: string
+    FiberCommit:
+      title: FiberCommit
+      type: object
+      required:
+      - recordHash
+      - sequenceNumber
+      properties:
+        recordHash:
+          type: string
+        stateDataHash:
+          type: string
+        sequenceNumber:
+          type: integer
+          format: int64
+    Map_V:
+      title: Map_V
+      type: object
+      additionalProperties:
+        $ref: '#/components/schemas/FiberCommit'
+    OnChain:
+      title: OnChain
+      type: object
+      required:
+      - fiberCommits
+      - latestLogs
+      - registryCommits
+      - assetCommits
+      properties:
+        fiberCommits:
+          $ref: '#/components/schemas/Map_V'
+        latestLogs:
+          $ref: '#/components/schemas/Map_V'
+        registryCommits:
+          $ref: '#/components/schemas/Map_V'
+        assetCommits:
+          $ref: '#/components/schemas/Map_V'
+    VersionInfo:
+      title: VersionInfo
+      type: object
+      required:
+      - service
+      - version
+      - name
+      - scalaVersion
+      - sbtVersion
+      - gitCommit
+      - buildTime
+      - tessellationVersion
+      properties:
+        service:
+          type: string
+        version:
+          type: string
+        name:
+          type: string
+        scalaVersion:
+          type: string
+        sbtVersion:
+          type: string
+        gitCommit:
+          type: string
+        buildTime:
+          type: string
+        tessellationVersion:
+          type: string

--- a/docs/openapi-ml0.json
+++ b/docs/openapi-ml0.json
@@ -1,14 +1,15 @@
 {
   "openapi" : "3.1.0",
   "info" : {
-    "title" : "OttoChain Metagraph API",
+    "title" : "OttoChain Metagraph L0 API",
     "version" : "1.0.0"
   },
   "paths" : {
     "/data-application/v1/version" : {
       "get" : {
         "tags" : [
-          "meta"
+          "meta",
+          "ml0"
         ],
         "summary" : "Service identity + build metadata",
         "operationId" : "getData-applicationV1Version",
@@ -29,7 +30,8 @@
     "/data-application/v1/util/hash" : {
       "post" : {
         "tags" : [
-          "meta"
+          "meta",
+          "ml0"
         ],
         "summary" : "Canonical hash of a signed message",
         "operationId" : "postData-applicationV1UtilHash",
@@ -71,7 +73,8 @@
     "/data-application/v1/onchain" : {
       "get" : {
         "tags" : [
-          "state"
+          "state",
+          "ml0"
         ],
         "summary" : "Current on-chain state",
         "operationId" : "getData-applicationV1Onchain",
@@ -92,7 +95,8 @@
     "/data-application/v1/checkpoint" : {
       "get" : {
         "tags" : [
-          "state"
+          "state",
+          "ml0"
         ],
         "summary" : "Current checkpoint (calculated state snapshot)",
         "operationId" : "getData-applicationV1Checkpoint",
@@ -113,7 +117,8 @@
     "/data-application/v1/state-machines" : {
       "get" : {
         "tags" : [
-          "state-machines"
+          "state-machines",
+          "ml0"
         ],
         "summary" : "List state machines (optionally filtered by status)",
         "operationId" : "getData-applicationV1State-machines",
@@ -155,7 +160,8 @@
     "/data-application/v1/state-machines/{id}" : {
       "get" : {
         "tags" : [
-          "state-machines"
+          "state-machines",
+          "ml0"
         ],
         "summary" : "Get a state machine by id",
         "operationId" : "getData-applicationV1State-machinesId",
@@ -197,7 +203,8 @@
     "/data-application/v1/state-machines/{id}/events" : {
       "get" : {
         "tags" : [
-          "state-machines"
+          "state-machines",
+          "ml0"
         ],
         "summary" : "Event receipts for a state machine",
         "operationId" : "getData-applicationV1State-machinesIdEvents",
@@ -242,7 +249,8 @@
     "/data-application/v1/state-machines/{id}/audit" : {
       "get" : {
         "tags" : [
-          "state-machines"
+          "state-machines",
+          "ml0"
         ],
         "summary" : "Audit trail for a state machine",
         "operationId" : "getData-applicationV1State-machinesIdAudit",
@@ -284,7 +292,8 @@
     "/data-application/v1/state-machines/{id}/estimate-fee" : {
       "get" : {
         "tags" : [
-          "state-machines"
+          "state-machines",
+          "ml0"
         ],
         "summary" : "Static fee estimate for a transition",
         "operationId" : "getData-applicationV1State-machinesIdEstimate-fee",
@@ -334,7 +343,8 @@
     "/data-application/v1/state-machines/{id}/state-proof" : {
       "get" : {
         "tags" : [
-          "proofs"
+          "proofs",
+          "ml0"
         ],
         "summary" : "Committed-state Merkle proof for a state machine",
         "operationId" : "getData-applicationV1State-machinesIdState-proof",
@@ -385,7 +395,8 @@
     "/data-application/v1/scripts" : {
       "get" : {
         "tags" : [
-          "scripts"
+          "scripts",
+          "ml0"
         ],
         "summary" : "List scripts (optionally filtered by status)",
         "operationId" : "getData-applicationV1Scripts",
@@ -427,7 +438,8 @@
     "/data-application/v1/scripts/{id}" : {
       "get" : {
         "tags" : [
-          "scripts"
+          "scripts",
+          "ml0"
         ],
         "summary" : "Get a script by id",
         "operationId" : "getData-applicationV1ScriptsId",
@@ -469,7 +481,8 @@
     "/data-application/v1/scripts/{id}/invocations" : {
       "get" : {
         "tags" : [
-          "scripts"
+          "scripts",
+          "ml0"
         ],
         "summary" : "Invocation history for a script",
         "operationId" : "getData-applicationV1ScriptsIdInvocations",
@@ -514,7 +527,8 @@
     "/data-application/v1/scripts/{id}/estimate-fee" : {
       "get" : {
         "tags" : [
-          "scripts"
+          "scripts",
+          "ml0"
         ],
         "summary" : "Static fee estimate for a script invocation",
         "operationId" : "getData-applicationV1ScriptsIdEstimate-fee",
@@ -556,7 +570,8 @@
     "/data-application/v1/scripts/{id}/state-proof" : {
       "get" : {
         "tags" : [
-          "proofs"
+          "proofs",
+          "ml0"
         ],
         "summary" : "Committed-state Merkle proof for a script",
         "operationId" : "getData-applicationV1ScriptsIdState-proof",
@@ -607,7 +622,8 @@
     "/data-application/v1/assets/{id}/state-proof" : {
       "get" : {
         "tags" : [
-          "proofs"
+          "proofs",
+          "ml0"
         ],
         "summary" : "Custody (committed-state) Merkle proof for an asset",
         "operationId" : "getData-applicationV1AssetsIdState-proof",
@@ -658,7 +674,8 @@
     "/data-application/v1/registry" : {
       "get" : {
         "tags" : [
-          "registry"
+          "registry",
+          "ml0"
         ],
         "summary" : "All registered package versions",
         "operationId" : "getData-applicationV1Registry",
@@ -679,7 +696,8 @@
     "/data-application/v1/registry/reverse/{id}" : {
       "get" : {
         "tags" : [
-          "registry"
+          "registry",
+          "ml0"
         ],
         "summary" : "Reverse-lookup a registry name by id",
         "operationId" : "getData-applicationV1RegistryReverseId",
@@ -721,7 +739,8 @@
     "/data-application/v1/registry/{name}" : {
       "get" : {
         "tags" : [
-          "registry"
+          "registry",
+          "ml0"
         ],
         "summary" : "Resolve a registry entry by name",
         "operationId" : "getData-applicationV1RegistryName",
@@ -752,7 +771,8 @@
     "/data-application/v1/webhooks/subscribe" : {
       "post" : {
         "tags" : [
-          "webhooks"
+          "webhooks",
+          "ml0"
         ],
         "summary" : "Register a webhook subscriber",
         "operationId" : "postData-applicationV1WebhooksSubscribe",
@@ -793,7 +813,8 @@
     "/data-application/v1/webhooks/subscribe/{id}" : {
       "delete" : {
         "tags" : [
-          "webhooks"
+          "webhooks",
+          "ml0"
         ],
         "summary" : "Unregister a webhook subscriber",
         "operationId" : "deleteData-applicationV1WebhooksSubscribeId",
@@ -817,7 +838,8 @@
     "/data-application/v1/webhooks/subscribers" : {
       "get" : {
         "tags" : [
-          "webhooks"
+          "webhooks",
+          "ml0"
         ],
         "summary" : "List webhook subscribers (secrets redacted)",
         "operationId" : "getData-applicationV1WebhooksSubscribers",

--- a/docs/openapi-ml0.yaml
+++ b/docs/openapi-ml0.yaml
@@ -1,12 +1,13 @@
 openapi: 3.1.0
 info:
-  title: OttoChain Metagraph API
+  title: OttoChain Metagraph L0 API
   version: 1.0.0
 paths:
   /data-application/v1/version:
     get:
       tags:
       - meta
+      - ml0
       summary: Service identity + build metadata
       operationId: getData-applicationV1Version
       responses:
@@ -20,6 +21,7 @@ paths:
     post:
       tags:
       - meta
+      - ml0
       summary: Canonical hash of a signed message
       operationId: postData-applicationV1UtilHash
       requestBody:
@@ -45,6 +47,7 @@ paths:
     get:
       tags:
       - state
+      - ml0
       summary: Current on-chain state
       operationId: getData-applicationV1Onchain
       responses:
@@ -58,6 +61,7 @@ paths:
     get:
       tags:
       - state
+      - ml0
       summary: Current checkpoint (calculated state snapshot)
       operationId: getData-applicationV1Checkpoint
       responses:
@@ -71,6 +75,7 @@ paths:
     get:
       tags:
       - state-machines
+      - ml0
       summary: List state machines (optionally filtered by status)
       operationId: getData-applicationV1State-machines
       parameters:
@@ -97,6 +102,7 @@ paths:
     get:
       tags:
       - state-machines
+      - ml0
       summary: Get a state machine by id
       operationId: getData-applicationV1State-machinesId
       parameters:
@@ -123,6 +129,7 @@ paths:
     get:
       tags:
       - state-machines
+      - ml0
       summary: Event receipts for a state machine
       operationId: getData-applicationV1State-machinesIdEvents
       parameters:
@@ -151,6 +158,7 @@ paths:
     get:
       tags:
       - state-machines
+      - ml0
       summary: Audit trail for a state machine
       operationId: getData-applicationV1State-machinesIdAudit
       parameters:
@@ -176,6 +184,7 @@ paths:
     get:
       tags:
       - state-machines
+      - ml0
       summary: Static fee estimate for a transition
       operationId: getData-applicationV1State-machinesIdEstimate-fee
       parameters:
@@ -208,6 +217,7 @@ paths:
     get:
       tags:
       - proofs
+      - ml0
       summary: Committed-state Merkle proof for a state machine
       operationId: getData-applicationV1State-machinesIdState-proof
       parameters:
@@ -242,6 +252,7 @@ paths:
     get:
       tags:
       - scripts
+      - ml0
       summary: List scripts (optionally filtered by status)
       operationId: getData-applicationV1Scripts
       parameters:
@@ -268,6 +279,7 @@ paths:
     get:
       tags:
       - scripts
+      - ml0
       summary: Get a script by id
       operationId: getData-applicationV1ScriptsId
       parameters:
@@ -294,6 +306,7 @@ paths:
     get:
       tags:
       - scripts
+      - ml0
       summary: Invocation history for a script
       operationId: getData-applicationV1ScriptsIdInvocations
       parameters:
@@ -322,6 +335,7 @@ paths:
     get:
       tags:
       - scripts
+      - ml0
       summary: Static fee estimate for a script invocation
       operationId: getData-applicationV1ScriptsIdEstimate-fee
       parameters:
@@ -348,6 +362,7 @@ paths:
     get:
       tags:
       - proofs
+      - ml0
       summary: Committed-state Merkle proof for a script
       operationId: getData-applicationV1ScriptsIdState-proof
       parameters:
@@ -382,6 +397,7 @@ paths:
     get:
       tags:
       - proofs
+      - ml0
       summary: Custody (committed-state) Merkle proof for an asset
       operationId: getData-applicationV1AssetsIdState-proof
       parameters:
@@ -416,6 +432,7 @@ paths:
     get:
       tags:
       - registry
+      - ml0
       summary: All registered package versions
       operationId: getData-applicationV1Registry
       responses:
@@ -429,6 +446,7 @@ paths:
     get:
       tags:
       - registry
+      - ml0
       summary: Reverse-lookup a registry name by id
       operationId: getData-applicationV1RegistryReverseId
       parameters:
@@ -455,6 +473,7 @@ paths:
     get:
       tags:
       - registry
+      - ml0
       summary: Resolve a registry entry by name
       operationId: getData-applicationV1RegistryName
       parameters:
@@ -474,6 +493,7 @@ paths:
     post:
       tags:
       - webhooks
+      - ml0
       summary: Register a webhook subscriber
       operationId: postData-applicationV1WebhooksSubscribe
       requestBody:
@@ -499,6 +519,7 @@ paths:
     delete:
       tags:
       - webhooks
+      - ml0
       summary: Unregister a webhook subscriber
       operationId: deleteData-applicationV1WebhooksSubscribeId
       parameters:
@@ -514,6 +535,7 @@ paths:
     get:
       tags:
       - webhooks
+      - ml0
       summary: List webhook subscribers (secrets redacted)
       operationId: getData-applicationV1WebhooksSubscribers
       responses:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1,829 +1,1121 @@
-openapi: 3.0.3
+openapi: 3.1.0
 info:
   title: OttoChain Metagraph API
-  description: |
-    API for interacting with OttoChain metagraph on Constellation Network.
-    
-    ## Layers & Ports
-    | Layer | Port | Description |
-    |-------|------|-------------|
-    | GL0   | 9000 | Global L0 — DAG consensus |
-    | GL1   | 9100 | Global L1 — DAG transaction batching |
-    | ML0   | 9200 | Metagraph L0 — OttoChain snapshots |
-    | CL1   | 9300 | Currency L1 — token transactions |
-    | DL1   | 9400 | Data L1 — data transaction validation |
   version: 1.0.0
-  contact:
-    name: OttoChain
-    url: https://github.com/scasplte2/ottochain
-  license:
-    name: MIT
-
-servers:
-  - url: http://localhost:9200
-    description: Local ML0 (Metagraph L0)
-  - url: http://localhost:9400
-    description: Local DL1 (Data L1)
-
-tags:
-  - name: Node
-    description: Node status and health
-  - name: Cluster
-    description: Cluster management
-  - name: Snapshots
-    description: Metagraph snapshots
-  - name: StateMachines
-    description: OttoChain state machines (fibers)
-  - name: Currency
-    description: Token operations
-
 paths:
-  # ===== Node Endpoints =====
-  /node/info:
+  /data-application/v1/version:
     get:
-      tags: [Node]
-      summary: Get node information
-      operationId: getNodeInfo
+      tags:
+      - meta
+      summary: Service identity + build metadata
+      operationId: getData-applicationV1Version
       responses:
         '200':
-          description: Node information
+          description: ''
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/NodeInfo'
-
-  /node/state:
-    get:
-      tags: [Node]
-      summary: Get node state
-      operationId: getNodeState
+                $ref: '#/components/schemas/VersionInfo'
+  /data-application/v1/util/hash:
+    post:
+      tags:
+      - meta
+      summary: Canonical hash of a signed message
+      operationId: postData-applicationV1UtilHash
+      requestBody:
+        description: Signed[OttochainMessage]
+        content:
+          application/json:
+            schema: {}
+        required: true
       responses:
         '200':
-          description: Current node state
+          description: 'HashResult: { "messageHash": <hash>, "message": <message>
+            }'
           content:
             application/json:
-              schema:
-                $ref: '#/components/schemas/NodeState'
-
-  /node/health:
-    get:
-      tags: [Node]
-      summary: Health check
-      operationId: getHealth
-      responses:
-        '200':
-          description: Node is healthy
-        '503':
-          description: Node is unhealthy
-
-  /node/session:
-    get:
-      tags: [Node]
-      summary: Get current session ID
-      operationId: getNodeSession
-      responses:
-        '200':
-          description: Current session
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  session:
-                    type: string
-
-  /metrics:
-    get:
-      tags: [Node]
-      summary: Prometheus metrics
-      operationId: getMetrics
-      responses:
-        '200':
-          description: Prometheus metrics
+              schema: {}
+        '400':
+          description: 'Invalid value for: body'
           content:
             text/plain:
               schema:
                 type: string
-
-  # ===== Cluster Endpoints =====
-  /cluster/info:
+  /data-application/v1/onchain:
     get:
-      tags: [Cluster]
-      summary: Get cluster info
-      operationId: getClusterInfo
+      tags:
+      - state
+      summary: Current on-chain state
+      operationId: getData-applicationV1Onchain
       responses:
         '200':
-          description: Cluster peer list
+          description: ''
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ClusterPeer'
-
-  /cluster/session:
+                $ref: '#/components/schemas/OnChain'
+  /data-application/v1/checkpoint:
     get:
-      tags: [Cluster]
-      summary: Get cluster session
-      operationId: getClusterSession
+      tags:
+      - state
+      summary: Current checkpoint (calculated state snapshot)
+      operationId: getData-applicationV1Checkpoint
       responses:
         '200':
-          description: Current cluster session
+          description: ''
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ClusterSession'
-
-  /cluster/peers:
+                $ref: '#/components/schemas/Checkpoint_CalculatedState'
+  /data-application/v1/state-machines:
     get:
-      tags: [Cluster]
-      summary: Get peer details
-      operationId: getClusterPeers
+      tags:
+      - state-machines
+      summary: List state machines (optionally filtered by status)
+      operationId: getData-applicationV1State-machines
+      parameters:
+      - name: status
+        in: query
+        description: 'Filter by fiber status: ACTIVE | ARCHIVED | FAILED'
+        required: false
+        schema:
+          type: string
       responses:
         '200':
-          description: Detailed peer information
+          description: ''
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ClusterPeer'
-
-  /cluster/join:
-    post:
-      tags: [Cluster]
-      summary: Join cluster
-      operationId: joinCluster
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/JoinRequest'
-      responses:
-        '200':
-          description: Successfully joined
+                $ref: '#/components/schemas/Map_V'
         '400':
-          description: Invalid request
-
-  /cluster/leave:
-    post:
-      tags: [Cluster]
-      summary: Leave cluster
-      operationId: leaveCluster
-      responses:
-        '200':
-          description: Successfully left cluster
-
-  # ===== Snapshot Endpoints (ML0) =====
-  /snapshots/latest:
-    get:
-      tags: [Snapshots]
-      summary: Get latest snapshot
-      operationId: getLatestSnapshot
-      responses:
-        '200':
-          description: Latest metagraph snapshot
+          description: 'Invalid value for: query parameter status'
           content:
-            application/json:
+            text/plain:
               schema:
-                $ref: '#/components/schemas/Snapshot'
-
-  /snapshots/latest/ordinal:
+                type: string
+  /data-application/v1/state-machines/{id}:
     get:
-      tags: [Snapshots]
-      summary: Get latest ordinal
-      operationId: getLatestOrdinal
-      responses:
-        '200':
-          description: Latest snapshot ordinal
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/SnapshotOrdinal'
-
-  /snapshots/{ordinal}:
-    get:
-      tags: [Snapshots]
-      summary: Get snapshot by ordinal
-      operationId: getSnapshotByOrdinal
+      tags:
+      - state-machines
+      summary: Get a state machine by id
+      operationId: getData-applicationV1State-machinesId
       parameters:
-        - name: ordinal
-          in: path
-          required: true
-          schema:
-            type: integer
-            format: int64
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
       responses:
         '200':
-          description: Snapshot at ordinal
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Snapshot'
-        '404':
-          description: Snapshot not found
-
-  /snapshots/latest/metadata:
-    get:
-      tags: [Snapshots]
-      summary: Get latest snapshot metadata
-      operationId: getLatestSnapshotMetadata
-      responses:
-        '200':
-          description: Snapshot metadata
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/SnapshotMetadata'
-
-  /snapshots/latest/combined:
-    get:
-      tags: [Snapshots]
-      summary: Get latest combined snapshot
-      operationId: getLatestCombinedSnapshot
-      responses:
-        '200':
-          description: Combined snapshot with full state
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/CombinedSnapshot'
-
-  /snapshots/{hash}:
-    get:
-      tags: [Snapshots]
-      summary: Get snapshot by hash
-      operationId: getSnapshotByHash
-      parameters:
-        - name: hash
-          in: path
-          required: true
-          schema:
-            $ref: '#/components/schemas/HashValue'
-      responses:
-        '200':
-          description: Snapshot
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Snapshot'
-        '404':
-          description: Snapshot not found
-
-  # ===== OttoChain Custom Endpoints =====
-  /v1/state-machines:
-    get:
-      tags: [StateMachines]
-      summary: List all state machines
-      operationId: listStateMachines
-      responses:
-        '200':
-          description: List of state machine fiber records
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/StateMachineFiberRecord'
-
-  /v1/state-machines/{fiberId}:
-    get:
-      tags: [StateMachines]
-      summary: Get state machine by fiber ID
-      operationId: getStateMachine
-      parameters:
-        - name: fiberId
-          in: path
-          required: true
-          schema:
-            type: string
-      responses:
-        '200':
-          description: State machine fiber record
+          description: ''
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/StateMachineFiberRecord'
-        '404':
-          description: State machine not found
-
-  /v1/checkpoint:
-    get:
-      tags: [StateMachines]
-      summary: Get latest checkpoint
-      operationId: getCheckpoint
-      responses:
-        '200':
-          description: Latest on-chain state checkpoint
+        '400':
+          description: 'Invalid value for: path parameter id'
           content:
-            application/json:
+            text/plain:
               schema:
-                $ref: '#/components/schemas/OnChainState'
-
-  # ===== Currency Endpoints =====
-  /currency/{address}/balance:
+                type: string
+  /data-application/v1/state-machines/{id}/events:
     get:
-      tags: [Currency]
-      summary: Get token balance
-      operationId: getBalance
+      tags:
+      - state-machines
+      summary: Event receipts for a state machine
+      operationId: getData-applicationV1State-machinesIdEvents
       parameters:
-        - name: address
-          in: path
-          required: true
-          schema:
-            $ref: '#/components/schemas/Address'
-      responses:
-        '200':
-          description: Token balance
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Balance'
-
-  /currency/total-supply:
-    get:
-      tags: [Currency]
-      summary: Get total token supply
-      operationId: getTotalSupply
-      responses:
-        '200':
-          description: Total supply
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/TokenSupply'
-
-  /currency/last-reference/{address}:
-    get:
-      tags: [Currency]
-      summary: Get last transaction reference for address
-      operationId: getLastReference
-      parameters:
-        - name: address
-          in: path
-          required: true
-          schema:
-            $ref: '#/components/schemas/Address'
-      responses:
-        '200':
-          description: Last reference
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/TransactionReference'
-
-  # ===== Transaction Endpoints (CL1) =====
-  /transactions:
-    post:
-      tags: [Currency]
-      summary: Submit currency transaction
-      operationId: submitTransaction
-      requestBody:
+      - name: id
+        in: path
         required: true
+        schema:
+          type: string
+          format: uuid
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/EventReceipt'
+        '400':
+          description: 'Invalid value for: path parameter id'
+          content:
+            text/plain:
+              schema:
+                type: string
+  /data-application/v1/state-machines/{id}/audit:
+    get:
+      tags:
+      - state-machines
+      summary: Audit trail for a state machine
+      operationId: getData-applicationV1State-machinesIdAudit
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      responses:
+        '200':
+          description: Rendered audit trail
+          content:
+            application/json:
+              schema: {}
+        '400':
+          description: 'Invalid value for: path parameter id'
+          content:
+            text/plain:
+              schema:
+                type: string
+  /data-application/v1/state-machines/{id}/estimate-fee:
+    get:
+      tags:
+      - state-machines
+      summary: Static fee estimate for a transition
+      operationId: getData-applicationV1State-machinesIdEstimate-fee
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: event
+        in: query
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TransitionFeeEstimate'
+        '400':
+          description: 'Invalid value for: path parameter id, Invalid value for: query
+            parameter event'
+          content:
+            text/plain:
+              schema:
+                type: string
+  /data-application/v1/state-machines/{id}/state-proof:
+    get:
+      tags:
+      - proofs
+      summary: Committed-state Merkle proof for a state machine
+      operationId: getData-applicationV1State-machinesIdState-proof
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: field
+        in: query
+        description: 'Optional: also surface this named `stateData` field of the proven
+          record'
+        required: false
+        schema:
+          type: string
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StateProofResponse'
+        '400':
+          description: 'Invalid value for: path parameter id, Invalid value for: query
+            parameter field'
+          content:
+            text/plain:
+              schema:
+                type: string
+  /data-application/v1/scripts:
+    get:
+      tags:
+      - scripts
+      summary: List scripts (optionally filtered by status)
+      operationId: getData-applicationV1Scripts
+      parameters:
+      - name: status
+        in: query
+        description: 'Filter by fiber status: ACTIVE | ARCHIVED | FAILED'
+        required: false
+        schema:
+          type: string
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Map_V'
+        '400':
+          description: 'Invalid value for: query parameter status'
+          content:
+            text/plain:
+              schema:
+                type: string
+  /data-application/v1/scripts/{id}:
+    get:
+      tags:
+      - scripts
+      summary: Get a script by id
+      operationId: getData-applicationV1ScriptsId
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ScriptFiberRecord'
+        '400':
+          description: 'Invalid value for: path parameter id'
+          content:
+            text/plain:
+              schema:
+                type: string
+  /data-application/v1/scripts/{id}/invocations:
+    get:
+      tags:
+      - scripts
+      summary: Invocation history for a script
+      operationId: getData-applicationV1ScriptsIdInvocations
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ScriptInvocation'
+        '400':
+          description: 'Invalid value for: path parameter id'
+          content:
+            text/plain:
+              schema:
+                type: string
+  /data-application/v1/scripts/{id}/estimate-fee:
+    get:
+      tags:
+      - scripts
+      summary: Static fee estimate for a script invocation
+      operationId: getData-applicationV1ScriptsIdEstimate-fee
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ScriptFeeEstimate'
+        '400':
+          description: 'Invalid value for: path parameter id'
+          content:
+            text/plain:
+              schema:
+                type: string
+  /data-application/v1/scripts/{id}/state-proof:
+    get:
+      tags:
+      - proofs
+      summary: Committed-state Merkle proof for a script
+      operationId: getData-applicationV1ScriptsIdState-proof
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: field
+        in: query
+        description: 'Optional: also surface this named `stateData` field of the proven
+          record'
+        required: false
+        schema:
+          type: string
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StateProofResponse'
+        '400':
+          description: 'Invalid value for: path parameter id, Invalid value for: query
+            parameter field'
+          content:
+            text/plain:
+              schema:
+                type: string
+  /data-application/v1/assets/{id}/state-proof:
+    get:
+      tags:
+      - proofs
+      summary: Custody (committed-state) Merkle proof for an asset
+      operationId: getData-applicationV1AssetsIdState-proof
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: field
+        in: query
+        description: 'Optional: also surface this named `stateData` field of the proven
+          record'
+        required: false
+        schema:
+          type: string
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StateProofResponse'
+        '400':
+          description: 'Invalid value for: path parameter id, Invalid value for: query
+            parameter field'
+          content:
+            text/plain:
+              schema:
+                type: string
+  /data-application/v1/registry:
+    get:
+      tags:
+      - registry
+      summary: All registered package versions
+      operationId: getData-applicationV1Registry
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Map_V'
+  /data-application/v1/registry/reverse/{id}:
+    get:
+      tags:
+      - registry
+      summary: Reverse-lookup a registry name by id
+      operationId: getData-applicationV1RegistryReverseId
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                type: string
+        '400':
+          description: 'Invalid value for: path parameter id'
+          content:
+            text/plain:
+              schema:
+                type: string
+  /data-application/v1/registry/{name}:
+    get:
+      tags:
+      - registry
+      summary: Resolve a registry entry by name
+      operationId: getData-applicationV1RegistryName
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RegistryEntry'
+  /data-application/v1/webhooks/subscribe:
+    post:
+      tags:
+      - webhooks
+      summary: Register a webhook subscriber
+      operationId: postData-applicationV1WebhooksSubscribe
+      requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/SignedTransaction'
-      responses:
-        '200':
-          description: Transaction accepted
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/TransactionResponse'
-        '400':
-          description: Invalid transaction
-
-  /transactions/{hash}:
-    get:
-      tags: [Currency]
-      summary: Get pending transaction by hash
-      operationId: getTransaction
-      parameters:
-        - name: hash
-          in: path
-          required: true
-          schema:
-            $ref: '#/components/schemas/HashValue'
-      responses:
-        '200':
-          description: Transaction details
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/TransactionInfo'
-        '404':
-          description: Transaction not found
-
-  # ===== Data L1 Endpoints =====
-  /data:
-    post:
-      tags: [StateMachines]
-      summary: Submit data transaction
-      operationId: submitDataTransaction
-      requestBody:
+              $ref: '#/components/schemas/SubscribeRequest'
         required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/DataTransaction'
       responses:
         '200':
-          description: Transaction accepted
+          description: 201 Created
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/TransactionResponse'
+                $ref: '#/components/schemas/SubscribeResponse'
         '400':
-          description: Invalid transaction
-
+          description: 'Invalid value for: body'
+          content:
+            text/plain:
+              schema:
+                type: string
+  /data-application/v1/webhooks/subscribe/{id}:
+    delete:
+      tags:
+      - webhooks
+      summary: Unregister a webhook subscriber
+      operationId: deleteData-applicationV1WebhooksSubscribeId
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '204':
+          description: ''
+  /data-application/v1/webhooks/subscribers:
+    get:
+      tags:
+      - webhooks
+      summary: List webhook subscribers (secrets redacted)
+      operationId: getData-applicationV1WebhooksSubscribers
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SubscriberList'
 components:
   schemas:
-    # ===== Common Types (from ottochain.v1.common) =====
-    Address:
-      type: string
-      pattern: '^DAG[0-9A-Za-z]{37}$'
-      description: Constellation DAG address
-      example: "DAG4o41NzhfX6DyYBTTXu6sJa6awm36abJpv89jB"
-
-    HashValue:
-      type: string
-      pattern: '^[a-f0-9]{64}$'
-      description: 256-bit hash value
-      example: "a1b2c3d4e5f6789012345678901234567890123456789012345678901234abcd"
-
-    SnapshotOrdinal:
+    AssetCommit:
+      title: AssetCommit
       type: object
+      required:
+      - behavior
+      - sequenceNumber
+      - recordHash
       properties:
-        value:
+        behavior:
+          type: integer
+          format: int32
+        sequenceNumber:
           type: integer
           format: int64
-      required: [value]
-
-    FiberOrdinal:
+        recordHash:
+          type: string
+        origin:
+          type: string
+    AssetRecord:
+      title: AssetRecord
       type: object
+      required:
+      - assetId
+      - schemaBinding
+      - behavior
+      - holder
+      - amount
+      - sequenceNumber
+      - creationOrdinal
+      - latestUpdateOrdinal
       properties:
-        value:
+        assetId:
+          type: string
+          format: uuid
+        schemaBinding:
+          $ref: '#/components/schemas/SchemaBinding'
+        behavior:
+          $ref: '#/components/schemas/TokenBehavior'
+        holder: {}
+        amount:
           type: integer
           format: int64
-      required: [value]
-
-    StateId:
-      type: object
-      properties:
-        value:
-          type: string
-      required: [value]
-
-    # ===== Node Types =====
-    NodeInfo:
-      type: object
-      properties:
-        state:
-          $ref: '#/components/schemas/NodeState'
-        version:
-          type: string
-        host:
-          type: string
-        publicPort:
+        sequenceNumber:
           type: integer
-        p2pPort:
+          format: int64
+        creationOrdinal:
           type: integer
-        id:
-          type: string
-          description: Node peer ID
-        session:
-          type: string
-
-    NodeState:
-      type: string
-      enum:
-        - Initial
-        - ReadyToJoin
-        - LoadingGenesis
-        - GenesisReady
-        - RollbackInProgress
-        - RollbackDone
-        - StartingSession
-        - SessionStarted
-        - WaitingForDownload
-        - DownloadInProgress
-        - Observing
-        - WaitingForObserving
-        - WaitingForReady
-        - Ready
-        - Leaving
-        - Offline
-
-    # ===== Cluster Types =====
-    ClusterPeer:
-      type: object
-      properties:
-        id:
-          type: string
-        ip:
-          type: string
-        publicPort:
+          format: int64
+        latestUpdateOrdinal:
           type: integer
-        p2pPort:
+          format: int64
+        expiresAt:
           type: integer
-        session:
-          type: string
-        state:
-          $ref: '#/components/schemas/NodeState'
-
-    ClusterSession:
-      type: object
-      properties:
-        token:
-          type: string
-
-    JoinRequest:
-      type: object
-      properties:
-        id:
-          type: string
-          description: Peer ID to join
-        ip:
-          type: string
-        p2pPort:
-          type: integer
-      required: [id, ip, p2pPort]
-
-    # ===== Snapshot Types =====
-    Snapshot:
-      type: object
-      properties:
-        ordinal:
-          $ref: '#/components/schemas/SnapshotOrdinal'
-        hash:
-          $ref: '#/components/schemas/HashValue'
-        lastSnapshotHash:
-          $ref: '#/components/schemas/HashValue'
-        timestamp:
-          type: string
-          format: date-time
-        blocks:
+          format: int64
+        componentFiberIds:
           type: array
           items:
-            type: object
-        tips:
-          type: object
-
-    SnapshotMetadata:
+            type: string
+            format: uuid
+        componentsCommitment:
+          type: string
+        parentCompositeId:
+          type: string
+          format: uuid
+        provenance:
+          $ref: '#/components/schemas/OriginProvenance'
+    CalculatedState:
+      title: CalculatedState
       type: object
+      required:
+      - stateMachines
+      - scripts
+      - registry
+      - reverseNames
+      - assets
+      - usedNonces
+      properties:
+        stateMachines:
+          $ref: '#/components/schemas/Map_V'
+        scripts:
+          $ref: '#/components/schemas/Map_V'
+        registry:
+          $ref: '#/components/schemas/Map_V'
+        reverseNames:
+          $ref: '#/components/schemas/Map_V'
+        assets:
+          $ref: '#/components/schemas/Map_V'
+        usedNonces:
+          $ref: '#/components/schemas/Map_V'
+    Checkpoint_CalculatedState:
+      title: Checkpoint_CalculatedState
+      type: object
+      required:
+      - ordinal
+      - state
       properties:
         ordinal:
-          $ref: '#/components/schemas/SnapshotOrdinal'
-        hash:
-          $ref: '#/components/schemas/HashValue'
-        timestamp:
-          type: string
-          format: date-time
-        size:
           type: integer
-
-    CombinedSnapshot:
-      type: object
-      properties:
-        snapshot:
-          $ref: '#/components/schemas/Snapshot'
+          format: int64
         state:
-          type: object
-          description: Full calculated state
-
-    # ===== OttoChain State Machine Types (from ottochain.v1.records) =====
-    StateMachineFiberRecord:
+          $ref: '#/components/schemas/CalculatedState'
+    DynamicDependency:
+      title: DynamicDependency
       type: object
-      description: On-chain state machine fiber record
+      required:
+      - fiberId
+      - active
+      - addedAt
       properties:
         fiberId:
           type: string
-          description: Unique fiber identifier
-        creationOrdinal:
-          $ref: '#/components/schemas/SnapshotOrdinal'
-        previousUpdateOrdinal:
-          $ref: '#/components/schemas/SnapshotOrdinal'
-        latestUpdateOrdinal:
-          $ref: '#/components/schemas/SnapshotOrdinal'
-        definition:
-          $ref: '#/components/schemas/StateMachineDefinition'
-        currentState:
-          $ref: '#/components/schemas/StateId'
-        stateData:
-          type: object
-          description: Current state data (JSON)
-        stateDataHash:
-          $ref: '#/components/schemas/HashValue'
+          format: uuid
+        active:
+          type: boolean
+        addedAt:
+          type: integer
+          format: int64
+    EmittedEvent:
+      title: EmittedEvent
+      type: object
+      required:
+      - name
+      - data
+      - emitterFiberId
+      - emissionIndex
+      properties:
+        name:
+          type: string
+        data: {}
+        destination:
+          type: string
+        emitterFiberId:
+          type: string
+          format: uuid
+        emissionIndex:
+          type: integer
+          format: int32
+    EventReceipt:
+      title: EventReceipt
+      type: object
+      required:
+      - fiberId
+      - sequenceNumber
+      - eventName
+      - ordinal
+      - fromState
+      - toState
+      - success
+      - gasUsed
+      - triggersFired
+      properties:
+        fiberId:
+          type: string
+          format: uuid
         sequenceNumber:
-          $ref: '#/components/schemas/FiberOrdinal'
-        owners:
+          type: integer
+          format: int64
+        eventName:
+          type: string
+        ordinal:
+          type: integer
+          format: int64
+        fromState:
+          type: string
+        toState:
+          type: string
+        success:
+          type: boolean
+        gasUsed:
+          type: integer
+          format: int64
+        triggersFired:
+          type: integer
+          format: int32
+        errorMessage:
+          type: string
+        sourceFiberId:
+          type: string
+          format: uuid
+        emittedEvents:
           type: array
           items:
-            $ref: '#/components/schemas/Address'
+            $ref: '#/components/schemas/EmittedEvent'
+    FiberCommit:
+      title: FiberCommit
+      type: object
+      required:
+      - recordHash
+      - sequenceNumber
+      properties:
+        recordHash:
+          type: string
+        stateDataHash:
+          type: string
+        sequenceNumber:
+          type: integer
+          format: int64
+    Map_V:
+      title: Map_V
+      type: object
+      additionalProperties:
+        $ref: '#/components/schemas/FiberCommit'
+    OnChain:
+      title: OnChain
+      type: object
+      required:
+      - fiberCommits
+      - latestLogs
+      - registryCommits
+      - assetCommits
+      properties:
+        fiberCommits:
+          $ref: '#/components/schemas/Map_V'
+        latestLogs:
+          $ref: '#/components/schemas/Map_V'
+        registryCommits:
+          $ref: '#/components/schemas/Map_V'
+        assetCommits:
+          $ref: '#/components/schemas/Map_V'
+    OriginProvenance:
+      title: OriginProvenance
+      type: object
+      required:
+      - originChainId
+      - originAssetRef
+      - attestationHash
+      properties:
+        originChainId:
+          type: string
+        originAssetRef:
+          type: string
+        fullPath:
+          type: array
+          items:
+            type: string
+        attestationHash:
+          type: string
+    RegistryEntry:
+      title: RegistryEntry
+      type: object
+      required:
+      - name
+      - target
+      - metadata
+      properties:
+        name:
+          type: string
+        owner:
+          type: array
+          uniqueItems: true
+          items:
+            type: string
+        target: {}
+        metadata:
+          $ref: '#/components/schemas/Map_V'
+    SchemaBinding:
+      title: SchemaBinding
+      type: object
+      required:
+      - name
+      - version
+      - schemaHash
+      - logicHash
+      properties:
+        name:
+          type: string
+        version:
+          type: string
+        schemaHash:
+          type: string
+        logicHash:
+          type: string
+    ScriptFeeEstimate:
+      title: ScriptFeeEstimate
+      type: object
+      required:
+      - scriptId
+      - gasEstimate
+      - opCount
+      - maxDepth
+      - note
+      properties:
+        scriptId:
+          type: string
+          format: uuid
+        gasEstimate:
+          type: integer
+          format: int64
+        opCount:
+          type: integer
+          format: int32
+        maxDepth:
+          type: integer
+          format: int32
+        note:
+          type: string
+    ScriptFiberRecord:
+      title: ScriptFiberRecord
+      type: object
+      required:
+      - fiberId
+      - creationOrdinal
+      - latestUpdateOrdinal
+      - scriptProgram
+      - accessControl
+      - sequenceNumber
+      - status
+      properties:
+        fiberId:
+          type: string
+          format: uuid
+        creationOrdinal:
+          type: integer
+          format: int64
+        latestUpdateOrdinal:
+          type: integer
+          format: int64
+        scriptProgram: {}
+        stateData: {}
+        stateDataHash:
+          type: string
+        accessControl: {}
+        sequenceNumber:
+          type: integer
+          format: int64
+        owners:
+          type: array
+          uniqueItems: true
+          items:
+            type: string
         status:
-          $ref: '#/components/schemas/FiberStatus'
+          type: string
+        lastInvocation:
+          $ref: '#/components/schemas/ScriptInvocation'
+        schemaBinding:
+          $ref: '#/components/schemas/SchemaBinding'
+    ScriptInvocation:
+      title: ScriptInvocation
+      type: object
+      required:
+      - fiberId
+      - method
+      - args
+      - result
+      - gasUsed
+      - invokedAt
+      - invokedBy
+      properties:
+        fiberId:
+          type: string
+          format: uuid
+        method:
+          type: string
+        args: {}
+        result: {}
+        gasUsed:
+          type: integer
+          format: int64
+        invokedAt:
+          type: integer
+          format: int64
+        invokedBy:
+          type: string
+    StateMachineFiberRecord:
+      title: StateMachineFiberRecord
+      type: object
+      required:
+      - fiberId
+      - creationOrdinal
+      - previousUpdateOrdinal
+      - latestUpdateOrdinal
+      - definition
+      - currentState
+      - stateData
+      - stateDataHash
+      - sequenceNumber
+      - status
+      properties:
+        fiberId:
+          type: string
+          format: uuid
+        creationOrdinal:
+          type: integer
+          format: int64
+        previousUpdateOrdinal:
+          type: integer
+          format: int64
+        latestUpdateOrdinal:
+          type: integer
+          format: int64
+        definition: {}
+        currentState:
+          type: string
+        stateData: {}
+        stateDataHash:
+          type: string
+        sequenceNumber:
+          type: integer
+          format: int64
+        owners:
+          type: array
+          uniqueItems: true
+          items:
+            type: string
+        status:
+          type: string
         lastReceipt:
           $ref: '#/components/schemas/EventReceipt'
         parentFiberId:
           type: string
+          format: uuid
         childFiberIds:
           type: array
+          uniqueItems: true
           items:
             type: string
-
-    StateMachineDefinition:
-      type: object
-      description: State machine definition (from ottochain.v1.fiber)
-      properties:
-        states:
-          type: object
-          additionalProperties:
-            $ref: '#/components/schemas/StateDefinition'
-        initialState:
-          $ref: '#/components/schemas/StateId'
-        version:
-          type: string
-
-    StateDefinition:
-      type: object
-      properties:
-        transitions:
+            format: uuid
+        schemaBinding:
+          $ref: '#/components/schemas/SchemaBinding'
+        authorizedSigners:
+          type: array
+          uniqueItems: true
+          items:
+            type: string
+        dynamicDependencies:
           type: array
           items:
-            $ref: '#/components/schemas/TransitionDefinition'
-        onEnter:
-          type: object
-        onExit:
-          type: object
-
-    TransitionDefinition:
+            $ref: '#/components/schemas/DynamicDependency'
+    StateProofResponse:
+      title: StateProofResponse
       type: object
+      required:
+      - key
+      - ordinal
+      - committedRoot
+      - mptRoot
+      - record
+      - proof
       properties:
-        event:
+        key:
           type: string
-        target:
-          $ref: '#/components/schemas/StateId'
-        guard:
-          type: object
-          description: JSON Logic guard condition
-        actions:
-          type: array
-          items:
-            type: object
-
-    FiberStatus:
-      type: string
-      enum:
-        - FIBER_STATUS_UNSPECIFIED
-        - ACTIVE
-        - COMPLETED
-        - SUSPENDED
-        - DEACTIVATED
-        - MIGRATING
-        - PENDING_VERIFICATION
-      description: Current fiber status
-
-    EventReceipt:
-      type: object
-      properties:
-        eventHash:
-          $ref: '#/components/schemas/HashValue'
-        success:
-          type: boolean
-        resultData:
-          type: object
-        errorMessage:
-          type: string
-
-    OnChainState:
-      type: object
-      description: Complete on-chain state checkpoint
-      properties:
-        fiberCommits:
-          type: object
-          additionalProperties:
-            $ref: '#/components/schemas/FiberCommit'
-        latestLogs:
-          type: object
-          additionalProperties:
-            type: array
-            items:
-              $ref: '#/components/schemas/FiberLogEntry'
-
-    FiberCommit:
-      type: object
-      properties:
-        recordHash:
-          $ref: '#/components/schemas/HashValue'
-        stateDataHash:
-          $ref: '#/components/schemas/HashValue'
-        sequenceNumber:
-          $ref: '#/components/schemas/FiberOrdinal'
-
-    FiberLogEntry:
-      type: object
-      properties:
-        ordinal:
-          $ref: '#/components/schemas/FiberOrdinal'
-        eventType:
-          type: string
-        data:
-          type: object
-        timestamp:
-          type: string
-          format: date-time
-
-    # ===== Currency Types =====
-    Balance:
-      type: object
-      properties:
-        balance:
-          type: integer
-          format: int64
-        ordinal:
-          $ref: '#/components/schemas/SnapshotOrdinal'
-
-    TokenSupply:
-      type: object
-      properties:
-        total:
-          type: integer
-          format: int64
-
-    TransactionReference:
-      type: object
-      properties:
         ordinal:
           type: integer
           format: int64
-        hash:
-          $ref: '#/components/schemas/HashValue'
-
-    SignedTransaction:
-      type: object
-      properties:
-        value:
-          $ref: '#/components/schemas/Transaction'
-        proofs:
-          type: array
-          items:
-            $ref: '#/components/schemas/Proof'
-      required: [value, proofs]
-
-    Transaction:
-      type: object
-      properties:
-        source:
-          $ref: '#/components/schemas/Address'
-        destination:
-          $ref: '#/components/schemas/Address'
-        amount:
-          type: integer
-          format: int64
-        fee:
-          type: integer
-          format: int64
-        parent:
-          $ref: '#/components/schemas/TransactionReference'
-        salt:
-          type: integer
-          format: int64
-
-    TransactionInfo:
-      type: object
-      properties:
-        transaction:
-          $ref: '#/components/schemas/SignedTransaction'
-        hash:
-          $ref: '#/components/schemas/HashValue'
-        status:
+        committedRoot: {}
+        mptRoot: {}
+        record: {}
+        proof: {}
+        field:
           type: string
-          enum: [Pending, Accepted, Rejected]
-
-    # ===== Transaction Types =====
-    DataTransaction:
+        fieldValue: {}
+    SubscribeRequest:
+      title: SubscribeRequest
       type: object
+      required:
+      - callbackUrl
       properties:
-        value:
-          type: object
-          description: Transaction payload
-        proofs:
-          type: array
-          items:
-            $ref: '#/components/schemas/Proof'
-
-    Proof:
+        callbackUrl:
+          type: string
+        secret:
+          type: string
+    SubscribeResponse:
+      title: SubscribeResponse
       type: object
+      required:
+      - id
+      - callbackUrl
+      - createdAt
       properties:
         id:
           type: string
-        signature:
+        callbackUrl:
           type: string
-
-    TransactionResponse:
+        createdAt:
+          type: string
+          format: date-time
+    Subscriber:
+      title: Subscriber
+      type: object
+      required:
+      - id
+      - callbackUrl
+      - active
+      - createdAt
+      - failCount
+      properties:
+        id:
+          type: string
+        callbackUrl:
+          type: string
+        secret:
+          type: string
+        active:
+          type: boolean
+        createdAt:
+          type: string
+          format: date-time
+        lastDeliveryAt:
+          type: string
+          format: date-time
+        failCount:
+          type: integer
+          format: int32
+    SubscriberList:
+      title: SubscriberList
       type: object
       properties:
-        hash:
-          $ref: '#/components/schemas/HashValue'
+        subscribers:
+          type: array
+          items:
+            $ref: '#/components/schemas/Subscriber'
+    TokenBehavior:
+      title: TokenBehavior
+      type: object
+      required:
+      - transferable
+      - splittable
+      - combinable
+      - expirable
+      - governable
+      properties:
+        transferable:
+          type: boolean
+        splittable:
+          type: boolean
+        combinable:
+          type: boolean
+        expirable:
+          type: boolean
+        governable:
+          type: boolean
+    TransitionFeeEstimate:
+      title: TransitionFeeEstimate
+      type: object
+      required:
+      - fiberId
+      - currentState
+      - event
+      - gasEstimate
+      - opCount
+      - maxDepth
+      - candidateTransitions
+      - note
+      properties:
+        fiberId:
+          type: string
+          format: uuid
+        currentState:
+          type: string
+        event:
+          type: string
+        gasEstimate:
+          type: integer
+          format: int64
+        opCount:
+          type: integer
+          format: int32
+        maxDepth:
+          type: integer
+          format: int32
+        candidateTransitions:
+          type: integer
+          format: int32
+        note:
+          type: string
+    VersionInfo:
+      title: VersionInfo
+      type: object
+      required:
+      - service
+      - version
+      - name
+      - scalaVersion
+      - sbtVersion
+      - gitCommit
+      - buildTime
+      - tessellationVersion
+      properties:
+        service:
+          type: string
+        version:
+          type: string
+        name:
+          type: string
+        scalaVersion:
+          type: string
+        sbtVersion:
+          type: string
+        gitCommit:
+          type: string
+        buildTime:
+          type: string
+        tessellationVersion:
+          type: string

--- a/modules/l0/src/main/scala/xyz/kd5ujc/metagraph_l0/openapi/ApiEndpoints.scala
+++ b/modules/l0/src/main/scala/xyz/kd5ujc/metagraph_l0/openapi/ApiEndpoints.scala
@@ -255,9 +255,13 @@ object ApiEndpoints {
     webhookSubscribers
   )
 
-  /** The tapir-derived OpenAPI document — the one source both renderings share. */
+  /**
+   * The tapir-derived OpenAPI document — the one source both renderings share. Every endpoint is tagged
+   *  `ml0` so this single-layer contract is self-identifying (the DL1 surface is a separate document,
+   *  [[DataL1ApiEndpoints]]).
+   */
   private def openApiDoc: OpenAPI =
-    OpenAPIDocsInterpreter().toOpenAPI(all, "OttoChain Metagraph API", contractVersion)
+    OpenAPIDocsInterpreter().toOpenAPI(all.map(_.tag("ml0")), "OttoChain Metagraph L0 API", contractVersion)
 
   def openApiJson: String =
     openApiDoc.asJson.deepDropNullValues.spaces2

--- a/modules/l0/src/main/scala/xyz/kd5ujc/metagraph_l0/openapi/ApiEndpoints.scala
+++ b/modules/l0/src/main/scala/xyz/kd5ujc/metagraph_l0/openapi/ApiEndpoints.scala
@@ -15,7 +15,9 @@ import xyz.kd5ujc.schema.{CalculatedState, OnChain, Records}
 
 import io.circe.Json
 import io.circe.syntax._
+import sttp.apispec.openapi.OpenAPI
 import sttp.apispec.openapi.circe._
+import sttp.apispec.openapi.circe.yaml._
 import sttp.model.StatusCode
 import sttp.tapir._
 import sttp.tapir.docs.openapi.OpenAPIDocsInterpreter
@@ -253,10 +255,14 @@ object ApiEndpoints {
     webhookSubscribers
   )
 
+  /** The tapir-derived OpenAPI document — the one source both renderings share. */
+  private def openApiDoc: OpenAPI =
+    OpenAPIDocsInterpreter().toOpenAPI(all, "OttoChain Metagraph API", contractVersion)
+
   def openApiJson: String =
-    OpenAPIDocsInterpreter()
-      .toOpenAPI(all, "OttoChain Metagraph API", contractVersion)
-      .asJson
-      .deepDropNullValues
-      .spaces2
+    openApiDoc.asJson.deepDropNullValues.spaces2
+
+  /** Same document as [[openApiJson]], rendered as YAML (nulls dropped by `toYaml`). */
+  def openApiYaml: String =
+    openApiDoc.toYaml
 }

--- a/modules/l0/src/main/scala/xyz/kd5ujc/metagraph_l0/openapi/DataL1ApiEndpoints.scala
+++ b/modules/l0/src/main/scala/xyz/kd5ujc/metagraph_l0/openapi/DataL1ApiEndpoints.scala
@@ -1,0 +1,72 @@
+package xyz.kd5ujc.metagraph_l0.openapi
+
+import xyz.kd5ujc.metagraph_l0.openapi.DomainSchemas._
+import xyz.kd5ujc.schema.OnChain
+import xyz.kd5ujc.schema.api.VersionInfo
+
+import io.circe.Json
+import io.circe.syntax._
+import sttp.apispec.openapi.OpenAPI
+import sttp.apispec.openapi.circe._
+import sttp.apispec.openapi.circe.yaml._
+import sttp.tapir._
+import sttp.tapir.docs.openapi.OpenAPIDocsInterpreter
+import sttp.tapir.generic.auto._
+import sttp.tapir.json.circe._
+
+/**
+ * The DL1 (Data L1) custom HTTP surface, mirroring [[xyz.kd5ujc.data_l1.DataL1CustomRoutes]]. DL1 serves a
+ * small monitoring/echo subset at the same `/data-application/v1/...` mount as ML0, but on the DL1 port and
+ * with `service: "ottochain-dl1"`.
+ *
+ * WHY A SEPARATE DOCUMENT: OpenAPI keys operations by (path, method), so the ML0 and DL1 copies of
+ * `/data-application/v1/{version,util/hash,onchain}` cannot coexist in one document — they would collide.
+ * Each layer therefore gets its own contract (`openapi-ml0.*` / `openapi-dl1.*`), differentiated by the
+ * `ml0`/`dl1` tag and the filename (no `servers` block — consumers supply the base URL/port).
+ *
+ * The framework's update-submission endpoint on DL1 is intentionally OUT OF SCOPE here (documented
+ * elsewhere); this contract covers only the app's own custom routes.
+ */
+object DataL1ApiEndpoints {
+
+  /** Opaque JSON body, documented — for the handful of bodies intentionally left untyped. */
+  private def opaqueJson(desc: String): EndpointIO.Body[String, Json] =
+    jsonBody[Json].description(desc)
+
+  val version: PublicEndpoint[Unit, Unit, VersionInfo, Any] =
+    endpoint.get
+      .in("data-application" / "v1" / "version")
+      .out(jsonBody[VersionInfo])
+      .summary("Service identity + build metadata")
+      .tag("meta")
+
+  val utilHash: PublicEndpoint[Json, Unit, Json, Any] =
+    endpoint.post
+      .in("data-application" / "v1" / "util" / "hash")
+      .in(opaqueJson("Signed[OttochainMessage]"))
+      .out(opaqueJson("""HashResult: { "messageHash": <hash>, "message": <message> }"""))
+      .summary("Canonical hash of a signed message")
+      .tag("meta")
+
+  val onchain: PublicEndpoint[Unit, Unit, OnChain, Any] =
+    endpoint.get
+      .in("data-application" / "v1" / "onchain")
+      .out(jsonBody[OnChain])
+      .summary("Current on-chain state")
+      .tag("state")
+
+  /** Deterministic ON PURPOSE — see [[ApiEndpoints.contractVersion]]. */
+  val contractVersion = "1.0.0"
+
+  /** Every DL1 custom endpoint, in route order. */
+  val all: List[AnyEndpoint] = List(version, utilHash, onchain)
+
+  private def openApiDoc: OpenAPI =
+    OpenAPIDocsInterpreter().toOpenAPI(all.map(_.tag("dl1")), "OttoChain Data L1 API", contractVersion)
+
+  def openApiJson: String =
+    openApiDoc.asJson.deepDropNullValues.spaces2
+
+  def openApiYaml: String =
+    openApiDoc.toYaml
+}

--- a/modules/l0/src/main/scala/xyz/kd5ujc/metagraph_l0/openapi/GenerateOpenApi.scala
+++ b/modules/l0/src/main/scala/xyz/kd5ujc/metagraph_l0/openapi/GenerateOpenApi.scala
@@ -4,29 +4,34 @@ import java.nio.charset.StandardCharsets
 import java.nio.file.{Files, Path, Paths}
 
 /**
- * Writes the OpenAPI document to disk so it can be committed as a build artifact and consumed by the SDK
- * codegen (Phase 3). The JSON goes to `outPath` (default `docs/openapi.json`) and a YAML rendering of the
- * same document is written alongside it (the `.json` extension swapped for `.yaml`, or `.yaml` appended).
+ * Writes the OpenAPI contracts to disk so they can be committed as build artifacts and consumed by the SDK
+ * codegen. One document PER LAYER — OpenAPI keys by (path, method), so the ML0 and DL1 surfaces (which share
+ * `/data-application/v1/...` paths) cannot live in one document. For each layer we emit both JSON and YAML:
  *
- * Run: `sbt "currencyL0/runMain xyz.kd5ujc.metagraph_l0.openapi.GenerateOpenApi [outPath]"`
+ *   <outDir>/openapi-ml0.json  <outDir>/openapi-ml0.yaml   ([[ApiEndpoints]])
+ *   <outDir>/openapi-dl1.json  <outDir>/openapi-dl1.yaml   ([[DataL1ApiEndpoints]])
+ *
+ * `outDir` defaults to `docs`. Run:
+ * `sbt "currencyL0/runMain xyz.kd5ujc.metagraph_l0.openapi.GenerateOpenApi [outDir]"`
  */
 object GenerateOpenApi {
 
-  /** `foo/openapi.json` -> `foo/openapi.yaml`; anything else gets `.yaml` appended. */
-  private def yamlSibling(json: Path): Path = {
-    val name = json.getFileName.toString
-    val yamlName = if (name.endsWith(".json")) name.dropRight(".json".length) + ".yaml" else name + ".yaml"
-    Option(json.getParent).map(_.resolve(yamlName)).getOrElse(Paths.get(yamlName))
-  }
+  final private case class Spec(baseName: String, endpoints: Int, json: String, yaml: String)
+
+  private def specs: List[Spec] = List(
+    Spec("openapi-ml0", ApiEndpoints.all.size, ApiEndpoints.openApiJson, ApiEndpoints.openApiYaml),
+    Spec("openapi-dl1", DataL1ApiEndpoints.all.size, DataL1ApiEndpoints.openApiJson, DataL1ApiEndpoints.openApiYaml)
+  )
 
   def main(args: Array[String]): Unit = {
-    val jsonOut = Paths.get(if (args.nonEmpty) args(0) else "docs/openapi.json")
-    val yamlOut = yamlSibling(jsonOut)
-    Option(jsonOut.getParent).foreach(Files.createDirectories(_))
-    Files.write(jsonOut, ApiEndpoints.openApiJson.getBytes(StandardCharsets.UTF_8))
-    Files.write(yamlOut, ApiEndpoints.openApiYaml.getBytes(StandardCharsets.UTF_8))
-    println(
-      s"Wrote OpenAPI (${ApiEndpoints.all.size} endpoints) to ${jsonOut.toAbsolutePath} and ${yamlOut.toAbsolutePath}"
-    )
+    val dir: Path = Paths.get(if (args.nonEmpty) args(0) else "docs")
+    Files.createDirectories(dir)
+    specs.foreach { s =>
+      val jsonOut = dir.resolve(s.baseName + ".json")
+      val yamlOut = dir.resolve(s.baseName + ".yaml")
+      Files.write(jsonOut, s.json.getBytes(StandardCharsets.UTF_8))
+      Files.write(yamlOut, s.yaml.getBytes(StandardCharsets.UTF_8))
+      println(s"Wrote ${s.baseName} (${s.endpoints} endpoints, json+yaml) to ${dir.toAbsolutePath}")
+    }
   }
 }

--- a/modules/l0/src/main/scala/xyz/kd5ujc/metagraph_l0/openapi/GenerateOpenApi.scala
+++ b/modules/l0/src/main/scala/xyz/kd5ujc/metagraph_l0/openapi/GenerateOpenApi.scala
@@ -1,20 +1,32 @@
 package xyz.kd5ujc.metagraph_l0.openapi
 
 import java.nio.charset.StandardCharsets
-import java.nio.file.{Files, Paths}
+import java.nio.file.{Files, Path, Paths}
 
 /**
  * Writes the OpenAPI document to disk so it can be committed as a build artifact and consumed by the SDK
- * codegen (Phase 3). Default target `docs/openapi.json`.
+ * codegen (Phase 3). The JSON goes to `outPath` (default `docs/openapi.json`) and a YAML rendering of the
+ * same document is written alongside it (the `.json` extension swapped for `.yaml`, or `.yaml` appended).
  *
  * Run: `sbt "currencyL0/runMain xyz.kd5ujc.metagraph_l0.openapi.GenerateOpenApi [outPath]"`
  */
 object GenerateOpenApi {
 
+  /** `foo/openapi.json` -> `foo/openapi.yaml`; anything else gets `.yaml` appended. */
+  private def yamlSibling(json: Path): Path = {
+    val name = json.getFileName.toString
+    val yamlName = if (name.endsWith(".json")) name.dropRight(".json".length) + ".yaml" else name + ".yaml"
+    Option(json.getParent).map(_.resolve(yamlName)).getOrElse(Paths.get(yamlName))
+  }
+
   def main(args: Array[String]): Unit = {
-    val out = Paths.get(if (args.nonEmpty) args(0) else "docs/openapi.json")
-    Option(out.getParent).foreach(Files.createDirectories(_))
-    Files.write(out, ApiEndpoints.openApiJson.getBytes(StandardCharsets.UTF_8))
-    println(s"Wrote OpenAPI (${ApiEndpoints.all.size} endpoints) to ${out.toAbsolutePath}")
+    val jsonOut = Paths.get(if (args.nonEmpty) args(0) else "docs/openapi.json")
+    val yamlOut = yamlSibling(jsonOut)
+    Option(jsonOut.getParent).foreach(Files.createDirectories(_))
+    Files.write(jsonOut, ApiEndpoints.openApiJson.getBytes(StandardCharsets.UTF_8))
+    Files.write(yamlOut, ApiEndpoints.openApiYaml.getBytes(StandardCharsets.UTF_8))
+    println(
+      s"Wrote OpenAPI (${ApiEndpoints.all.size} endpoints) to ${jsonOut.toAbsolutePath} and ${yamlOut.toAbsolutePath}"
+    )
   }
 }

--- a/modules/l0/src/test/scala/xyz/kd5ujc/metagraph_l0/openapi/OpenApiDocSuite.scala
+++ b/modules/l0/src/test/scala/xyz/kd5ujc/metagraph_l0/openapi/OpenApiDocSuite.scala
@@ -10,9 +10,18 @@ import weaver.SimpleIOSuite
 object OpenApiDocSuite extends SimpleIOSuite {
 
   private val doc = ApiEndpoints.openApiJson
+  private val yaml = ApiEndpoints.openApiYaml
 
   pureTest("generates an OpenAPI 3.x document") {
     expect.all(doc.contains("\"openapi\""), doc.contains("3.1") || doc.contains("3.0"))
+  }
+
+  pureTest("renders the same document as YAML") {
+    expect.all(
+      yaml.contains("openapi: 3.1"),
+      yaml.contains("title: OttoChain Metagraph API"),
+      yaml.contains("/data-application/v1/version:")
+    )
   }
 
   pureTest("documents every custom path family") {

--- a/modules/l0/src/test/scala/xyz/kd5ujc/metagraph_l0/openapi/OpenApiDocSuite.scala
+++ b/modules/l0/src/test/scala/xyz/kd5ujc/metagraph_l0/openapi/OpenApiDocSuite.scala
@@ -19,8 +19,23 @@ object OpenApiDocSuite extends SimpleIOSuite {
   pureTest("renders the same document as YAML") {
     expect.all(
       yaml.contains("openapi: 3.1"),
-      yaml.contains("title: OttoChain Metagraph API"),
-      yaml.contains("/data-application/v1/version:")
+      yaml.contains("title: OttoChain Metagraph L0 API"),
+      yaml.contains("/data-application/v1/version:"),
+      yaml.contains("- ml0")
+    )
+  }
+
+  pureTest("DL1 is a separate single-layer contract") {
+    val dl1Json = DataL1ApiEndpoints.openApiJson
+    val dl1Yaml = DataL1ApiEndpoints.openApiYaml
+    expect.all(
+      DataL1ApiEndpoints.all.size == 3,
+      dl1Json.contains("3.1"),
+      dl1Json.contains("/data-application/v1/version"),
+      dl1Json.contains("/data-application/v1/onchain"),
+      !dl1Json.contains("/data-application/v1/state-machines"), // ML0-only surface stays out
+      dl1Yaml.contains("title: OttoChain Data L1 API"),
+      dl1Yaml.contains("- dl1")
     )
   }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -51,6 +51,7 @@ object Dependencies {
     val tapirHttp4sServer = "com.softwaremill.sttp.tapir" %% "tapir-http4s-server" % V.tapir
     val tapirOpenApiDocs = "com.softwaremill.sttp.tapir" %% "tapir-openapi-docs" % V.tapir
     val sttpOpenApiCirce = "com.softwaremill.sttp.apispec" %% "openapi-circe" % V.sttpApiSpec
+    val sttpOpenApiCirceYaml = "com.softwaremill.sttp.apispec" %% "openapi-circe-yaml" % V.sttpApiSpec
 
   }
 


### PR DESCRIPTION
## What

Ships the tapir-generated OpenAPI contract as a **release artifact**, so every tagged release pins a machine-readable API contract to its jar version.

On `release: published` / `workflow_dispatch`, the workflow regenerates the contract from the **tagged source** (same generator the CI drift gate runs — sbt is already warm from `assembly`) and uploads, next to the three JARs:

- `openapi-<version>.json` / `openapi-<version>.yaml` — version-stamped (ties the contract to the jar)
- `openapi.json` / `openapi.yaml` — stable-named "spec for this tag"

## Why

The SDK codegen consumes `docs/openapi.json`; attaching a versioned copy to the release lets consumers pin a contract to a shipped jar rather than tracking `main`. Regenerating from the tag (vs. copying the committed file) guarantees the attached spec matches the released code even if a tag predates a drift-gate sync (a mismatch logs a `::warning::`, never fails the release).

## JSON **and** YAML

- `ApiEndpoints.openApiYaml` renders the *same* document via `sttp-apispec` `openapi-circe-yaml` (new dep, wired into `currencyL0`).
- `GenerateOpenApi` now writes the JSON at its target path **and** a `.yaml` sibling.
- The **CI drift gate** (`ci.yml`) now checks/auto-syncs `docs/openapi.json` **and** `docs/openapi.yaml`.
- `docs/openapi.yaml` is regenerated from the endpoints — this **replaces the stale hand-written 3.0.3 file** with a real 3.1.0 doc (22 paths, in parity with the JSON). Nothing referenced the old file.

## Note on versions

`info.version` stays the deliberately-decoupled `contractVersion` (`1.0.0`) — the drift gate depends on it not tracking the git-describe build version. The **build** version rides on the release *filename*, not the doc body.

## Verified locally
- `currencyL0/assembly` — fat-jar still builds (new snakeyaml/circe-yaml transitives absorbed by existing merge strategies)
- `OpenApiDocSuite` — 5/5 pass (incl. new YAML-rendering test)
- `docs/openapi.json` byte-identical to committed; `docs/openapi.yaml` regenerated, valid 3.1.0, 22 paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L9R14tyCrZNyt9pDu1Hged