### PR TITLE
test(e2e): published SDK 2.6.0 + typecheck + webhook client

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -61,6 +61,26 @@ jobs:
           echo "lanes=$LANES" >>"$GITHUB_OUTPUT"
           echo "Selected lanes:"; echo "$LANES" | jq -r '.[].name'
 
+  # Lightweight, cluster-free gate: type-check the e2e harness against the PUBLISHED @ottochain/sdk.
+  # The harness runs under tsx (which erases types), so without this a drift between the SDK's export
+  # surface and the harness (e.g. a renamed/removed type) would silently pass CI and only bite a user.
+  # This is the circular-dep guard: an SDK change that breaks the harness's contract fails here.
+  typecheck:
+    name: E2E Typecheck (published SDK)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+      - name: Install E2E dependencies
+        working-directory: e2e-test
+        run: npm ci
+      - name: Type-check harness against @ottochain/sdk
+        working-directory: e2e-test
+        run: npm run typecheck
+
   e2e:
     name: E2E Tests (${{ matrix.lane.name }})
     needs: prepare

--- a/e2e-test/lib/registry/publishVersion.ts
+++ b/e2e-test/lib/registry/publishVersion.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import type {
   OttochainMessage,
-  SchemaShape,
+  MachineShape,
   StateMachineDefinition,
   CalculatedState,
 } from '@ottochain/sdk/core';
