### PR TITLE
fix(fiber): permissionless-safety hardening L2–L6

### DIFF
--- a/docs/openapi-ml0.json
+++ b/docs/openapi-ml0.json
@@ -860,6 +860,14 @@
   },
   "components" : {
     "schemas" : {
+      "AppendOnly" : {
+        "title" : "AppendOnly",
+        "type" : "object"
+      },
+      "Arbitrary" : {
+        "title" : "Arbitrary",
+        "type" : "object"
+      },
       "AssetCommit" : {
         "title" : "AssetCommit",
         "type" : "object",
@@ -1133,12 +1141,39 @@
           }
         }
       },
+      "Governed" : {
+        "title" : "Governed",
+        "type" : "object",
+        "required" : [
+          "authority"
+        ],
+        "properties" : {
+          "authority" : {
+            "$ref" : "#/components/schemas/MigrationAuthority"
+          }
+        }
+      },
+      "Immutable" : {
+        "title" : "Immutable",
+        "type" : "object"
+      },
       "Map_V" : {
         "title" : "Map_V",
         "type" : "object",
         "additionalProperties" : {
           "$ref" : "#/components/schemas/FiberCommit"
         }
+      },
+      "MigrationAuthority" : {
+        "title" : "MigrationAuthority",
+        "oneOf" : [
+          {
+            "$ref" : "#/components/schemas/Role"
+          },
+          {
+            "$ref" : "#/components/schemas/Signers"
+          }
+        ]
       },
       "OnChain" : {
         "title" : "OnChain",
@@ -1214,6 +1249,23 @@
           },
           "metadata" : {
             "$ref" : "#/components/schemas/Map_V"
+          }
+        }
+      },
+      "Role" : {
+        "title" : "Role",
+        "type" : "object",
+        "required" : [
+          "registryFiberId",
+          "roleField"
+        ],
+        "properties" : {
+          "registryFiberId" : {
+            "type" : "string",
+            "format" : "uuid"
+          },
+          "roleField" : {
+            "type" : "string"
           }
         }
       },
@@ -1329,6 +1381,9 @@
           },
           "schemaBinding" : {
             "$ref" : "#/components/schemas/SchemaBinding"
+          },
+          "upgradePolicy" : {
+            "$ref" : "#/components/schemas/UpgradePolicy"
           }
         }
       },
@@ -1368,6 +1423,19 @@
           },
           "invokedBy" : {
             "type" : "string"
+          }
+        }
+      },
+      "Signers" : {
+        "title" : "Signers",
+        "type" : "object",
+        "properties" : {
+          "addresses" : {
+            "type" : "array",
+            "uniqueItems" : true,
+            "items" : {
+              "type" : "string"
+            }
           }
         }
       },
@@ -1658,6 +1726,23 @@
             "type" : "string"
           }
         }
