### PR TITLE
chore: bump features to minor on 0.x (0.8.0)

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,7 +5,7 @@
       "release-type": "simple",
       "package-name": "ottochain",
       "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": true,
+      "bump-patch-for-minor-pre-major": false,
       "include-component-in-tag": false,
       "include-v-in-tag": true,
       "changelog-sections": [


### PR DESCRIPTION
## Why
release-please was computing the next release as **0.7.17 (patch)** despite the changes since `v0.7.16` being **features** — because `release-please-config.json` set `bump-patch-for-minor-pre-major: true` (bump patch even for `feat:` on pre-1.0).

The `feat:` commits since `v0.7.16`:
- `#194` transitionPolicy dial
- `#193` object-form-only `_transferAsset` — **wire-breaking** for clients using bare-string recipients
- `#197` injection-immune directive extraction
- `#189` Immutable policy preset
- `#198` OpenAPI release artifacts
- `#183` effect hardening

These warrant a **minor** bump. `#193` in particular is a client-visible wire break.

## Change
Flip `bump-patch-for-minor-pre-major` → `false`. With `bump-minor-pre-major: true` still set, `feat:` now bumps the minor on 0.x → next release is **0.8.0**. `fix:` still bumps patch.

## Effect
After merge, release-please regenerates the release PR (**#185**) as **0.8.0** and re-runs its CI fresh (which also clears the transient `ECONNRESET` seen on the 0.7.17 run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)