@@ -22,7 +22,7 @@ export interface PublishVersionOptions {
   name: string;
   version: string;
   definition: string | StateMachineDefinition;
-  schemaShape: string | SchemaShape;
+  schemaShape: string | MachineShape;
   schemaB64?: string;
   strict?: boolean;
   metadata?: Record<string, string>;
@@ -39,14 +39,14 @@ function loadMaybe<T>(v: string | T): T {
 }
 
 export const generator = ({ options }: { cid?: string; wallets?: unknown; options: PublishVersionOptions }): OttochainMessage => {
-  // NOTE: chain renamed PublishVersion -> PublishMachineVersion and `schemaShape` -> `machineShape`
-  // (machine/script registry symmetry). The @ottochain/sdk types are not regenerated yet, so this is
-  // typed loosely and runs under tsx (no compile-time check) — "force past" until the SDK is updated.
+  // The chain renamed PublishVersion -> PublishMachineVersion and `schemaShape` -> `machineShape`
+  // (machine/script registry symmetry); the SDK's `MachineShape` supersedes the old `SchemaShape`.
+  // As of @ottochain/sdk 2.5.0 the types are aligned, so this now type-checks (no more tsx "force past").
   const msg = {
     name: options.name,
     version: options.version,
     schemaB64: options.schemaB64 ?? Buffer.from(`descriptor:${options.name}:${options.version}`).toString('base64'),
-    machineShape: loadMaybe<SchemaShape>(options.schemaShape),
+    machineShape: loadMaybe<MachineShape>(options.schemaShape),
     definition: loadMaybe<StateMachineDefinition>(options.definition),
     // `strict` is required on the chain (no default) — always send it so the signed canonical matches
     // what the chain re-derives. `metadata` is Option (omit-safe), so it stays conditional.

--- a/e2e-test/lib/webhookListener.ts
+++ b/e2e-test/lib/webhookListener.ts
@@ -1,6 +1,9 @@
 import http from 'http';
 import { execSync } from 'child_process';
 
+import { OttoMetagraphClient } from '@ottochain/sdk';
+import type { SubscribeResponse } from '@ottochain/sdk';
+
 /**
  * Push-driven confirmation source for the e2e runner.
  *
@@ -16,9 +19,20 @@ import { execSync } from 'child_process';
  * moment the snapshot that rejected it finalizes (still ahead of a "not included" timeout, but now
  * deterministic: it reflects committed state, not a pre-combine guess).
  *
+ * Subscription lifecycle goes through the SDK's typed client — `OttoMetagraphClient.subscribeWebhook`
+ * / `unsubscribeWebhook` / `listWebhookSubscribers` — NOT raw fetch. That is deliberate: it makes
+ * this harness exercise (and therefore GUARD) the SDK's webhook request surface, so a drift between
+ * the SDK client and the chain's `/webhooks/*` routes/DTOs breaks the e2e instead of a user.
+ *
+ * The PUSH payload (chain → this callback) is not yet modeled by the SDK (it's a server-initiated
+ * notification, outside the client's request surface), so the local `RejectionPayload` / handler
+ * shapes below mirror the chain's `SnapshotNotification` (webhooks/Subscriber.scala) verbatim. TODO:
+ * once the SDK exports the notification payload types, import them here so this shape is guarded too.
+ *
  * Webhook API (modules/l0 ML0Routes + WebhookDispatcher):
- *   POST   /data-application/v1/webhooks/subscribe      { callbackUrl, secret? }
- *   DELETE /data-application/v1/webhooks/subscribe/{id}
+ *   POST   /data-application/v1/webhooks/subscribe      { callbackUrl, secret? }  (SDK subscribeWebhook)
+ *   DELETE /data-application/v1/webhooks/subscribe/{id}                           (SDK unsubscribeWebhook)
+ *   GET    /data-application/v1/webhooks/subscribers                              (SDK listWebhookSubscribers)
  *   push:  { event: "snapshot.finalized", ordinal, hash, stats:{updatesProcessed,...,rejectedCount},
  *           rejections:[{ updateType, fiberId, targetSequenceNumber, actualSequenceNumber,
  *                         reason, updateHash }] }
@@ -73,7 +87,7 @@ function resolveCallbackHost(): string {
 
 export class WebhookListener {
   private server?: http.Server;
-  private subscriptions: { ml0Url: string; id: string }[] = [];
+  private subscriptions: { client: OttoMetagraphClient; id: string }[] = [];
   private snapshotWaiters: Array<() => void> = [];
   private rejections: RejectionInfo[] = [];
   /** Highest finalized ordinal seen via `snapshot.finalized`. */
@@ -114,18 +128,30 @@ export class WebhookListener {
     const uniqueMl0 = [...new Set(ml0Urls)];
     for (const ml0Url of uniqueMl0) {
       try {
-        const r = await fetch(`${ml0Url}/data-application/v1/webhooks/subscribe`, {
-          method: 'POST',
-          headers: { 'content-type': 'application/json' },
-          body: JSON.stringify({ callbackUrl: this.callbackUrl }),
-        });
-        const id = (await r.json().catch(() => ({})))?.id as string | undefined;
-        if (r.ok && id) {
-          this.subscriptions.push({ ml0Url, id });
+        // Subscribe through the SDK's typed client (not raw fetch) so this harness guards the SDK's
+        // webhook request surface: a drift in the method signature, path, or DTO breaks here.
+        const client = new OttoMetagraphClient({ ml0Url });
+        const resp: SubscribeResponse = await client.subscribeWebhook({ callbackUrl: this.callbackUrl });
+        if (resp?.id) {
+          this.subscriptions.push({ client, id: resp.id });
           this.active = true;
         }
       } catch {
         // ML0 may not expose webhooks (older build) — caller falls back to polling.
+      }
+    }
+
+    // Exercise the list endpoint too (and confirm the node registered our callback) — another SDK
+    // surface guarded, and a useful sanity log for the container→host reachability.
+    if (this.active) {
+      try {
+        const list = await this.subscriptions[0].client.listWebhookSubscribers();
+        console.log(
+          `\x1b[36m[webhook]\x1b[0m subscribed ${this.subscriptions.length} node(s); ` +
+            `node reports ${list.subscribers?.length ?? 0} active subscriber(s)`
+        );
+      } catch {
+        /* non-fatal: the subscribe already succeeded */
       }
     }
   }
@@ -202,7 +228,7 @@ export class WebhookListener {
   async stop(): Promise<void> {
     for (const sub of this.subscriptions) {
       try {
-        await fetch(`${sub.ml0Url}/data-application/v1/webhooks/subscribe/${sub.id}`, { method: 'DELETE' });
+        await sub.client.unsubscribeWebhook(sub.id);
       } catch {
         /* best-effort */
       }

--- a/e2e-test/package-lock.json
+++ b/e2e-test/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@ottochain/sdk": "^2.5.0",
+        "@ottochain/sdk": "^2.6.0",
         "commander": "13.1.0",
         "dotenv": "^16.4.7"
       },
@@ -610,9 +610,9 @@
       "license": "MIT"
     },
     "node_modules/@ottochain/sdk": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@ottochain/sdk/-/sdk-2.5.0.tgz",
-      "integrity": "sha512-/a65aJPNRKoO/38Br7o6Bt56r2ZTw4MRCeaN0l0TGx1KFl59YCUjJnLBgC/SJ4AtC8xDlojaC5v5ssfZCuqm0g==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@ottochain/sdk/-/sdk-2.6.0.tgz",
+      "integrity": "sha512-NSn2e0tkKmGoFIEKYlPHsO0o7JvOWvnmP/SWXZJopl0mUr7+ZXLsnNLYN9pkv40VTd8AKqH3Wib9lXxlvJ7VbQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@bufbuild/protobuf": "^2.12.1",

--- a/e2e-test/package-lock.json
+++ b/e2e-test/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@ottochain/sdk": "github:ottobot-ai/ottochain-sdk#main",
+        "@ottochain/sdk": "^2.5.0",
         "commander": "13.1.0",
         "dotenv": "^16.4.7"
       },
@@ -20,10 +20,101 @@
       }
     },
     "node_modules/@bufbuild/protobuf": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.11.0.tgz",
-      "integrity": "sha512-sBXGT13cpmPR5BMgHE6UEEfEaShh5Ror6rfN3yEK5si7QVrtZg8LEPQb0VVhiLRUslD2yLnXtnRzG035J/mZXQ==",
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.12.1.tgz",
+      "integrity": "sha512-BvAMfS6LrgZiryOAZ4pBYucu4wG/Ei/9o9DZ9akbREnMLbPJiom2i8b9C8IsKErQoiKqVhrerzt3kOT/RrzLHg==",
       "license": "(Apache-2.0 AND BSD-3-Clause)"
+    },
+    "node_modules/@constellation-network/metagraph-sdk": {
+      "version": "1.8.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@constellation-network/metagraph-sdk/-/metagraph-sdk-1.8.0-rc.7.tgz",
+      "integrity": "sha512-/8mYIHhwQrIPbGK9Def29fXUVv8hDvyLTJKqWnIK5FCjVndexEqJxoGsmZZVUhZtxpvw+KxjnfqkPwcOTGEgww==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@constellation-network/metagraph-sdk-core": "1.8.0-rc.7",
+        "@noble/hashes": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@constellation-network/metagraph-sdk-core": {
+      "version": "1.8.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@constellation-network/metagraph-sdk-core/-/metagraph-sdk-core-1.8.0-rc.7.tgz",
+      "integrity": "sha512-dshRWUlVES5W4JnouDrXxHmN1n5Ma83801sQo48jhp4GAPMNHL48k9s1VS6QbW6R4B8340yXR5HbGFdOPOB1RA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@noble/curves": "^2.0.1",
+        "@noble/hashes": "^2.0.1",
+        "bs58": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@constellation-network/metagraph-sdk-core/node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@constellation-network/metagraph-sdk-core/node_modules/base-x": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-5.0.1.tgz",
+      "integrity": "sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg==",
+      "license": "MIT"
+    },
+    "node_modules/@constellation-network/metagraph-sdk-core/node_modules/bs58": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-6.0.0.tgz",
+      "integrity": "sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw==",
+      "license": "MIT",
+      "dependencies": {
+        "base-x": "^5.0.0"
+      }
+    },
+    "node_modules/@constellation-network/metagraph-sdk-jlvm": {
+      "version": "1.8.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@constellation-network/metagraph-sdk-jlvm/-/metagraph-sdk-jlvm-1.8.0-rc.7.tgz",
+      "integrity": "sha512-eMzJGMCO9zWsS/+EMuhQSKaJZplFLh0QiQZqS66xdx6lqitxGFfFEBLcrfENthECxdxS+7Q1hTPL9TWnS0ejUw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@noble/curves": "^2.0.1",
+        "@noble/hashes": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@constellation-network/metagraph-sdk-jlvm/node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@constellation-network/metagraph-sdk/node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.27.3",
@@ -467,6 +558,33 @@
         "node": ">=18"
       }
     },
