### PR TITLE
test(e2e): raise riverdale confirm budget (block-inclusion flake)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -40,6 +40,11 @@ jobs:
           #   rule110        light per-step; concurrency 3 is the intra-lane contention probe.
           #   staked-oracle  quorum-3 pool; webhook-confirmed; needs 3 distinct joiners.
           #   riverdale-economy  full 6-party economy, REAL asset custody + multi-fiber — the HEAVY lane.
+          #     Highest confirm budget (ordinalThreshold 30 × maxResubmits 4 = 150 ordinals): at its
+          #     deepest cross-fiber contention point a VALID transition can be excluded from every DL1
+          #     block by one trailing DL1 node (no apply, no reject — "not included") until it catches
+          #     up. Observed twice on run 28912533047; result=VALID at all DL1 nodes, zero ML0
+          #     rejections — a block-inclusion timing issue, not a validation bug. The wide window rides it out.
           ALL="$(cat <<'JSON'
           [
             {"name":"core","filter":"--exclude sigma-mixer,rule110,staked-oracle-pool,tictactoe,riverdale-economy","concurrency":"","ordinalThreshold":"","maxResubmits":"","wallets":"","timeout":30},
@@ -47,7 +52,7 @@ jobs:
             {"name":"sigma-mixer","filter":"--only sigma-mixer","concurrency":"2","ordinalThreshold":"10","maxResubmits":"4","wallets":"","timeout":25},
             {"name":"rule110","filter":"--only rule110","concurrency":"3","ordinalThreshold":"10","maxResubmits":"4","wallets":"","timeout":30},
             {"name":"staked-oracle","filter":"--only staked-oracle-pool","concurrency":"1","ordinalThreshold":"30","maxResubmits":"1","wallets":"alice,bob,carol","timeout":45},
-            {"name":"riverdale-economy","filter":"--only riverdale-economy","concurrency":"1","ordinalThreshold":"15","maxResubmits":"2","wallets":"alice,bob,carol,dave,erin,frank","timeout":55}
+            {"name":"riverdale-economy","filter":"--only riverdale-economy","concurrency":"1","ordinalThreshold":"30","maxResubmits":"4","wallets":"alice,bob,carol,dave,erin,frank","timeout":55}
           ]
           JSON
           )"


### PR DESCRIPTION
Raises the confirm budget for the heavy `riverdale-economy` e2e lane so it rides out a load-induced **block-inclusion** flake at the flow's deepest cross-fiber contention point.

## Why (investigated, not a bug)
On run [28912533047](https://github.com/scasplte2/ottochain/actions/runs/28912533047) the lane failed twice at the same step (step 73, a `processEvent`) with `transaction not included after 15 ordinals × 3 attempts`. The node logs show it was **not** a validation rejection:
- DL1 validated the transition as **`result=VALID` on all 3 nodes** (re-validated VALID on each resubmit).
- ML0 combined it into **zero** snapshots and logged **zero** rejections across the entire confirm window (every ordinal: `0 updates, rejections=0`).

That's the harness's documented failure mode: a single trailing DL1 node excludes a valid update from every block during consensus (no apply, no reject) until it catches up — worst at the heaviest contention point. A block-inclusion timing issue, not a correctness regression.

## Change
`riverdale-economy` lane only:
- `ordinalThreshold` **15 → 30** (patience per window — matches the `staked-oracle` pool lane, giving the lagging DL1 node time to catch up)
- `maxResubmits` **2 → 4** (total budget **45 → 150 ordinals**)

The stall gate (consensus-dead fail-fast) and the 55-minute lane timeout still bound the wait. No other lane changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)