+      },
+      "UpgradePolicy" : {
+        "title" : "UpgradePolicy",
+        "oneOf" : [
+          {
+            "$ref" : "#/components/schemas/AppendOnly"
+          },
+          {
+            "$ref" : "#/components/schemas/Arbitrary"
+          },
+          {
+            "$ref" : "#/components/schemas/Governed"
+          },
+          {
+            "$ref" : "#/components/schemas/Immutable"
+          }
+        ]
       },
       "VersionInfo" : {
         "title" : "VersionInfo",

--- a/docs/openapi-ml0.yaml
+++ b/docs/openapi-ml0.yaml
@@ -547,6 +547,12 @@ paths:
                 $ref: '#/components/schemas/SubscriberList'
 components:
   schemas:
+    AppendOnly:
+      title: AppendOnly
+      type: object
+    Arbitrary:
+      title: Arbitrary
+      type: object
     AssetCommit:
       title: AssetCommit
       type: object
@@ -744,11 +750,27 @@ components:
         sequenceNumber:
           type: integer
           format: int64
+    Governed:
+      title: Governed
+      type: object
+      required:
+      - authority
+      properties:
+        authority:
+          $ref: '#/components/schemas/MigrationAuthority'
+    Immutable:
+      title: Immutable
+      type: object
     Map_V:
       title: Map_V
       type: object
       additionalProperties:
         $ref: '#/components/schemas/FiberCommit'
+    MigrationAuthority:
+      title: MigrationAuthority
+      oneOf:
+      - $ref: '#/components/schemas/Role'
+      - $ref: '#/components/schemas/Signers'
     OnChain:
       title: OnChain
       type: object
@@ -802,6 +824,18 @@ components:
         target: {}
         metadata:
           $ref: '#/components/schemas/Map_V'
+    Role:
+      title: Role
+      type: object
+      required:
+      - registryFiberId
+      - roleField
+      properties:
+        registryFiberId:
+          type: string
+          format: uuid
+        roleField:
+          type: string
     SchemaBinding:
       title: SchemaBinding
       type: object
@@ -883,6 +917,8 @@ components:
           $ref: '#/components/schemas/ScriptInvocation'
         schemaBinding:
           $ref: '#/components/schemas/SchemaBinding'
+        upgradePolicy:
+          $ref: '#/components/schemas/UpgradePolicy'
     ScriptInvocation:
       title: ScriptInvocation
       type: object
@@ -910,6 +946,15 @@ components:
           format: int64
         invokedBy:
           type: string
+    Signers:
+      title: Signers
+      type: object
+      properties:
+        addresses:
+          type: array
+          uniqueItems: true
+          items:
+            type: string
     StateMachineFiberRecord:
       title: StateMachineFiberRecord
       type: object
@@ -1112,6 +1157,13 @@ components:
           format: int32
         note:
           type: string
+    UpgradePolicy:
+      title: UpgradePolicy
+      oneOf:
+      - $ref: '#/components/schemas/AppendOnly'
+      - $ref: '#/components/schemas/Arbitrary'
+      - $ref: '#/components/schemas/Governed'
+      - $ref: '#/components/schemas/Immutable'
     VersionInfo:
       title: VersionInfo
       type: object

--- a/modules/models/src/main/scala/xyz/kd5ujc/schema/Records.scala
+++ b/modules/models/src/main/scala/xyz/kd5ujc/schema/Records.scala
@@ -61,7 +61,11 @@ object Records {
     owners:              Set[Address],
     status:              FiberStatus,
     lastInvocation:      Option[ScriptInvocation] = None,
-    schemaBinding:       Option[SchemaBinding] = None
+    schemaBinding:       Option[SchemaBinding] = None,
+    // L2 (audit 2026-07-07): the script's upgrade constitution, pinned at create from CreateScript.upgradePolicy
+    // and consulted by UpgradeGate at every UpgradeScript. `None` ⇒ Arbitrary (legacy). Server-derived record
+    // state — the `= None` default is fine (signing-canonical invariant #1 governs SIGNED messages only).
+    upgradePolicy: Option[UpgradePolicy] = None
   ) extends FiberRecord
 
   /**

--- a/modules/models/src/main/scala/xyz/kd5ujc/schema/Updates.scala
+++ b/modules/models/src/main/scala/xyz/kd5ujc/schema/Updates.scala
@@ -13,7 +13,7 @@ import io.constellationnetwork.security.signature.Signed
 
 import xyz.kd5ujc.schema.CodecConfiguration._
 import xyz.kd5ujc.schema.asset._
-import xyz.kd5ujc.schema.fiber.{AccessControlPolicy, FiberOrdinal, StateMachineDefinition}
+import xyz.kd5ujc.schema.fiber.{AccessControlPolicy, FiberOrdinal, StateMachineDefinition, UpgradePolicy}
 import xyz.kd5ujc.schema.registry._
 
 import derevo.circe.magnolia.{customizableDecoder, customizableEncoder}
@@ -105,7 +105,13 @@ object Updates {
     scriptProgram: JsonLogicExpression,
     initialState:  Option[JsonLogicValue],
     accessControl: AccessControlPolicy,
-    schemaRef:     Option[SchemaRef] = None
+    schemaRef:     Option[SchemaRef] = None,
+    // L2 (audit 2026-07-07): the script's upgrade-path constitution, mirroring a state machine's
+    // FiberPolicy.upgradePolicy. Fixed AT CREATE and read from the OLD record at `UpgradeScript` (never
+    // re-suppliable on upgrade — closes the self-authorizing-authority hole by construction). `None`/`Arbitrary`
+    // is today's behaviour (any owner may re-point to any registered same-package version). `Immutable` freezes
+    // the script; `Governed` requires the migration authority's consent. Omit-safe (`Option`, signing rule #1).
+    upgradePolicy: Option[UpgradePolicy] = None
   ) extends ScriptFiberOp
       with OttochainMessage
 

--- a/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/fiber/FiberEngine.scala
+++ b/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/fiber/FiberEngine.scala
@@ -648,6 +648,16 @@ object FiberEngine {
        * append-only spawn tree never produces but crafted/migrated state could) is likewise unverifiable and
        * would otherwise loop forever, so a revisited id also fails closed (DoS-safe). Orthogonal to
        * `ExecutionLimits.maxDepth` (trigger-chain depth, a different axis). No-op (always Right) when unset.
+       *
+       * MIGRATION RESET (audit 2026-07-07, finding L3 — READ BEFORE relying on this cap as absolute). The
+       * lineage is counted by DEFINITION DIGEST (`selfDigest = fiber.definition.computeDigest`), so a
+       * migration (`UpgradeFiber`) that changes the definition changes the digest: post-migration ancestors
+       * no longer hash-equal `selfDigest`, the count restarts from 0, and a non-`Immutable` self-reproducing
+       * lineage can migrate and re-spawn `cap` MORE generations, repeatably (owner-funded + gas-metered — a
+       * cost-bounded amplifier, not a free exploit). To make `maxGenerations` an ABSOLUTE, migration-proof cap,
+       * pair it with `upgradePolicy = Immutable` (which `UpgradeGate` enforces by forbidding migration outright),
+       * so the digest can never change. A migration-surviving lineage anchor (counting by a stable lineage root
+       * rather than the mutable digest) is deferred — `Immutable` covers the guarantee today.
        */
       private def checkMaxGenerations(
         fiber: Records.StateMachineFiberRecord

--- a/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/fiber/UpgradeGate.scala
+++ b/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/fiber/UpgradeGate.scala
@@ -82,6 +82,39 @@ object UpgradeGate {
         gateAppendOnly(old.schemaBinding, newBinding, state)
     }
 
+  /**
+   * SCRIPT upgrade gate (audit 2026-07-07, finding L2). A script is a raw JSON-Logic program with no protobuf
+   * machine shape, so only the owner-constitution tiers apply: an absent dial / [[UpgradePolicy.Arbitrary]]
+   * admits (today's behaviour — any owner may re-point to any registered same-package version); [[UpgradePolicy.Immutable]]
+   * denies ALL upgrades; [[UpgradePolicy.Governed]] requires the migration authority's consent (reusing
+   * [[gateGoverned]] — the authority is read from the OLD record's pinned policy, never re-suppliable on
+   * `UpgradeScript`, so the self-authorizing `Role(registryFiberId = attacker)` hole is closed by construction).
+   * [[UpgradePolicy.AppendOnly]] needs a strict machine schema to verify an additive delta, which a script does
+   * NOT have — DENIED as unsupported (rejected at create, fail-closed here too). `addrs` are the VERIFIED signer
+   * addresses of the `UpgradeScript`. There is no `newDefinition` policy to tighten-check (the policy is fixed
+   * at create), so only `gateByUpgradePolicy`'s equivalent runs.
+   */
+  def gateScriptUpgrade(
+    policy: Option[UpgradePolicy],
+    state:  CalculatedState,
+    addrs:  Set[Address]
+  ): Option[FailureReason] =
+    policy.getOrElse(UpgradePolicy.default) match {
+      case UpgradePolicy.Arbitrary =>
+        None
+      case UpgradePolicy.Immutable =>
+        Some(FailureReason.PolicyViolation("upgradePolicy", "immutable: script migrations are forbidden"))
+      case UpgradePolicy.Governed(authority) =>
+        gateGoverned(authority, state, addrs)
+      case UpgradePolicy.AppendOnly =>
+        Some(
+          FailureReason.PolicyViolation(
+            "upgradePolicy",
+            "appendOnly requires a strict machine schema and is not supported for scripts"
+          )
+        )
+    }
+
   // ── Governed ────────────────────────────────────────────────────────────────────────────────────────
 
   /**

--- a/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/fiber/evaluation/EffectExtractor.scala
+++ b/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/fiber/evaluation/EffectExtractor.scala
@@ -2,7 +2,6 @@ package xyz.kd5ujc.shared_data.fiber.evaluation
 
 import java.util.UUID
 
-import cats.data.OptionT
 import cats.effect.Async
 import cats.mtl.{Ask, Stateful}
 import cats.syntax.all._
@@ -136,11 +135,13 @@ object EffectExtractor {
         ctx =>
           extractSpawnDirectivesFromExpression(ctx.effectExpr).map(d => FiberEffect.Spawned(d): FiberEffect).pure[G]
 
-        // Fix (1): `extractEmittedEvents` stamps the EMITTING fiber id (`sourceFiberId`) into every emitted
-      // event — the emitter, distinct from any cross-fiber caller.
+        // `extractEmittedEvents` stamps the EMITTING fiber id (`sourceFiberId`) into every emitted event — the
+      // emitter, distinct from any cross-fiber caller. Loud on a malformed `_emit` item (audit L5).
       case FiberDirective.Emit =>
         ctx =>
-          extractEmittedEvents(ctx.authored, ctx.sourceFiberId).map(e => FiberEffect.Emitted(e): FiberEffect).pure[G]
+          extractEmittedEvents[F, G](ctx.authored, ctx.sourceFiberId).map(
+            _.map(e => FiberEffect.Emitted(e): FiberEffect)
+          )
 
       case FiberDirective.Transfer =>
         ctx => extractAssetTransfers[F, G](ctx.authored, ctx.contextData).map(_.map(x => x: FiberEffect))
@@ -335,37 +336,34 @@ object EffectExtractor {
     sourceFiberId: UUID
   )(implicit S: Stateful[G, ExecutionState], A: Ask[G, FiberContext], lift: F ~> G): G[List[FiberTrigger]] =
     extractArrayByKey(effectResult, ReservedKeys.TRIGGERS)
-      .flatTraverse { item =>
-        parseTriggerEvent[F, G](item, contextData, sourceFiberId)
-          .map(_.toList)
-      }
+      .traverse(parseTriggerEvent[F, G](_, contextData, sourceFiberId))
 
   private def parseTriggerEvent[F[_]: Async, G[_]: Monad](
     value:         JsonLogicValue,
     contextData:   JsonLogicValue,
     sourceFiberId: UUID
-  )(implicit S: Stateful[G, ExecutionState], A: Ask[G, FiberContext], lift: F ~> G): G[Option[FiberTrigger]] =
+  )(implicit S: Stateful[G, ExecutionState], A: Ask[G, FiberContext], lift: F ~> G): G[FiberTrigger] =
     value match {
       case MapValue(triggerMap) =>
-        (for {
-          targetIdStr <- OptionT.fromOption[G](
-            triggerMap.get(ReservedKeys.TARGET_MACHINE_ID).collect { case StrValue(id) => id }
-          )
-          targetId <- OptionT.fromOption[G](scala.util.Try(UUID.fromString(targetIdStr)).toOption)
-          eventType <- OptionT.fromOption[G](
-            triggerMap.get(ReservedKeys.EVENT_NAME).collect { case StrValue(et) => et }
-          )
-          payloadValue <- OptionT.fromOption[G](triggerMap.get(ReservedKeys.PAYLOAD))
-          payloadExpr = ExpressionParser.valueToExpression(payloadValue)
-          evaluatedPayload <- OptionT(
-            MeteredEvaluator.evalOpt[F, G](payloadExpr, contextData, GasExhaustionPhase.Trigger)
+        for {
+          targetIdStr <- requireString[F, G](triggerMap, ReservedKeys.TARGET_MACHINE_ID, "_triggers", "targetMachineId")
+          targetId    <- requireUuid[F, G](targetIdStr, "_triggers", "targetMachineId")
+          eventType   <- requireString[F, G](triggerMap, ReservedKeys.EVENT_NAME, "_triggers", "eventName")
+          payloadValue <- requireField[F, G](triggerMap, ReservedKeys.PAYLOAD, "_triggers", "payload")
+          evaluatedPayload <- evalOrReject[F, G](
+            payloadValue,
+            contextData,
+            GasExhaustionPhase.Trigger,
+            "_triggers",
+            "payload"
           )
         } yield FiberTrigger(
           targetFiberId = targetId,
           input = FiberInput.Transition(eventType, evaluatedPayload),
           sourceFiberId = Some(sourceFiberId)
-        )).value
-      case _ => none[FiberTrigger].pure[G]
+        )
+      case other =>
+        rejectDirective[F, G, FiberTrigger]("_triggers", s"malformed item (expected an object), got $other")
     }
 
   /**
@@ -385,21 +383,22 @@ object EffectExtractor {
     sourceFiberId: UUID
   )(implicit S: Stateful[G, ExecutionState], A: Ask[G, FiberContext], lift: F ~> G): G[Option[FiberTrigger]] =
     extractByKey(effectResult, ReservedKeys.SCRIPT_CALL) match {
+      case None => none[FiberTrigger].pure[G] // absent directive ⇒ no-op (not malformed)
       case Some(MapValue(scriptCallMap)) =>
-        (for {
-          cidStr <- OptionT.fromOption[G](scriptCallMap.get(ReservedKeys.FIBER_ID).collect { case StrValue(id) => id })
-          targetId  <- OptionT.fromOption[G](scala.util.Try(UUID.fromString(cidStr)).toOption)
-          method    <- OptionT.fromOption[G](scriptCallMap.get(ReservedKeys.METHOD).collect { case StrValue(m) => m })
-          argsValue <- OptionT.fromOption[G](scriptCallMap.get(ReservedKeys.ARGS))
-          argsExpr = ExpressionParser.valueToExpression(argsValue)
-          evaluatedArgs <- OptionT(MeteredEvaluator.evalOpt[F, G](argsExpr, contextData, GasExhaustionPhase.Trigger))
+        for {
+          cidStr        <- requireString[F, G](scriptCallMap, ReservedKeys.FIBER_ID, "_scriptCall", "fiberId")
+          targetId      <- requireUuid[F, G](cidStr, "_scriptCall", "fiberId")
+          method        <- requireString[F, G](scriptCallMap, ReservedKeys.METHOD, "_scriptCall", "method")
+          argsValue     <- requireField[F, G](scriptCallMap, ReservedKeys.ARGS, "_scriptCall", "args")
+          evaluatedArgs <- evalOrReject[F, G](argsValue, contextData, GasExhaustionPhase.Trigger, "_scriptCall", "args")
         } yield FiberTrigger(
           targetFiberId = targetId,
           input = FiberInput.Transition(method, evaluatedArgs),
           sourceFiberId = Some(sourceFiberId)
-        )).value
+        ).some
 
-      case _ => none[FiberTrigger].pure[G]
+      case Some(other) =>
+        rejectDirective[F, G, Option[FiberTrigger]]("_scriptCall", s"must be an object, got $other")
     }
 
   /**
@@ -452,52 +451,108 @@ object EffectExtractor {
     value match {
       case MapValue(transferMap) =>
         for {
-          assetIdValue     <- requireField[F, G](transferMap, ReservedKeys.ASSET_ID, "assetId")
-          evaluatedAssetId <- evalOrReject[F, G](assetIdValue, contextData, "assetId")
+          assetIdValue <- requireField[F, G](transferMap, ReservedKeys.ASSET_ID, "_transferAsset", "assetId")
+          evaluatedAssetId <- evalOrReject[F, G](
+            assetIdValue,
+            contextData,
+            GasExhaustionPhase.Morphism,
+            "_transferAsset",
+            "assetId"
+          )
           assetId <- evaluatedAssetId match {
             case StrValue(s) =>
               scala.util.Try(UUID.fromString(s)).toOption match {
                 case Some(uuid) => uuid.pure[G]
-                case None       => rejectTransfer[F, G, UUID](s"assetId is not a valid UUID: '$s'")
+                case None       => rejectDirective[F, G, UUID]("_transferAsset", s"assetId is not a valid UUID: '$s'")
               }
-            case other => rejectTransfer[F, G, UUID](s"assetId must be a UUID string, got $other")
+            case other => rejectDirective[F, G, UUID]("_transferAsset", s"assetId must be a UUID string, got $other")
           }
-          recipientValue     <- requireField[F, G](transferMap, ReservedKeys.RECIPIENT, "recipient")
-          evaluatedRecipient <- evalOrReject[F, G](recipientValue, contextData, "recipient")
+          recipientValue <- requireField[F, G](transferMap, ReservedKeys.RECIPIENT, "_transferAsset", "recipient")
+          evaluatedRecipient <- evalOrReject[F, G](
+            recipientValue,
+            contextData,
+            GasExhaustionPhase.Morphism,
+            "_transferAsset",
+            "recipient"
+          )
           recipient <- evaluatedRecipient match {
             case MapValue(_) =>
               evaluatedRecipient.asJson.as[AssetHolder] match {
                 case Right(holder) => holder.pure[G]
                 case Left(err) =>
-                  rejectTransfer[F, G, AssetHolder](
+                  rejectDirective[F, G, AssetHolder](
+                    "_transferAsset",
                     s"recipient is not a valid AssetHolder object {Fiber|Wallet}: ${err.getMessage}"
                   )
               }
             case other =>
-              rejectTransfer[F, G, AssetHolder](
+              rejectDirective[F, G, AssetHolder](
+                "_transferAsset",
                 s"""recipient must be an AssetHolder object {"Fiber":{"fiberId":..}} / {"Wallet":{"address":..}}, got $other"""
               )
           }
         } yield FiberEffect.AssetTransferred(assetId = assetId, recipient = recipient)
       case other =>
-        rejectTransfer[F, G, FiberEffect.AssetTransferred](s"malformed item (expected an object), got $other")
+        rejectDirective[F, G, FiberEffect.AssetTransferred](
+          "_transferAsset",
+          s"malformed item (expected an object), got $other"
+        )
     }
 
-  /** Look up a required `_transferAsset` field, or raise a graceful [[CombineRejected]] naming what is missing. */
+  // ── Loud directive parsing (audit 2026-07-07, finding L5) ─────────────────────────────────────────────
+  // A MALFORMED reserved directive (wrong type / missing required field / non-UUID / gas-or-eval failure) is
+  // NOT silently dropped — it raises a graceful [[CombineRejected]] naming the directive + what is wrong, the
+  // SAME loud mode `_transferAsset` already uses. Extraction runs ONLY on the combiner apply path
+  // (FiberEvaluator ← FiberEngine.process/migrate & TriggerHandler cascade ← Combiner.insert), so the raise
+  // surfaces as a `RejectionReceipt` (rule #2), NEVER a block-acceptance `Invalid`. An ABSENT directive is a
+  // no-op (empty array ⇒ no items ⇒ no raise); only a PRESENT-but-malformed item is loud — a silently-dropped
+  // trigger/scriptCall/dependency/emit is a latent value-safety bug, not a benign no-op.
+
+  /** Raise a graceful, combiner-caught [[CombineRejected]] for a malformed `directive`. */
+  private def rejectDirective[F[_]: Async, G[_], A](directive: String, reason: String)(implicit lift: F ~> G): G[A] =
+    lift(Async[F].raiseError[A](CombineRejected(s"$directive: $reason")))
+
+  /** Look up a required `directive` field, or raise a graceful [[CombineRejected]] naming what is missing. */
   private def requireField[F[_]: Async, G[_]: Monad](
-    map:   Map[String, JsonLogicValue],
-    key:   String,
-    label: String
+    map:       Map[String, JsonLogicValue],
+    key:       String,
+    directive: String,
+    label:     String
   )(implicit lift: F ~> G): G[JsonLogicValue] =
     map.get(key) match {
       case Some(v) => v.pure[G]
-      case None    => rejectTransfer[F, G, JsonLogicValue](s"missing $label")
+      case None    => rejectDirective[F, G, JsonLogicValue](directive, s"missing $label")
     }
 
-  /** Evaluate a `_transferAsset` sub-expression under the Morphism gas phase; a `Left` (gas/eval failure) is LOUD. */
+  /** A required string `directive` field, or a graceful [[CombineRejected]] (missing / not a string). */
+  private def requireString[F[_]: Async, G[_]: Monad](
+    map:       Map[String, JsonLogicValue],
+    key:       String,
+    directive: String,
+    label:     String
+  )(implicit lift: F ~> G): G[String] =
+    requireField[F, G](map, key, directive, label).flatMap {
+      case StrValue(s) => s.pure[G]
+      case other       => rejectDirective[F, G, String](directive, s"$label must be a string, got $other")
+    }
+
+  /** Parse a required UUID, or raise a graceful [[CombineRejected]] naming the offending value. */
+  private def requireUuid[F[_]: Async, G[_]: Monad](
+    raw:       String,
+    directive: String,
+    label:     String
+  )(implicit lift: F ~> G): G[UUID] =
+    scala.util.Try(UUID.fromString(raw)).toOption match {
+      case Some(u) => u.pure[G]
+      case None    => rejectDirective[F, G, UUID](directive, s"$label is not a valid UUID: '$raw'")
+    }
+
+  /** Evaluate a directive sub-expression under `phase`; a `Left` (gas/eval failure) is LOUD (rejects). */
   private def evalOrReject[F[_]: Async, G[_]: Monad](
     value:       JsonLogicValue,
     contextData: JsonLogicValue,
+    phase:       GasExhaustionPhase,
+    directive:   String,
     label:       String
   )(implicit
     S:    Stateful[G, ExecutionState],
@@ -505,15 +560,11 @@ object EffectExtractor {
     lift: F ~> G
   ): G[JsonLogicValue] =
     MeteredEvaluator
-      .eval[F, G](ExpressionParser.valueToExpression(value), contextData, GasExhaustionPhase.Morphism)
+      .eval[F, G](ExpressionParser.valueToExpression(value), contextData, phase)
       .flatMap {
         case Right(v)     => v.pure[G]
-        case Left(reason) => rejectTransfer[F, G, JsonLogicValue](s"$label did not evaluate: $reason")
+        case Left(reason) => rejectDirective[F, G, JsonLogicValue](directive, s"$label did not evaluate: $reason")
       }
-
-  /** Raise a graceful, combiner-caught [[CombineRejected]] for a malformed `_transferAsset` directive. */
-  private def rejectTransfer[F[_]: Async, G[_], A](reason: String)(implicit lift: F ~> G): G[A] =
-    lift(Async[F].raiseError[A](CombineRejected(s"_transferAsset: $reason")))
 
   /**
    * Extract dynamic-dependency mutations (`_addDependency` / `_setDependencyActive`) with gas metering.
@@ -535,59 +586,91 @@ object EffectExtractor {
   ): G[List[FiberEffect.DependencyMutated]] =
     for {
       adds <- extractArrayByKey(effectResult, ReservedKeys.ADD_DEPENDENCY)
-        .flatTraverse(item => parseDependencyMutation[F, G](item, contextData, forcedActive = Some(true)).map(_.toList))
+        .traverse(parseDependencyMutation[F, G](_, contextData, "_addDependency", forcedActive = Some(true)))
       sets <- extractArrayByKey(effectResult, ReservedKeys.SET_DEPENDENCY_ACTIVE)
-        .flatTraverse(item => parseDependencyMutation[F, G](item, contextData, forcedActive = None).map(_.toList))
+        .traverse(parseDependencyMutation[F, G](_, contextData, "_setDependencyActive", forcedActive = None))
     } yield adds ++ sets
 
   private def parseDependencyMutation[F[_]: Async, G[_]: Monad](
     value:        JsonLogicValue,
     contextData:  JsonLogicValue,
+    directive:    String,
     forcedActive: Option[Boolean]
   )(implicit
     S:    Stateful[G, ExecutionState],
     A:    Ask[G, FiberContext],
     lift: F ~> G
-  ): G[Option[FiberEffect.DependencyMutated]] =
+  ): G[FiberEffect.DependencyMutated] =
     value match {
       case MapValue(depMap) =>
-        (for {
-          fiberIdValue <- OptionT.fromOption[G](depMap.get(ReservedKeys.FIBER_ID))
-          fiberIdExpr = ExpressionParser.valueToExpression(fiberIdValue)
+        for {
+          fiberIdValue <- requireField[F, G](depMap, ReservedKeys.FIBER_ID, directive, "fiberId")
           // Charge gas for fiberId resolution under the DependencyMutation phase.
-          evaluatedFiberId <- OptionT(
-            MeteredEvaluator.evalOpt[F, G](fiberIdExpr, contextData, GasExhaustionPhase.DependencyMutation)
+          evaluatedFiberId <- evalOrReject[F, G](
+            fiberIdValue,
+            contextData,
+            GasExhaustionPhase.DependencyMutation,
+            directive,
+            "fiberId"
           )
-          fiberIdStr <- OptionT.fromOption[G](evaluatedFiberId match { case StrValue(s) => Some(s); case _ => None })
-          fiberId    <- OptionT.fromOption[G](scala.util.Try(UUID.fromString(fiberIdStr)).toOption)
-          active <- OptionT.fromOption[G](
-            forcedActive.orElse(depMap.get(ReservedKeys.ACTIVE).collect { case BoolValue(b) => b })
-          )
-        } yield FiberEffect.DependencyMutated(fiberId, active)).value
-      case _ => none[FiberEffect.DependencyMutated].pure[G]
+          fiberIdStr <- evaluatedFiberId match {
+            case StrValue(s) => s.pure[G]
+            case other       => rejectDirective[F, G, String](directive, s"fiberId must be a string, got $other")
+          }
+          fiberId <- requireUuid[F, G](fiberIdStr, directive, "fiberId")
+          active <- forcedActive match {
+            case Some(b) => b.pure[G]
+            case None =>
+              depMap.get(ReservedKeys.ACTIVE) match {
+                case Some(BoolValue(b)) => b.pure[G]
+                case Some(other) => rejectDirective[F, G, Boolean](directive, s"active must be a boolean, got $other")
+                case None        => rejectDirective[F, G, Boolean](directive, "missing active")
+              }
+          }
+        } yield FiberEffect.DependencyMutated(fiberId, active)
+      case other =>
+        rejectDirective[F, G, FiberEffect.DependencyMutated](
+          directive,
+          s"malformed item (expected an object), got $other"
+        )
     }
 
   /**
-   * Fix (1) — `_emit` emitter-stamping. `.zipWithIndex` runs over the RAW `_emit` array BEFORE the
-   * `flatMap`-drop, so `emissionIndex` is the true authoring-time position; a malformed sibling that
-   * `parseEmittedEvent` drops leaves a SPARSE gap (survivors keep their original positions). `emitterFiberId`
-   * is the engine-supplied id of the fiber whose transition ran `_emit` — never user-supplied, so the stamp
-   * cannot be forged from inside a guard/effect expression.
+   * `_emit` emitter-stamping. `.zipWithIndex` runs over the RAW `_emit` array, so `emissionIndex` is the true
+   * authoring-time position. A malformed sibling is now LOUD (audit L5): it raises a graceful [[CombineRejected]]
+   * rather than a silent drop, so the survivors are never sparse (the first malformed item aborts the whole
+   * transition). `emitterFiberId` is the engine-supplied id of the fiber whose transition ran `_emit` — never
+   * user-supplied, so the stamp cannot be forged from inside a guard/effect expression.
    */
-  def extractEmittedEvents(effectResult: JsonLogicValue, emitterFiberId: UUID): List[EmittedEvent] =
-    extractArrayByKey(effectResult, ReservedKeys.EMIT).zipWithIndex.flatMap { case (v, i) =>
-      parseEmittedEvent(v, emitterFiberId, i)
+  def extractEmittedEvents[F[_]: Async, G[_]: Monad](
+    effectResult:   JsonLogicValue,
+    emitterFiberId: UUID
+  )(implicit lift: F ~> G): G[List[EmittedEvent]] =
+    extractArrayByKey(effectResult, ReservedKeys.EMIT).zipWithIndex.traverse { case (v, i) =>
+      parseEmittedEvent[F, G](v, emitterFiberId, i)
     }
 
-  private def parseEmittedEvent(value: JsonLogicValue, emitterFiberId: UUID, emissionIndex: Int): Option[EmittedEvent] =
+  private def parseEmittedEvent[F[_]: Async, G[_]: Monad](
+    value:          JsonLogicValue,
+    emitterFiberId: UUID,
+    emissionIndex:  Int
+  )(implicit lift: F ~> G): G[EmittedEvent] =
     value match {
       case MapValue(m) =>
         for {
-          name <- m.get(ReservedKeys.NAME).collect { case StrValue(n) => n }
-          data <- m.get(ReservedKeys.DATA)
+          name <- m.get(ReservedKeys.NAME) match {
+            case Some(StrValue(n)) => n.pure[G]
+            case Some(other)       => rejectDirective[F, G, String]("_emit", s"name must be a string, got $other")
+            case None              => rejectDirective[F, G, String]("_emit", "missing name")
+          }
+          data <- m.get(ReservedKeys.DATA) match {
+            case Some(d) => d.pure[G]
+            case None    => rejectDirective[F, G, JsonLogicValue]("_emit", "missing data")
+          }
           destination = m.get(ReservedKeys.DESTINATION).collect { case StrValue(d) => d }
         } yield EmittedEvent(name, data, destination, emitterFiberId, emissionIndex)
-      case _ => None
+      case other =>
+        rejectDirective[F, G, EmittedEvent]("_emit", s"malformed item (expected an object), got $other")
     }
 
   def extractSpawnDirectivesFromExpression(effectExpr: JsonLogicExpression): List[SpawnDirective] =

--- a/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/fiber/evaluation/ScriptProcessor.scala
+++ b/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/fiber/evaluation/ScriptProcessor.scala
@@ -62,7 +62,8 @@ object ScriptProcessor {
       sequenceNumber = FiberOrdinal.MinValue,
       owners = owners,
       status = FiberStatus.Active,
-      schemaBinding = binding
+      schemaBinding = binding,
+      upgradePolicy = update.upgradePolicy // L2: pin the upgrade constitution at create
     )
 
     result <- current.withRecord[F](update.fiberId, scriptRecord)

--- a/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/combine/FiberCombiner.scala
+++ b/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/combine/FiberCombiner.scala
@@ -51,6 +51,16 @@ class FiberCombiner[F[_]: Async: SecurityProvider](
     initialDataHash <- update.initialData.computeDigest
     binding         <- resolveBinding(update.schemaRef, update.definition)
 
+    // L6 (audit 2026-07-07): `CreateStateMachine.parentFiberId` is a self-declaration and is deliberately NOT
+    // owner-validated. It was considered for a `child.owners ⊆ parent.owners` floor (mirroring the H1 spawn
+    // path), but that would break the legitimate cross-owner "child observes parent" pattern (a child owned by
+    // B declaring a parent owned by A, to read the parent's state) for NO safety benefit: the traced
+    // consequences of a bogus parent claim are benign — `childFiberIds` is mutated only by `_spawn` (never by
+    // create), no capability is inherited across the link, and `maxGenerations` counting only TIGHTENS. Existence
+    // + active are already checked (`FiberRules.L1.parentFiberExistsInOnChain` / `L0.parentFiberActive`). If a
+    // future capability ever flows parent→child, this is the site to gate it — in the combiner (rule #3), never
+    // the block-acceptance validator.
+
     // #33 runtime conformance gate: if bound to a strict version, the initial state must conform.
     _ <- ConformanceChecker.violationsFor(binding, current.calculated, update.initialData) match {
       case Nil => Async[F].unit

--- a/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/combine/ScriptCombiner.scala
+++ b/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/combine/ScriptCombiner.scala
@@ -13,8 +13,8 @@ import io.constellationnetwork.security.signature.Signed
 import xyz.kd5ujc.schema.fiber._
 import xyz.kd5ujc.schema.registry._
 import xyz.kd5ujc.schema.{CalculatedState, OnChain, Records, Updates}
-import xyz.kd5ujc.shared_data.fiber.FiberEngine
 import xyz.kd5ujc.shared_data.fiber.evaluation.ScriptProcessor
+import xyz.kd5ujc.shared_data.fiber.{FiberEngine, UpgradeGate}
 import xyz.kd5ujc.shared_data.syntax.all._
 
 /**
@@ -39,8 +39,19 @@ class ScriptCombiner[F[_]: Async: SecurityProvider](
     update: Signed[Updates.CreateScript]
   ): CombineResult[F] = for {
     currentOrdinal <- ctx.getCurrentOrdinal
-    binding        <- resolveScriptBinding(update.schemaRef, update.scriptProgram)
-    result         <- ScriptProcessor.createScript(current, update, currentOrdinal, binding)
+    // L2: `appendOnly` gates an additive protobuf-schema delta, which a raw JSON-Logic script has no shape for;
+    // reject it up front so an owner never pins an upgrade guarantee the chain cannot enforce for a script.
+    _ <- update.upgradePolicy match {
+      case Some(UpgradePolicy.AppendOnly) =>
+        Async[F].raiseError[Unit](
+          CombineRejected(
+            "script upgradePolicy 'appendOnly' requires a strict machine schema; not supported for scripts"
+          )
+        )
+      case _ => Async[F].unit
+    }
+    binding <- resolveScriptBinding(update.schemaRef, update.scriptProgram)
+    result  <- ScriptProcessor.createScript(current, update, currentOrdinal, binding)
   } yield result
 
   /**
@@ -139,6 +150,17 @@ class ScriptCombiner[F[_]: Async: SecurityProvider](
         )
       )
       .whenA(scriptRecord.sequenceNumber =!= update.targetSequenceNumber)
+
+    // L2 (audit 2026-07-07): the script's upgrade constitution gates the migration BEFORE any work. Immutable
+    // denies; Governed needs the migration authority's consent (authority pinned in the OLD record, never
+    // re-suppliable on UpgradeScript); Arbitrary/None is today's behaviour. Graceful CombineRejected (rule #2),
+    // reading only the record's own hash-pinned `upgradePolicy` + verified signer addresses — the Governed
+    // `Role` branch reads a registry FIBER's state (owner-set of a role map), never registry-lineage (rule #3).
+    upgraderAddrs <- update.proofs.toList.traverse(_.id.toAddress).map(_.toSet)
+    _ <- UpgradeGate.gateScriptUpgrade(scriptRecord.upgradePolicy, current.calculated, upgraderAddrs) match {
+      case None         => Async[F].unit
+      case Some(reason) => Async[F].raiseError[Unit](CombineRejected(s"script upgrade denied: ${reason.toMessage}"))
+    }
 
     // Must currently be bound, and the upgrade must target the SAME package.
     _ <- scriptRecord.schemaBinding match {

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/EffectDirectiveLoudnessSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/EffectDirectiveLoudnessSuite.scala
@@ -1,0 +1,161 @@
+package xyz.kd5ujc.shared_data
+
+import java.util.UUID
+
+import cats.effect.IO
+
+import io.constellationnetwork.metagraph_sdk.json_logic._
+import io.constellationnetwork.schema.SnapshotOrdinal
+import io.constellationnetwork.security.hash.Hash
+
+import xyz.kd5ujc.schema.fiber._
+import xyz.kd5ujc.shared_data.fiber.core._
+import xyz.kd5ujc.shared_data.fiber.evaluation.EffectExtractor
+import xyz.kd5ujc.shared_data.lifecycle.combine.CombineRejected
+
+import weaver.SimpleIOSuite
+
+/**
+ * L5 (audit 2026-07-07): a MALFORMED reserved directive is LOUD, not silently dropped. `_triggers`,
+ * `_scriptCall`, `_addDependency`/`_setDependencyActive`, and `_emit` now raise a graceful [[CombineRejected]]
+ * on a present-but-malformed item (missing required field / non-UUID / wrong type), the SAME mode
+ * `_transferAsset` already used ([[AssetTransferRecipientObjectFormSuite]]). An ABSENT directive stays a no-op
+ * (empty array ⇒ nothing to reject); only a PRESENT-but-malformed item rejects. Asserts at the
+ * [[EffectExtractor]] boundary, in the same FiberT MTL stack the engine uses.
+ */
+object EffectDirectiveLoudnessSuite extends SimpleIOSuite {
+
+  import xyz.kd5ujc.shared_data.fiber.core.FiberTInstances._
+
+  private val src: UUID = new UUID(0L, 1L)
+  private val target: UUID = new UUID(0L, 2L)
+
+  private def run[A](prog: FiberT[IO, A]): IO[A] =
+    prog
+      .run(
+        FiberContext(
+          SnapshotOrdinal.MinValue,
+          Hash.empty,
+          io.constellationnetwork.schema.epoch
+            .EpochProgress(eu.timepit.refined.types.numeric.NonNegLong.unsafeFrom(0L)),
+          ExecutionLimits(),
+          io.constellationnetwork.metagraph_sdk.json_logic.gas.GasConfig.Default,
+          FiberGasConfig.Default
+        )
+      )
+      .runA(ExecutionState.initial)
+
+  private def rejected[A](io: IO[A]): IO[Boolean] =
+    io.attempt.map(_.left.toOption.exists(_.isInstanceOf[CombineRejected]))
+
+  private def arr(items: JsonLogicValue*): JsonLogicValue = ArrayValue(items.toList)
+
+  // ── _triggers ─────────────────────────────────────────────────────────────────────────────────────
+
+  private def triggersEffect(item: JsonLogicValue): JsonLogicValue =
+    MapValue(Map(ReservedKeys.TRIGGERS -> arr(item)))
+
+  private def runTriggers(effect: JsonLogicValue): IO[List[FiberTrigger]] =
+    run(EffectExtractor.extractTriggerEvents[IO, FiberT[IO, *]](effect, MapValue(Map.empty), src))
+
+  test("_triggers: a well-formed item parses; an absent directive is a no-op") {
+    val good = triggersEffect(
+      MapValue(
+        Map(
+          ReservedKeys.TARGET_MACHINE_ID -> StrValue(target.toString),
+          ReservedKeys.EVENT_NAME        -> StrValue("go"),
+          ReservedKeys.PAYLOAD           -> MapValue(Map.empty)
+        )
+      )
+    )
+    for {
+      parsed <- runTriggers(good)
+      absent <- runTriggers(MapValue(Map.empty))
+    } yield expect(parsed.map(_.targetFiberId) == List(target)) and expect(absent.isEmpty)
+  }
+
+  test("_triggers: a non-UUID targetMachineId is REJECTED (not silently dropped)") {
+    val bad = triggersEffect(
+      MapValue(
+        Map(
+          ReservedKeys.TARGET_MACHINE_ID -> StrValue("not-a-uuid"),
+          ReservedKeys.EVENT_NAME        -> StrValue("go"),
+          ReservedKeys.PAYLOAD           -> MapValue(Map.empty)
+        )
+      )
+    )
+    rejected(runTriggers(bad)).map(expect(_))
+  }
+
+  test("_triggers: a missing eventName is REJECTED") {
+    val bad = triggersEffect(
+      MapValue(
+        Map(ReservedKeys.TARGET_MACHINE_ID -> StrValue(target.toString), ReservedKeys.PAYLOAD -> MapValue(Map.empty))
+      )
+    )
+    rejected(runTriggers(bad)).map(expect(_))
+  }
+
+  // ── _scriptCall ───────────────────────────────────────────────────────────────────────────────────
+
+  private def runScriptCall(effect: JsonLogicValue): IO[Option[FiberTrigger]] =
+    run(EffectExtractor.extractScriptCall[IO, FiberT[IO, *]](effect, MapValue(Map.empty), src))
+
+  test("_scriptCall: absent ⇒ None; present-but-missing-method ⇒ REJECTED") {
+    val bad = MapValue(
+      Map(
+        ReservedKeys.SCRIPT_CALL -> MapValue(
+          Map(ReservedKeys.FIBER_ID -> StrValue(target.toString), ReservedKeys.ARGS -> MapValue(Map.empty))
+        )
+      )
+    )
+    for {
+      absent <- runScriptCall(MapValue(Map.empty))
+      rejBad <- rejected(runScriptCall(bad))
+    } yield expect(absent.isEmpty) and expect(rejBad)
+  }
+
+  // ── _addDependency / _setDependencyActive ───────────────────────────────────────────────────────────
+
+  private def runDeps(effect: JsonLogicValue): IO[List[FiberEffect.DependencyMutated]] =
+    run(EffectExtractor.extractDependencyMutations[IO, FiberT[IO, *]](effect, MapValue(Map.empty)))
+
+  test("_addDependency: a non-UUID fiberId is REJECTED") {
+    val bad =
+      MapValue(Map(ReservedKeys.ADD_DEPENDENCY -> arr(MapValue(Map(ReservedKeys.FIBER_ID -> StrValue("nope"))))))
+    rejected(runDeps(bad)).map(expect(_))
+  }
+
+  test("_setDependencyActive: a missing/non-boolean active is REJECTED; a well-formed _addDependency parses") {
+    val badActive = MapValue(
+      Map(ReservedKeys.SET_DEPENDENCY_ACTIVE -> arr(MapValue(Map(ReservedKeys.FIBER_ID -> StrValue(target.toString)))))
+    )
+    val good = MapValue(
+      Map(ReservedKeys.ADD_DEPENDENCY -> arr(MapValue(Map(ReservedKeys.FIBER_ID -> StrValue(target.toString)))))
+    )
+    for {
+      rej    <- rejected(runDeps(badActive))
+      parsed <- runDeps(good)
+    } yield expect(rej) and expect(parsed == List(FiberEffect.DependencyMutated(target, active = true)))
+  }
+
+  // ── _emit ───────────────────────────────────────────────────────────────────────────────────────────
+
+  private def runEmit(effect: JsonLogicValue): IO[List[EmittedEvent]] =
+    run(EffectExtractor.extractEmittedEvents[IO, FiberT[IO, *]](effect, src))
+
+  test("_emit: a missing name is REJECTED; a well-formed event parses") {
+    val bad = MapValue(Map(ReservedKeys.EMIT -> arr(MapValue(Map(ReservedKeys.DATA -> StrValue("x"))))))
+    val good = MapValue(
+      Map(
+        ReservedKeys.EMIT -> arr(
+          MapValue(Map(ReservedKeys.NAME -> StrValue("evt"), ReservedKeys.DATA -> StrValue("x")))
+        )
+      )
+    )
+    for {
+      rej    <- rejected(runEmit(bad))
+      parsed <- runEmit(good)
+    } yield expect(rej) and expect(parsed.map(_.name) == List("evt"))
+  }
+}

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/PublishVersionSigningCanonicalSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/PublishVersionSigningCanonicalSuite.scala
@@ -3,9 +3,17 @@ package xyz.kd5ujc.shared_data
 import cats.data.Validated.{Invalid, Valid}
 import cats.effect.IO
 
+import io.constellationnetwork.metagraph_sdk.json_logic.{BoolValue, ConstExpression}
+
 import xyz.kd5ujc.schema.Updates
 import xyz.kd5ujc.schema.Updates.OttochainMessage
-import xyz.kd5ujc.schema.fiber.{FiberPolicy, StateMachineDefinition, TransitionPolicy}
+import xyz.kd5ujc.schema.fiber.{
+  AccessControlPolicy,
+  FiberPolicy,
+  StateMachineDefinition,
+  TransitionPolicy,
+  UpgradePolicy
+}
 import xyz.kd5ujc.shared_data.lifecycle.validate.RegistryValidator
 
 import io.circe.parser.{decode, parse}
@@ -136,6 +144,36 @@ object PublishVersionSigningCanonicalSuite extends SimpleIOSuite {
       expect(dropNulls(encoded).noSpaces.contains("\"transitionPolicy\":\"Owners\"")) and
       // a SET dial does NOT collapse to Unconstrained — the `policy` key is present
       expect(dropNulls(encoded).noSpaces.contains("\"policy\""))
+    )
+  }
+
+  // ── L2 script upgradePolicy — the same rule #1 omit-safe guard on a NEW signed-message surface (CreateScript).
+  // The field is `Option[UpgradePolicy]`: an ABSENT dial encodes byte-identically to the pre-change canonical
+  // (None → null → stripped by dropNulls, so a pre-L2 client and the chain agree); a SET dial round-trips
+  // through its bare string tag. Without this, a client that omits it would InvalidSignature on every CreateScript.
+
+  private val scriptNoPolicy: Updates.CreateScript =
+    Updates.CreateScript(
+      fiberId = new java.util.UUID(0L, 7L),
+      scriptProgram = ConstExpression(BoolValue(true)),
+      initialState = None,
+      accessControl = AccessControlPolicy.Public
+    )
+
+  test("absent script upgradePolicy: decode->encode injects nothing (omit-safe canonical)") {
+    val encoded = (scriptNoPolicy: Updates.CreateScript).asJson
+    IO.pure(
+      expect(decode[Updates.CreateScript](encoded.noSpaces) == Right(scriptNoPolicy)) and
+      expect(!dropNulls(encoded).noSpaces.contains("upgradePolicy"))
+    )
+  }
+
+  test("set script upgradePolicy = Immutable round-trips and emits its bare string tag") {
+    val withPolicy = scriptNoPolicy.copy(upgradePolicy = Some(UpgradePolicy.Immutable))
+    val encoded = withPolicy.asJson
+    IO.pure(
+      expect(decode[Updates.CreateScript](encoded.noSpaces) == Right(withPolicy)) and
+      expect(dropNulls(encoded).noSpaces.contains("\"upgradePolicy\":\"immutable\""))
     )
   }
 }

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/RollbackCompensationSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/RollbackCompensationSuite.scala
@@ -16,6 +16,7 @@ import io.constellationnetwork.security.SecurityProvider
 import xyz.kd5ujc.schema.fiber.{FiberOrdinal, _}
 import xyz.kd5ujc.schema.{CalculatedState, Records}
 import xyz.kd5ujc.shared_data.fiber.FiberEngine
+import xyz.kd5ujc.shared_data.lifecycle.combine.CombineRejected
 import xyz.kd5ujc.shared_test.TestFixture
 
 import weaver.SimpleIOSuite
@@ -412,10 +413,21 @@ object RollbackCompensationSuite extends SimpleIOSuite {
         limits = ExecutionLimits(maxDepth = 10, maxGas = 100_000L)
         orchestrator = FiberEngine.make[IO](calculatedState, ordinal, limits)
 
-        result <- orchestrator.process(parentId, input, List.empty)
+        // The `_triggers` directive here is MALFORMED — `targetMachineId "child-1"` is not a UUID. Since audit
+        // L5 that is LOUD: extraction raises a graceful `CombineRejected` instead of silently dropping the
+        // trigger, so `process` surfaces the rejection (in production it is caught at `Combiner.insert` →
+        // RejectionReceipt). Either way it is a ROLLBACK — nothing is applied and the source `calculatedState`
+        // is never mutated in place. (The `_spawn` here is independently inert: it uses the wrong
+        // `initializerData` key, so no child is produced regardless.)
+        result <- orchestrator.process(parentId, input, List.empty).attempt
 
       } yield result match {
-        case TransactionResult.Aborted(_, _, _) =>
+        case Left(err) =>
+          // Loud malformed-directive rejection = full rollback: the parent is untouched, no child created.
+          expect(err.isInstanceOf[CombineRejected]) and
+          expect(calculatedState.stateMachines.get(parentId).exists(_.currentState == StateId("ready"))) and
+          expect(calculatedState.stateMachines.size == 1)
+        case Right(TransactionResult.Aborted(_, _, _)) =>
           // Parent should remain unchanged
           expect(
             calculatedState.stateMachines.get(parentId).exists(_.currentState == StateId("ready"))
@@ -423,7 +435,7 @@ object RollbackCompensationSuite extends SimpleIOSuite {
           expect(calculatedState.stateMachines.get(parentId).exists(_.sequenceNumber == FiberOrdinal.MinValue)) and
           // No children should exist
           expect(calculatedState.stateMachines.size == 1)
-        case TransactionResult.Committed(machines, _, _, _, _, _, _) =>
+        case Right(TransactionResult.Committed(machines, _, _, _, _, _, _)) =>
           // If it committed, the child's trigger might have been handled differently
           // Document the actual behavior
           expect(machines.contains(parentId))

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/UpgradeGateSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/UpgradeGateSuite.scala
@@ -315,4 +315,35 @@ object UpgradeGateSuite extends FunSuite {
       )
     expect(isPolicyViolation(r, "tighten"))
   }
+
+  // ── gateScriptUpgrade (L2) — scripts have no MachineShape, so only the owner-constitution tiers apply ──
+
+  test("gateScriptUpgrade: absent policy (≡ Arbitrary) and explicit Arbitrary both admit") {
+    expect(UpgradeGate.gateScriptUpgrade(None, stateOf(), Set(alice)).isEmpty) and
+    expect(UpgradeGate.gateScriptUpgrade(Some(UpgradePolicy.Arbitrary), stateOf(), Set(alice)).isEmpty)
+  }
+
+  test("gateScriptUpgrade: Immutable denies ALL script upgrades") {
+    expect(
+      isPolicyViolation(
+        UpgradeGate.gateScriptUpgrade(Some(UpgradePolicy.Immutable), stateOf(), Set(alice)),
+        "upgradePolicy"
+      )
+    )
+  }
+
+  test("gateScriptUpgrade: Governed.Signers admits an authorized signer, denies a stranger") {
+    val pol = UpgradePolicy.Governed(MigrationAuthority.Signers(Set(alice)))
+    expect(UpgradeGate.gateScriptUpgrade(Some(pol), stateOf(), Set(alice)).isEmpty) and
+    expect(isPolicyViolation(UpgradeGate.gateScriptUpgrade(Some(pol), stateOf(), Set(bob)), "upgradePolicy"))
+  }
+
+  test("gateScriptUpgrade: AppendOnly is unsupported for scripts (fail-closed deny)") {
+    expect(
+      isPolicyViolation(
+        UpgradeGate.gateScriptUpgrade(Some(UpgradePolicy.AppendOnly), stateOf(), Set(alice)),
+        "upgradePolicy"
+      )
+    )
+  }
 }


### PR DESCRIPTION
Closes out the deferred lower-severity findings from the [fiber-engine permissionless-safety audit](docs/audit/fiber-engine-permissionless-safety-audit-2026-07-07.md) (L2–L6). While auditing the current code I found the "at-a-glance" table was stale, so the real scope differed from the doc:

| # | Finding | Disposition |
|---|---------|-------------|
| **L2** | Scripts have no upgrade policy/gate | **Implemented** — script `UpgradeGate` |
| **L3** | `maxGenerations` resets across a migration | **Documented** (behavioural fix would be breaking) |
| **L4** | `owners.headOption` picks an arbitrary owner | **Already done** on main (folded into the #201 H1 pass) — no change |
| **L5** | Malformed effect directives silently dropped | **Completed** (`_transferAsset` was already loud; the rest now are too) |
| **L6** | `parentFiberId` not owner-validated | **Documented** — an ownership check breaks legit cross-owner "child observes parent" for zero safety gain |

## L2 — script upgrade policy (feat)
Adds an omit-safe `upgradePolicy: Option[UpgradePolicy]` to `CreateScript` + `ScriptFiberRecord`, mirroring the state-machine constitution. **Fixed at create**, read from the OLD record at `UpgradeScript` (never re-suppliable → the self-authorizing-authority hole is closed by construction). Enforced by `UpgradeGate.gateScriptUpgrade`, reusing the state-machine `Governed` authority resolver:
- `Arbitrary`/absent → admit (today's behaviour; **the default, so existing scripts are unchanged**)
- `Immutable` → deny all upgrades
- `Governed(authority)` → require the authority's consent (`Signers`/`Role`)
- `AppendOnly` → unsupported for scripts (no strict machine shape); rejected at create, fail-closed at the gate.

Combiner gate = graceful `CombineRejected`, reading only the record's own hash-pinned policy + verified signers (no registry lineage, rule #3).

## L5 — loud malformed directives (fix / mild tightening)
`_triggers` / `_scriptCall` / `_emit` / `_addDependency` / `_setDependencyActive` now raise a graceful `CombineRejected` on a **present-but-malformed** item (matching `_transferAsset`), instead of silently dropping it while the transition commits as success. Absent directive = still a no-op. Safe because extraction runs only on the combiner apply path (→ `RejectionReceipt`, never a block-acceptance `Invalid`). **You green-lit this pre-launch tightening.**

## L3 / L6 — documentation
Both would need breaking behavioural changes for no real safety gain, so they're resolved as in-code docs: L3 says pair `maxGenerations` with `upgradePolicy = Immutable` for an absolute cap; L6 explains `parentFiberId` is a benign self-declaration and where to gate if a parent→child capability is ever added.

## Verification
- Full `sharedData` suite: **641 passed** / 0 failed (628 baseline + 13 new).
- `models` + full `Test/compile` green; `scalafmtCheckAll` clean.
- New: `EffectDirectiveLoudnessSuite` (L5, all four directive families), `gateScriptUpgrade` branches in `UpgradeGateSuite`, `CreateScript` omit-safe canonical in `PublishVersionSigningCanonicalSuite`.
- Regenerated `openapi-ml0` contracts (additive: `upgradePolicy` + `UpgradePolicy` schema) so the Code Quality gate stays green.

## Follow-ups (not in this PR)
- A full script-upgrade **integration** lane (publish v1→v2, create Immutable script, assert `UpgradeScript` rejects). The gate is unit-tested and the combiner wiring is type-checked; an end-to-end harness would be additive.
- L3 migration-surviving lineage anchor (only if `Immutable` proves insufficient in practice).

🤖 Generated with [Claude Code](https://claude.com/claude-code)