+    "node_modules/@noble/curves": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.2.0.tgz",
+      "integrity": "sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.2.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/curves/node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@noble/hashes": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
@@ -492,23 +610,36 @@
       "license": "MIT"
     },
     "node_modules/@ottochain/sdk": {
-      "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/ottobot-ai/ottochain-sdk.git#37c5fb4eab3d6bde8876abe1f6d2729c0e1b9e3f",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@ottochain/sdk/-/sdk-2.5.0.tgz",
+      "integrity": "sha512-/a65aJPNRKoO/38Br7o6Bt56r2ZTw4MRCeaN0l0TGx1KFl59YCUjJnLBgC/SJ4AtC8xDlojaC5v5ssfZCuqm0g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@bufbuild/protobuf": "^2.11.0",
+        "@bufbuild/protobuf": "^2.12.1",
+        "@constellation-network/metagraph-sdk": "1.8.0-rc.7",
+        "@constellation-network/metagraph-sdk-jlvm": "1.8.0-rc.7",
+        "@noble/hashes": "^1.8.0",
         "@stardust-collective/dag4": "^2.6.0",
         "@stardust-collective/dag4-keystore": "^2.6.0",
-        "canonicalize": "^2.1.0",
+        "canonicalize": "^3.0.0",
         "js-sha256": "^0.11.1",
         "js-sha512": "^0.9.0",
-        "zod": "^3.22.0"
+        "zod": "^4.4.3"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.19.0"
       },
       "peerDependencies": {
         "@stardust-collective/dag4": "^2.6.0"
+      }
+    },
+    "node_modules/@ottochain/sdk/node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@stardust-collective/dag4": {
@@ -980,12 +1111,15 @@
       }
     },
     "node_modules/canonicalize": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/canonicalize/-/canonicalize-2.1.0.tgz",
-      "integrity": "sha512-F705O3xrsUtgt98j7leetNhTWPe+5S72rlL5O4jA1pKqBVQ/dT1O1D6PFxmSXvc0SUOinWS57DKx0I3CHrXJHQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/canonicalize/-/canonicalize-3.0.0.tgz",
+      "integrity": "sha512-yYLfHyDMIXRyRqsKBRLX023riFLpXY2YOfdtqKXZRZy9qsfOJ9U+4F9YZL7MEzL5+ziN2x2nlBvY/Voi3EBljA==",
       "license": "Apache-2.0",
       "bin": {
         "canonicalize": "bin/canonicalize.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/caseless": {

--- a/e2e-test/package.json
+++ b/e2e-test/package.json
@@ -8,13 +8,14 @@
     "terminal:help": "npx tsx terminal.ts --help",
     "terminal:list": "npx tsx terminal.ts list",
     "test": "npx tsx runner.ts",
-    "test:ci": "npx tsx runner.ts --target ci"
+    "test:ci": "npx tsx runner.ts --target ci",
+    "typecheck": "tsc --noEmit"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@ottochain/sdk": "github:ottobot-ai/ottochain-sdk#main",
+    "@ottochain/sdk": "^2.5.0",
     "commander": "13.1.0",
     "dotenv": "^16.4.7"
   },

--- a/e2e-test/package.json
+++ b/e2e-test/package.json
@@ -15,7 +15,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@ottochain/sdk": "^2.5.0",
+    "@ottochain/sdk": "^2.6.0",
     "commander": "13.1.0",
     "dotenv": "^16.4.7"
   },


### PR DESCRIPTION
Switches the e2e harness from building the SDK **from git source** to consuming the **published npm artifact**, adds the type-check gate that makes SDK↔harness drift fail in CI, and routes the webhook subscription lifecycle through the SDK's typed client.

## What & why

**Dependency:** `@ottochain/sdk`: `github:ottobot-ai/ottochain-sdk#main` → `@ottochain/sdk@^2.6.0`
- Tests exactly what users install (published tarball, not unreleased `main`).
- Drops the SDK's **devDependencies** from the install — the `eslint@8`/`glob`/`rimraf`/`@humanwhocodes/*` deprecation noise came from *source-building* the stale SDK; gone now.
- Removes the git-dep `prepare` build step, which was the surface for the transient **`ECONNRESET`** install failure.
- Unpins the **5-month-stale** lockfile commit (Feb `37c5fb4`) that `#main` had frozen.

2.6.0 is the aligned surface: metakit-sdk **rc.7**, the **`transitionPolicy`** dial, the **`MachineShape`** type, and the typed **webhook client** methods the harness now uses.

**Webhook lifecycle via the SDK client:** `lib/webhookListener.ts` now drives subscribe / unsubscribe / list through `OttoMetagraphClient.subscribeWebhook` / `.unsubscribeWebhook` / `.listWebhookSubscribers` instead of raw `fetch`. This makes the harness **exercise (and therefore guard) the SDK's webhook request surface** — a drift in a method signature, path, or DTO now breaks the e2e instead of a user.
- Gotcha handled: `MetagraphClient` from the SDK root resolves to the *tessellation* client (via `export *`); the ottochain client is `OttoMetagraphClient`.
- Push model (unchanged in spirit, already wired): `snapshot.finalized` is the confirm tick, its `rejections[]` are definitive rejects. There is no per-update "accepted" event — acceptance = `updateHash` in a finalized snapshot and absent from every `rejections[]`.
- Follow-up (SDK #251): the SDK will export the push **payload** types (`SnapshotNotification`/`NotificationStats`/`SnapshotRejection`); once released, the harness will import them to replace its local mirror and guard the push shape too.

**Stale type fix:** `SchemaShape` → `MachineShape` in `lib/registry/publishVersion.ts` (the SDK renamed this type; the harness had been "forcing past" the dangling import under `tsx`).

**New `E2E Typecheck` CI job** (cluster-free, ~1 min) + `typecheck` script (`tsc --noEmit`). The harness runs under `tsx`, which **erases types** — so a renamed/removed SDK export silently passed CI for months and would only bite a user. This job is the circular-dep guard: **an SDK change that breaks the harness's contract now fails here.**

## Verification
- ✅ `npm ci` resolves the published `2.6.0` tarball (not git), clean install
- ✅ `npm run typecheck` (`tsc --noEmit`) passes — the whole harness type-checks against 2.6.0 (incl. the webhook client + `OttoMetagraphClient`)
- ✅ Rebased onto current `main` (0.8.0 config flip #199 + riverdale lane-gating #202); e2e.yml keeps both the `prepare` lane-selector and the new `typecheck` job
- ✅ Full e2e lanes green on the prior push (identical harness tree); re-running post-rebase

## Sequencing note
Lands the last step of the SDK↔chain alignment. The harness signs via the SDK's stable envelope, so it works against the chain regardless of the chain's own `0.8.0` release timing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)