### PR TITLE
feat(onchain): per-batch delta OnChain + CommitIndex recreation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,9 @@ See `docs/signing-canonical-and-validation.md` for the full rationale. The two r
    `CombineRejected` → `RejectionReceipt`, the authoritative deterministic gate). tessellation
    block acceptance is all-or-nothing, so a stateful Invalid on one tx drops the whole block.
    Registry stateful checks are combine-only (L1 can't see the version lineage); fiber stateful
-   checks stay at L1 (`OnChain.fiberCommits` has the seqNum).
+   checks stay at L1 (the recreated `CommitIndex` has the seqNum — OnChain v2 carries only
+   per-batch `touched*` deltas; the cumulative commit maps live in `CalculatedState` and the DL1
+   folds/heals them, see docs/proposals/onchain-incrementals.md).
 
 3. **`validateSignedUpdate` (block acceptance) must NEVER read `CalculatedState.registry` lineage.**
    Any validator that calls `lineageOf` / `refResolvesAndMatches` / `versionAppendable` inside
@@ -23,5 +25,8 @@ See `docs/signing-canonical-and-validation.md` for the full rationale. The two r
    returns `Invalid` → the entire block is dropped for ALL transactions in the snapshot.
    Rule: registry lineage checks belong ONLY in the combiner as graceful `CombineRejected`.
    `validateSignedUpdate` for fiber upgrade/create ops: structural checks only (field presence,
-   expression depth, sequence number against `OnChain`). Guarded by this comment — review every
-   new L0Validator method that takes a `SchemaRef` or `SchemaBinding` parameter.
+   expression depth, sequence number against the `CommitIndex`). Reading the RELOCATED commit
+   maps (`CalculatedState.fiberCommits/assetCommits` via `CommitIndex.fromCalculated`) is NOT a
+   violation — same safe triple as v1 `OnChain`, merely moved; the rule bars *lineage* reads.
+   Guarded by this comment — review every new L0Validator method that takes a `SchemaRef` or
+   `SchemaBinding` parameter.

--- a/docs/openapi-dl1.json
+++ b/docs/openapi-dl1.json
@@ -151,23 +151,31 @@
         "title" : "OnChain",
         "type" : "object",
         "required" : [
-          "fiberCommits",
+          "touchedFiberCommits",
           "latestLogs",
-          "registryCommits",
-          "assetCommits"
+          "touchedRegistryCommits",
+          "touchedAssetCommits"
         ],
         "properties" : {
-          "fiberCommits" : {
+          "touchedFiberCommits" : {
             "$ref" : "#/components/schemas/Map_V"
           },
           "latestLogs" : {
             "$ref" : "#/components/schemas/Map_V"
           },
-          "registryCommits" : {
+          "touchedRegistryCommits" : {
             "$ref" : "#/components/schemas/Map_V"
           },
-          "assetCommits" : {
+          "touchedAssetCommits" : {
             "$ref" : "#/components/schemas/Map_V"
+          },
+          "burnedAssets" : {
+            "type" : "array",
+            "uniqueItems" : true,
+            "items" : {
+              "type" : "string",
+              "format" : "uuid"
+            }
           }
         }
       },

--- a/docs/openapi-dl1.json
+++ b/docs/openapi-dl1.json
@@ -76,7 +76,7 @@
           "state",
           "dl1"
         ],
-        "summary" : "Current on-chain state",
+        "summary" : "Current on-chain state (OnChain v2: this batch's delta — cumulative view is /commit-index)",
         "operationId" : "getData-applicationV1Onchain",
         "responses" : {
           "200" : {
@@ -85,6 +85,28 @@
               "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/OnChain"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/data-application/v1/commit-index" : {
+      "get" : {
+        "tags" : [
+          "state",
+          "dl1"
+        ],
+        "summary" : "This node's folded/healed cumulative commit maps — the DL1-sync surface (reading it drives the same refresh the ingestion gate uses)",
+        "operationId" : "getData-applicationV1Commit-index",
+        "responses" : {
+          "200" : {
+            "description" : "",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/CommitIndexResponse"
                 }
               }
             }
@@ -117,6 +139,43 @@
           },
           "origin" : {
             "type" : "string"
+          }
+        }
+      },
+      "CommitIndex" : {
+        "title" : "CommitIndex",
+        "type" : "object",
+        "required" : [
+          "fiberCommits",
+          "assetCommits",
+          "registryCommits"
+        ],
+        "properties" : {
+          "fiberCommits" : {
+            "$ref" : "#/components/schemas/Map_V"
+          },
+          "assetCommits" : {
+            "$ref" : "#/components/schemas/Map_V"
+          },
+          "registryCommits" : {
+            "$ref" : "#/components/schemas/Map_V"
+          }
+        }
+      },
+      "CommitIndexResponse" : {
+        "title" : "CommitIndexResponse",
+        "type" : "object",
+        "required" : [
+          "ordinal",
+          "index"
+        ],
+        "properties" : {
+          "ordinal" : {
+            "type" : "integer",
+            "format" : "int64"
+          },
+          "index" : {
+            "$ref" : "#/components/schemas/CommitIndex"
           }
         }
       },

--- a/docs/openapi-dl1.yaml
+++ b/docs/openapi-dl1.yaml
@@ -48,7 +48,8 @@ paths:
       tags:
       - state
       - dl1
-      summary: Current on-chain state
+      summary: 'Current on-chain state (OnChain v2: this batch''s delta — cumulative
+        view is /commit-index)'
       operationId: getData-applicationV1Onchain
       responses:
         '200':
@@ -57,6 +58,21 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/OnChain'
+  /data-application/v1/commit-index:
+    get:
+      tags:
+      - state
+      - dl1
+      summary: This node's folded/healed cumulative commit maps — the DL1-sync surface
+        (reading it drives the same refresh the ingestion gate uses)
+      operationId: getData-applicationV1Commit-index
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CommitIndexResponse'
 components:
   schemas:
     AssetCommit:
@@ -77,6 +93,32 @@ components:
           type: string
         origin:
           type: string
+    CommitIndex:
+      title: CommitIndex
+      type: object
+      required:
+      - fiberCommits
+      - assetCommits
+      - registryCommits
+      properties:
+        fiberCommits:
+          $ref: '#/components/schemas/Map_V'
+        assetCommits:
+          $ref: '#/components/schemas/Map_V'
+        registryCommits:
+          $ref: '#/components/schemas/Map_V'
+    CommitIndexResponse:
+      title: CommitIndexResponse
+      type: object
+      required:
+      - ordinal
+      - index
+      properties:
+        ordinal:
+          type: integer
+          format: int64
+        index:
+          $ref: '#/components/schemas/CommitIndex'
     FiberCommit:
       title: FiberCommit
       type: object

--- a/docs/openapi-dl1.yaml
+++ b/docs/openapi-dl1.yaml
@@ -100,19 +100,25 @@ components:
       title: OnChain
       type: object
       required:
-      - fiberCommits
+      - touchedFiberCommits
       - latestLogs
-      - registryCommits
-      - assetCommits
+      - touchedRegistryCommits
+      - touchedAssetCommits
       properties:
-        fiberCommits:
+        touchedFiberCommits:
           $ref: '#/components/schemas/Map_V'
         latestLogs:
           $ref: '#/components/schemas/Map_V'
-        registryCommits:
+        touchedRegistryCommits:
           $ref: '#/components/schemas/Map_V'
-        assetCommits:
+        touchedAssetCommits:
           $ref: '#/components/schemas/Map_V'
+        burnedAssets:
+          type: array
+          uniqueItems: true
+          items:
+            type: string
+            format: uuid
     VersionInfo:
       title: VersionInfo
       type: object

--- a/docs/openapi-ml0.json
+++ b/docs/openapi-ml0.json
@@ -114,6 +114,28 @@
         }
       }
     },
+    "/data-application/v1/commit-index" : {
+      "get" : {
+        "tags" : [
+          "state",
+          "ml0"
+        ],
+        "summary" : "Full recreated commit maps at the last committed ordinal (OnChain v2 carries per-batch deltas only; this is the cumulative view — v1-onchain back-compat + the DL1 heal source)",
+        "operationId" : "getData-applicationV1Commit-index",
+        "responses" : {
+          "200" : {
+            "description" : "",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/CommitIndexResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/data-application/v1/state-machines" : {
       "get" : {
         "tags" : [
@@ -968,7 +990,10 @@
           "registry",
           "reverseNames",
           "assets",
-          "usedNonces"
+          "usedNonces",
+          "fiberCommits",
+          "assetCommits",
+          "registryCommits"
         ],
         "properties" : {
           "stateMachines" : {
@@ -988,6 +1013,15 @@
           },
           "usedNonces" : {
             "$ref" : "#/components/schemas/Map_V"
+          },
+          "fiberCommits" : {
+            "$ref" : "#/components/schemas/Map_V"
+          },
+          "assetCommits" : {
+            "$ref" : "#/components/schemas/Map_V"
+          },
+          "registryCommits" : {
+            "$ref" : "#/components/schemas/Map_V"
           }
         }
       },
@@ -1005,6 +1039,43 @@
           },
           "state" : {
             "$ref" : "#/components/schemas/CalculatedState"
+          }
+        }
+      },
+      "CommitIndex" : {
+        "title" : "CommitIndex",
+        "type" : "object",
+        "required" : [
+          "fiberCommits",
+          "assetCommits",
+          "registryCommits"
+        ],
+        "properties" : {
+          "fiberCommits" : {
+            "$ref" : "#/components/schemas/Map_V"
+          },
+          "assetCommits" : {
+            "$ref" : "#/components/schemas/Map_V"
+          },
+          "registryCommits" : {
+            "$ref" : "#/components/schemas/Map_V"
+          }
+        }
+      },
+      "CommitIndexResponse" : {
+        "title" : "CommitIndexResponse",
+        "type" : "object",
+        "required" : [
+          "ordinal",
+          "index"
+        ],
+        "properties" : {
+          "ordinal" : {
+            "type" : "integer",
+            "format" : "int64"
+          },
+          "index" : {
+            "$ref" : "#/components/schemas/CommitIndex"
           }
         }
       },
@@ -1179,23 +1250,31 @@
         "title" : "OnChain",
         "type" : "object",
         "required" : [
-          "fiberCommits",
+          "touchedFiberCommits",
           "latestLogs",
-          "registryCommits",
-          "assetCommits"
+          "touchedRegistryCommits",
+          "touchedAssetCommits"
         ],
         "properties" : {
-          "fiberCommits" : {
+          "touchedFiberCommits" : {
             "$ref" : "#/components/schemas/Map_V"
           },
           "latestLogs" : {
             "$ref" : "#/components/schemas/Map_V"
           },
-          "registryCommits" : {
+          "touchedRegistryCommits" : {
             "$ref" : "#/components/schemas/Map_V"
           },
-          "assetCommits" : {
+          "touchedAssetCommits" : {
             "$ref" : "#/components/schemas/Map_V"
+          },
+          "burnedAssets" : {
+            "type" : "array",
+            "uniqueItems" : true,
+            "items" : {
+              "type" : "string",
+              "format" : "uuid"
+            }
           }
         }
       },

--- a/docs/openapi-ml0.yaml
+++ b/docs/openapi-ml0.yaml
@@ -71,6 +71,22 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Checkpoint_CalculatedState'
+  /data-application/v1/commit-index:
+    get:
+      tags:
+      - state
+      - ml0
+      summary: Full recreated commit maps at the last committed ordinal (OnChain v2
+        carries per-batch deltas only; this is the cumulative view — v1-onchain back-compat
+        + the DL1 heal source)
+      operationId: getData-applicationV1Commit-index
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CommitIndexResponse'
   /data-application/v1/state-machines:
     get:
       tags:
@@ -629,6 +645,9 @@ components:
       - reverseNames
       - assets
       - usedNonces
+      - fiberCommits
+      - assetCommits
+      - registryCommits
       properties:
         stateMachines:
           $ref: '#/components/schemas/Map_V'
@@ -642,6 +661,12 @@ components:
           $ref: '#/components/schemas/Map_V'
         usedNonces:
           $ref: '#/components/schemas/Map_V'
+        fiberCommits:
+          $ref: '#/components/schemas/Map_V'
+        assetCommits:
+          $ref: '#/components/schemas/Map_V'
+        registryCommits:
+          $ref: '#/components/schemas/Map_V'
     Checkpoint_CalculatedState:
       title: Checkpoint_CalculatedState
       type: object
@@ -654,6 +679,32 @@ components:
           format: int64
         state:
           $ref: '#/components/schemas/CalculatedState'
+    CommitIndex:
+      title: CommitIndex
+      type: object
+      required:
+      - fiberCommits
+      - assetCommits
+      - registryCommits
+      properties:
+        fiberCommits:
+          $ref: '#/components/schemas/Map_V'
+        assetCommits:
+          $ref: '#/components/schemas/Map_V'
+        registryCommits:
+          $ref: '#/components/schemas/Map_V'
+    CommitIndexResponse:
+      title: CommitIndexResponse
+      type: object
+      required:
+      - ordinal
+      - index
+      properties:
+        ordinal:
+          type: integer
+          format: int64
+        index:
+          $ref: '#/components/schemas/CommitIndex'
     DynamicDependency:
       title: DynamicDependency
       type: object
@@ -775,19 +826,25 @@ components:
       title: OnChain
       type: object
       required:
-      - fiberCommits
+      - touchedFiberCommits
       - latestLogs
-      - registryCommits
-      - assetCommits
+      - touchedRegistryCommits
+      - touchedAssetCommits
       properties:
-        fiberCommits:
+        touchedFiberCommits:
           $ref: '#/components/schemas/Map_V'
         latestLogs:
           $ref: '#/components/schemas/Map_V'
-        registryCommits:
+        touchedRegistryCommits:
           $ref: '#/components/schemas/Map_V'
-        assetCommits:
+        touchedAssetCommits:
           $ref: '#/components/schemas/Map_V'
+        burnedAssets:
+          type: array
+          uniqueItems: true
+          items:
+            type: string
+            format: uuid
     OriginProvenance:
       title: OriginProvenance
       type: object

--- a/docs/proposals/onchain-incrementals.md
+++ b/docs/proposals/onchain-incrementals.md
@@ -1,0 +1,266 @@
+# OnChain incrementals — per-batch deltas + server-side recreation
+
+**Status:** draft / RFC. Date: 2026-07-11. Branch: `feat/onchain-incrementals`.
+**Goal:** remove the unbounded cumulative maps from the `OnChain` wire format so the metagraph
+cannot hit the tessellation 512KB state-channel snapshot cap, while preserving the DL1
+structural gate and every existing verification property. BREAKING wire change — ships in the
+0.8.0 window alongside the SDK alignment sequence.
+
+Reads with: `committed-state-migration.md` (the committed MPT/SMT substrate this builds on),
+`sharded-ml0-and-commitments.md` §2 (the "OnChain = commitments, CalculatedState = how to
+rebuild them" framing this realizes), `asset-model.md` §6 (why the L1 fast-path commit exists),
+`economics-and-state-rent.md` (the orthogonal node-storage answer).
+
+---
+
+## 1. The forcing constraint (verified, measured)
+
+tessellation caps the **whole state-channel snapshot binary** at
+`max-state-channel-snapshot-binary-size-in-bytes = 512000`
+(node-shared `application.conf`, develop:52 + release/mainnet:39). Enforcement is in
+`CurrencySnapshotCreator.createProposalArtifact`:
+
+```
+maxArtifactSize = 512000 − facilitators × singleSignatureSizeInBytes
+artifactSize    = |serialize(CurrencyIncrementalSnapshot)|   // includes dataApplication.onChainState
+```
+
+When a proposal exceeds the budget, `currencyEventsCutter.cut` drops **events** (data blocks,
+messages) and retries. But the cumulative `OnChain` maps are not events — they ride in
+`dataApplicationPart.onChainState` verbatim in **every** incremental. Once
+`fiberCommits + assetCommits + registryCommits` alone exceed the budget, cutting can never
+converge and the round raises `UnableToReduceProposalByCutting`: **the metagraph can never
+produce another snapshot. Permanent halt, no recovery path** (state can only grow; nothing is
+ever pruned — archive is a status flip).
+
+Measured marginal wire costs via the production path (`CommittedOnChain[OnChain].toBinary`,
+pinned by `OnChainWireSizeSuite` in shared-data):
+
+| Entry | Marginal cost | Ceiling (alone) |
+|---|---|---|
+| `FiberCommit` | 226 B | **~2,265 fibers** |
+| `AssetCommit` | 157 B | ~3,261 assets |
+| registry commit | 94 B | ~5,446 entries |
+
+A modest mixed economy — 1,500 fibers + 750 assets + 50 registry entries — already serializes
+to 461,676 B = **90.2% of the budget**. The ceiling binds long before any interesting scale.
+
+## 2. What OnChain is actually for (consumption audit)
+
+| Field | Growth | Consumers |
+|---|---|---|
+| `fiberCommits` | cumulative, never pruned | DL1 seq `<=` gate + parent-existence (`FiberRules.scala:196-233`); ML0 gate; `/v1/onchain` |
+| `assetCommits` | cumulative − burns | DL1/ML0 asset structural gate (behavior bitmask + seq, `AssetRules.scala:39,54`) |
+| `registryCommits` | cumulative | audit/lookup only — no validator reads it |
+| `latestLogs` | **per-batch already** (cleared each combine, `ML0Service.scala:107`) | `/events`, `/invocations` routes; webhooks |
+
+Two observations drive the design:
+
+1. **Only the per-fiber/per-asset *triple* is load-bearing at L1** — `{recordHash,
+   stateDataHash, seqNum}` and `{behavior, seq, recordHash, origin}`. The gate is
+   batching-tolerant (`<=`), fails open for unknown ids (create case), and is a best-effort
+   spam filter — the combiner remains the authoritative gate (invariant #2/#3).
+2. **Since #164, the chain already commits all of CalculatedState** behind
+   `sha256(mptRoot ++ catalogRoot)` = `calculatedStateProof` in the *signed* snapshot, with the
+   constant-size breadcrumb `(ordinal, mptRoot, catalogRoot)` riding in the `CommittedOnChain`
+   wrapper. There is a consensus-signed anchor available to verify *any* recreated state
+   against. `sharded-ml0-and-commitments.md` §2 asked for "OnChain = succinct commitments";
+   the commitment part already shipped — what remains is removing the flat cumulative maps.
+
+## 3. Design
+
+### 3.1 The move: cumulative maps become CalculatedState; OnChain carries the batch delta
+
+**CalculatedState** (never wire-shipped — only its root is) gains the commit maps:
+
+```scala
+case class CalculatedState(
+  stateMachines: SortedMap[UUID, StateMachineFiberRecord],
+  scripts:       SortedMap[UUID, ScriptFiberRecord],
+  registry:      SortedMap[RegistryName, RegistryEntry],
+  reverseNames:  SortedMap[UUID, RegistryName],
+  assets:        SortedMap[UUID, AssetRecord],
+  usedNonces:    SortedMap[UUID, SortedSet[Long]],
+  fiberCommits:    SortedMap[UUID, FiberCommit]     = SortedMap.empty,  // moved from OnChain
+  assetCommits:    SortedMap[UUID, AssetCommit]     = SortedMap.empty,  // moved from OnChain
+  registryCommits: SortedMap[RegistryName, Hash]    = SortedMap.empty   // moved from OnChain
+)
+```
+
+`CommittedView[CalculatedState]` projects them as new namespaces so every commit triple is a
+leaf under the consensus-signed `mptRoot`:
+
+```
+commit/f/<uuid>  ← FiberCommit        commit/a/<uuid>  ← AssetCommit
+commit/r/<name>  ← registry Hash      (over-long names: commit/r/h/<sha256hex>, as registry/)
+```
+
+The triples cannot diverge from the records: the same `DataStateOps` write that updates the
+record updates the commit map, in the same combine fold, from the same hash — the projection
+just moves which struct holds it. (The triple is *not* derivable inside `CommittedView.entries`
+because `entries` is pure/total and `recordHash` requires a `Hasher`; hence the explicit map.)
+
+**OnChain v2** carries only what changed in this batch, plus the existing per-batch logs:
+
+```scala
+case class OnChain(
+  touchedFiberCommits:    SortedMap[UUID, FiberCommit],      // this batch's writes (incl. creates)
+  touchedAssetCommits:    SortedMap[UUID, AssetCommit],
+  burnedAssets:           SortedSet[UUID],                   // removals can't be an upsert
+  touchedRegistryCommits: SortedMap[RegistryName, Hash],
+  latestLogs:             SortedMap[UUID, List[FiberLogEntry]] // unchanged (already per-batch)
+) extends DataOnChainState
+```
+
+The `touched*` maps use the **same clear-then-accumulate mechanism `latestLogs` already uses**
+(cleared at the top of `orderedCombiner`'s fold, repopulated by `DataStateOps`) — a proven
+pattern in this codebase, deterministic under ML0's re-combine-until-GL0-finalizes behavior.
+
+**Resulting size property:** snapshot bytes become O(churn per batch), not O(total state).
+Churn *is* events — so when a batch is too large, the framework's events-cutter now genuinely
+converges by deferring data blocks: the hard-halt failure mode becomes graceful backpressure.
+
+### 3.2 ML0: no new machinery
+
+`validateSignedUpdate` already receives `DataState[OnChain, CalculatedState]`. The fiber/asset
+gates (`FiberValidator`, `AssetValidator.L1Validator`) switch from `current.onChain.*Commits`
+to `current.calculated.*Commits` — the identical triple, same freshness (both are the previous
+committed state folded forward). This does NOT touch invariant #3: the TOCTOU rule bars
+*registry lineage* reads (`lineageOf`/`refResolvesAndMatches`/`versionAppendable`) in the block
+gate; the commit maps are the same L1-safe subset as today, merely relocated. No registry
+lineage is consulted.
+
+### 3.3 DL1: `CommitIndexService` (fold + heal)
+
+DL1 cannot see CalculatedState — today it decodes the full cumulative OnChain from the latest
+snapshot per ordinal (`Validator.withOnChainCache:189-221`). v2 replaces that with a node-local
+index:
+
+```scala
+trait CommitIndexService[F[_]] {
+  def current: F[CommitIndex]                    // fiberCommits + assetCommits at some ordinal
+  def advance(ord: SnapshotOrdinal, onChain: OnChain): F[Unit]  // fold touched* + burns
+  def heal(target: SnapshotOrdinal): F[Unit]     // full re-seed, verified against breadcrumb
+}
+```
+
+- **Common path (no extra HTTP):** on each new snapshot, if `snapshot.ordinal ==
+  index.ordinal + 1`, fold `touched*` upserts and `burnedAssets` removals into the index.
+  The decoded snapshot already contains everything needed.
+- **Heal path (restart / skipped ordinal / join):** fetch the full commit index from ML0 and
+  verify it against the **signed** breadcrumb before adopting:
+  1. `GET /v1/commit-index?proof=true` on ML0 → `{ ordinal, roots, entries, batchProof }`
+     where `entries` is the full `commit/` namespace slice (values included) and `batchProof`
+     is the `MerklePatriciaPrefixProver` batch proof over the slice.
+  2. Verify with `MerklePatriciaBatchInclusionVerifier` against `breadcrumb.mptRoot` from the
+     latest signed snapshot: (a) every entry's re-hashed value digest matches its leaf, and
+     (b) **completeness** — the proof covers the entire `commit/` subtree, no omitted keys.
+  3. Adopt as the index at `ordinal`; resume folding.
+- **Gate semantics preserved:** the folded index at the latest contiguous ordinal is
+  content-identical to today's latest-snapshot cumulative map. Staleness behaves exactly like
+  today's per-ordinal cache staleness (the `<=` gate is batching-tolerant by design).
+
+**Completeness is security-load-bearing.** `sequenceNumberMatches` **fails open** for unknown
+ids (`state.fiberCommits.get(id).fold(valid)(...)` — the create case). An index missing
+entries silently accepts what it should filter. Hence: heal MUST verify subtree completeness,
+and `advance` MUST refuse non-contiguous ordinals (heal instead) — never fold onto a gap.
+
+### 3.4 Routes / SDK surface
+
+- `GET /v1/onchain` — serves the v2 (delta) shape on both ML0 and DL1. Consumers that want the
+  full picture use:
+- `GET /v1/commit-index` (new, ML0 + DL1) — the recreated full maps
+  (`fiberCommits`/`assetCommits`/`registryCommits` as today's shapes); `?proof=true` on ML0
+  adds the batch proof for trustless healing. This is the back-compat surface for the SDK/e2e
+  asserts that previously read `/v1/onchain`.
+- Registry lookup stays on the committed-state routes (the registry is already in the MPT);
+  `registryCommits` is retained in CalculatedState for audit parity, not consulted by any gate.
+- Genesis: `GenesisBuilder` seeds the CalculatedState commit maps and emits the seed entries as
+  the genesis snapshot's `touched*` (so a from-genesis replayer folds correctly from ordinal 0).
+
+### 3.5 Rejected alternatives
+
+- **(a) Full `CommittedReplica` on DL1** (metakit rc.7, root-checked `fromSnapshot` +
+  `applyDelta`): works today with zero chain-side changes, but replicates the *entire*
+  CalculatedState trie (records, scripts, registry lineages) onto every DL1 — O(total state)
+  memory/transfer for nodes that need only the commit triples. Kept as the fallback if the
+  commit-namespace slice proves awkward; the `StateDelta` machinery is also the natural
+  transport if DL1 ever needs more than the triples.
+- **(b) Compress `onChainState`** (gzip/binary encoding): buys a ~3-5× constant factor against
+  a *linear* growth curve — delays the halt to ~10k fibers, solves nothing. Viable only as an
+  emergency stopgap on a live network approaching the cap.
+- **(c) Prune/rent instead of restructure:** state rent (`economics-and-state-rent.md`) bounds
+  *node storage* economically but cannot bound the *wire format* — even rent-solvent state
+  exceeds 512KB at trivial scale. Orthogonal; both are eventually needed.
+- **(d) OnChain = roots only** (pure `sharded-ml0` §2 shape): maximally succinct, but then the
+  DL1 common path needs an HTTP fetch + proof verification *per ordinal* (it can no longer
+  fold deltas it already has). The touched-delta shape keeps the common path free and matches
+  the shard seam — per-shard `touched*` partitions are exactly what a `ShardResult` carries
+  later (§6 of that doc).
+
+## 4. Reconciliation with sharded-ml0-and-commitments.md §2
+
+That design predates #164. Its components land as follows: `metagraphStateRoot` → **shipped**
+as the committed `mptRoot` (+ catalog) anchored via `calculatedStateProof`;
+`packageRegistryRoot` → subsumed by the `registry/` namespace under the same root; "OnChain =
+succinct commitments" → realized as breadcrumb roots + per-batch deltas (this RFC);
+`shardRoots`/`commitmentStore` → still future, and this RFC keeps the seam: `touched*` maps
+keyed by UUID partition by `shardIdFor` naturally, and the `commit/` namespace can split into
+per-shard sub-namespaces without another wire break.
+
+## 5. Migration (0.8.0 boundary)
+
+No production mainnet exists; testnets redeploy from genesis. Two supported paths:
+
+1. **Genesis redeploy (default):** 0.8.0 nodes start from a genesis whose CalculatedState
+   carries the commit maps (per §3.4). No decoder for the old shape is kept.
+2. **One-shot migration (if a network must carry state across):** at the upgrade ordinal,
+   decode the final v1 `OnChain`, move `fiberCommits`/`assetCommits`/`registryCommits` into
+   the CalculatedState seed, emit them as the first v2 snapshot's `touched*`. Gated behind a
+   startup flag; deleted after the window.
+
+SDK sequencing rides the existing 0.8.0 alignment train (`project_ottochain_sdk_chain_alignment`):
+chain types → ottochain-sdk decoders (`/v1/onchain` v2 + `/v1/commit-index` client) → e2e.
+Note: the metakit-sdk committed light-client port (`committed-roots.ts`,
+`mpt_verify`/`mpt_prefix_verify`) exists on its `dev` branch only — client-side slice
+verification needs that release, but is not on the critical path (server-side healing verifies
+with metakit Scala classes).
+
+## 6. What this does NOT change
+
+- Signing canonicals: `OnChain` is server-derived state, not a client-signed message —
+  invariant #1 untriggered (golden serde tests are still added for the new wire shape).
+- The combiner's authority: all stateful rejection stays `CombineRejected` → `RejectionReceipt`.
+- The committed-state machinery: same `CommittedApp.makeL0`, same breadcrumb, same proofs; the
+  MPT gains the `commit/` namespaces (leaf count grows ~2×, small leaves). The known
+  ~3-full-rebuilds-per-ordinal committed-layer cost is unchanged here and tracked as a separate
+  metakit workstream (thread `prev.trie` through `hashFor`/`advanceWork`; make the
+  `RootDivergence` full-rebuild assert a `CommittedConfig` flag).
+- `latestLogs` semantics, webhooks, `/events`/`/invocations`.
+
+## 7. Verification plan
+
+- `OnChainWireSizeSuite` (already landed): replace the ceiling test with an O(churn)
+  assertion — v2 wire size at N cumulative entities is flat in N, linear only in batch churn.
+- Golden serde tests for OnChain v2 + the commit-map CalculatedState (round-trip + fixed
+  fixtures, per the derive-codecs/golden-fieldnames rule).
+- `CommittedViewSuite`: `commit/` namespace projection totality (incl. over-long registry
+  names) and count arithmetic.
+- DL1 integration: kill/restart mid-stream → heal → identical index vs a never-restarted node;
+  skipped-ordinal injection → refuse-fold + heal; tampered slice (omitted key, altered value)
+  → heal rejects on completeness/digest.
+- Seq-gate property tests unchanged and green (`FiberRules`/`AssetRules`).
+- Full riverdale economy e2e (10/10) green on the v2 wire format.
+- End-to-end cap demonstration: seed a cluster past the v1 ceiling (>2,265 fibers), show v2
+  keeps snapshotting (the v1 format provably could not).
+
+## 8. Implementation phases (chain repo)
+
+1. **Schema:** OnChain v2 + CalculatedState commit maps + `CommittedView` `commit/` namespaces
+   + golden tests. (models, shared-data)
+2. **Combine plumbing:** `DataStateOps` writes both the CalculatedState map and the `touched*`
+   delta; `orderedCombiner` clears `touched*` like `latestLogs`; genesis seeding. (shared-data, l0)
+3. **Gates:** ML0 validators read `current.calculated.*Commits`; DL1 `CommitIndexService`
+   (fold + heal + completeness verification) replacing `withOnChainCache`. (shared-data, data_l1)
+4. **Routes:** `/v1/onchain` v2, `/v1/commit-index` (+`?proof=true` on ML0). (l0, data_l1)
+5. **Tests per §7**, then SDK/e2e alignment (Phase 3 of the workstream).

--- a/e2e-test/runner.ts
+++ b/e2e-test/runner.ts
@@ -21,7 +21,7 @@ import type { StatesMap, Wallets, GeneratorFn, ValidatorFn } from './lib/types.t
 import { HttpClient, OttoMetagraphClient } from '@ottochain/sdk';
 // WIRE record types (from `/core` = ottochain/types) — the exact shapes the client's typed getters
 // return. NOT the root's same-named exports, which resolve to the generated protobuf types.
-import type { StateMachineFiberRecord, ScriptFiberRecord, OnChain, RegistryEntry } from '@ottochain/sdk/core';
+import type { StateMachineFiberRecord, ScriptFiberRecord, RegistryEntry } from '@ottochain/sdk/core';
 import { waitForOrdinalConfirmation, waitForOrdinalAdvance } from './lib/ordinalConfirmation.ts';
 import { WebhookListener } from './lib/webhookListener.ts';
 import { ChainKeepalive } from './lib/keepalive.ts';
@@ -443,12 +443,30 @@ async function waitForMl0Confirmation(
 }
 
 /**
- * Wait until a DL1 node's OnChain state reflects a fiber commit that matches
+ * Minimal wire shape of `GET /v1/commit-index` (onchain-incrementals RFC §3.4) — typed locally
+ * until the published SDK ships the CommitIndexResponse type (Phase-3 alignment).
+ */
+interface CommitIndexWire {
+  fiberCommits?: Record<string, { sequenceNumber: number }>;
+  assetCommits?: Record<string, unknown>;
+}
+
+/** Fetch a node's folded/healed cumulative commit maps (DL1 and ML0 serve the same route). */
+async function fetchCommitIndex(baseUrl: string): Promise<CommitIndexWire> {
+  const res = await fetch(`${baseUrl}/data-application/v1/commit-index`);
+  if (!res.ok) throw new Error(`commit-index HTTP ${res.status}`);
+  const body = (await res.json()) as { index?: CommitIndexWire };
+  return body.index ?? {};
+}
+
+/**
+ * Wait until a DL1 node's commit index reflects a fiber commit that matches
  * the expected sequence number (or simply exists, for create steps).
  *
- * Compares the DL1's /v1/onchain fiberCommits against what ML0 has already
- * confirmed, ensuring snapshot propagation (ML0 → GL0 → DL1) has completed
- * before the runner sends the next step.
+ * OnChain v2 carries only per-batch deltas, so /v1/onchain is no longer a cumulative
+ * surface — the DL1's ingestion view is its folded/healed CommitIndex, served at
+ * /v1/commit-index (reading it drives the same fold/heal refresh the ingestion gate
+ * uses, so this poll observes exactly the state the gate will validate against).
  */
 async function waitForDl1Sync(
   dl1BaseUrls: string[],
@@ -463,7 +481,7 @@ async function waitForDl1Sync(
   const w = log ? (s: string) => log.write(s) : (s: string) => process.stdout.write(s);
   w(`      ⏳ DL1 sync ${fiberId.slice(0, 8)}… (${seqLabel}, ${dl1BaseUrls.length} nodes)`);
 
-  // Per-node readiness: a node is ready once its onchain fiberCommits reflect the prior commit.
+  // Per-node readiness: a node is ready once its commit index reflects the prior commit.
   // ALL nodes must be ready before we return, because the NEXT sequential transition fans out to
   // every DL1 node and each validates against its OWN cache — a single node still trailing rejects
   // that next update during block consensus, and it gets excluded from every block (no apply, no
@@ -475,10 +493,7 @@ async function waitForDl1Sync(
       dl1BaseUrls.map(async (base, i) => {
         if (ready[i]) return;
         try {
-          // Typed OnChain read against this DL1 node (path is identical on DL1); getOnChain throws on
-          // an unready node, caught below. `fiberCommits[id]` is a typed `FiberCommit`.
-          const onChain: OnChain = await new OttoMetagraphClient({ ml0Url: base }).getOnChain();
-          const commit = onChain.fiberCommits?.[fiberId];
+          const commit = (await fetchCommitIndex(base)).fiberCommits?.[fiberId];
           if (!commit) return;
           if (expectedSeqNum === null) {
             ready[i] = true;
@@ -510,9 +525,9 @@ async function waitForDl1Sync(
 }
 
 /**
- * Wait until every DL1 node's OnChain state carries an `assetCommits[assetId]` entry — the asset
- * analogue of waitForDl1Sync. An `applyMorphism` is structurally validated at DL1 against
- * `OnChain.assetCommits` (AssetRules.applyMorphismStructural: unknown asset is a HARD reject), so a
+ * Wait until every DL1 node's commit index carries an `assetCommits[assetId]` entry — the asset
+ * analogue of waitForDl1Sync. An `applyMorphism` is structurally validated at DL1 against the
+ * recreated CommitIndex (AssetRules.applyMorphismStructural: unknown asset is a HARD reject), so a
  * `mintAsset` → `applyMorphism` on the same asset races the snapshot's ML0→GL0→DL1 propagation: the
  * morphism reaches DL1 before the mint's commit does and is rejected HTTP 400. Gating on every DL1
  * node having the commit (existence is enough — STAKE/Transfer/Wrap keep the record; the seq bump is
@@ -534,9 +549,7 @@ async function waitForDl1AssetSync(
       dl1BaseUrls.map(async (base, i) => {
         if (ready[i]) return;
         try {
-          // Typed OnChain read against this DL1 node; `assetCommits[id]` is a typed `AssetCommit`.
-          const onChain: OnChain = await new OttoMetagraphClient({ ml0Url: base }).getOnChain();
-          if (onChain.assetCommits[assetId] != null) ready[i] = true;
+          if ((await fetchCommitIndex(base)).assetCommits?.[assetId] != null) ready[i] = true;
         } catch {
           // node not ready yet — retry next attempt
         }

--- a/modules/data_l1/src/main/scala/xyz/kd5ujc/data_l1/CommitIndexHttpClient.scala
+++ b/modules/data_l1/src/main/scala/xyz/kd5ujc/data_l1/CommitIndexHttpClient.scala
@@ -21,6 +21,7 @@ object CommitIndexHttpClient {
     new CommitIndexHealClient[F] {
 
       def fetch: F[CommitIndexResponse] =
-        client.expect[CommitIndexResponse](ml0Base / "v1" / "commit-index")
+        // the framework mounts an app's custom routes under /data-application, ML0Routes adds /v1
+        client.expect[CommitIndexResponse](ml0Base / "data-application" / "v1" / "commit-index")
     }
 }

--- a/modules/data_l1/src/main/scala/xyz/kd5ujc/data_l1/CommitIndexHttpClient.scala
+++ b/modules/data_l1/src/main/scala/xyz/kd5ujc/data_l1/CommitIndexHttpClient.scala
@@ -1,0 +1,26 @@
+package xyz.kd5ujc.data_l1
+
+import cats.effect.Async
+
+import xyz.kd5ujc.schema.api.CommitIndexResponse
+import xyz.kd5ujc.shared_data.lifecycle.CommitIndexHealClient
+
+import org.http4s.Uri
+import org.http4s.circe.CirceEntityDecoder._
+import org.http4s.client.Client
+
+/**
+ * http4s implementation of the DL1 heal transport (onchain-incrementals RFC §3.3): fetches the
+ * full recreated commit index from the ML0 node's `GET /v1/commit-index` — the same `--l0-peer`
+ * this node is already configured against for snapshots. Trust note in [[CommitIndexResponse]];
+ * batch-proof verification against the signed breadcrumb is the tracked hardening follow-up.
+ */
+object CommitIndexHttpClient {
+
+  def make[F[_]: Async](client: Client[F], ml0Base: Uri): CommitIndexHealClient[F] =
+    new CommitIndexHealClient[F] {
+
+      def fetch: F[CommitIndexResponse] =
+        client.expect[CommitIndexResponse](ml0Base / "v1" / "commit-index")
+    }
+}

--- a/modules/data_l1/src/main/scala/xyz/kd5ujc/data_l1/DataL1CustomRoutes.scala
+++ b/modules/data_l1/src/main/scala/xyz/kd5ujc/data_l1/DataL1CustomRoutes.scala
@@ -15,13 +15,14 @@ import io.constellationnetwork.security.signature.Signed
 import xyz.kd5ujc.buildinfo.BuildInfo
 import xyz.kd5ujc.schema.OnChain
 import xyz.kd5ujc.schema.Updates.OttochainMessage
-import xyz.kd5ujc.schema.api.{HashResult, VersionInfo}
+import xyz.kd5ujc.schema.api.{CommitIndexResponse, HashResult, VersionInfo}
+import xyz.kd5ujc.shared_data.lifecycle.CommitIndexService
 
 import org.http4s.HttpRoutes
 import org.http4s.circe.CirceEntityCodec.{circeEntityDecoder, circeEntityEncoder}
 import org.http4s.server.Router
 
-class DataL1CustomRoutes[F[_]: Async](implicit
+class DataL1CustomRoutes[F[_]: Async](commitIndexService: CommitIndexService[F])(implicit
   context: L1NodeContext[F]
 ) extends MetagraphPublicRoutes[F] {
 
@@ -47,9 +48,17 @@ class DataL1CustomRoutes[F[_]: Async](implicit
       }
 
     case GET -> Root / "onchain" =>
-      // ML0 commits CommittedOnChain[OnChain]; unwrap .inner so this route returns the plain OnChain
-      // (clients and the e2e harness see the unchanged shape).
+      // ML0 commits CommittedOnChain[OnChain]; unwrap .inner so this route returns the plain OnChain.
+      // Under OnChain v2 this is the PER-BATCH delta — cumulative consumers use /v1/commit-index.
       context.getOnChainState[CommittedOnChain[OnChain]].map(_.map(_.inner)).toResponse
+
+    case GET -> Root / "commit-index" =>
+      // This node's OWN folded/healed cumulative view (onchain-incrementals RFC §3.3) — the surface
+      // the e2e harness/SDK polls for DL1 sync. Reading it drives the same fold/heal refresh the
+      // ingestion gate uses, so the two cannot disagree.
+      commitIndexService.refreshed
+        .map(_.map(cp => CommitIndexResponse(cp.ordinal, cp.state)))
+        .toResponse
   }
 
   protected val routes: HttpRoutes[F] = Router(

--- a/modules/data_l1/src/main/scala/xyz/kd5ujc/data_l1/DataL1Service.scala
+++ b/modules/data_l1/src/main/scala/xyz/kd5ujc/data_l1/DataL1Service.scala
@@ -12,7 +12,7 @@ import io.constellationnetwork.security.SecurityProvider
 
 import xyz.kd5ujc.schema.Updates.OttochainMessage
 import xyz.kd5ujc.schema.{CalculatedState, OnChain}
-import xyz.kd5ujc.shared_data.lifecycle.{CommitIndexHealClient, Validator}
+import xyz.kd5ujc.shared_data.lifecycle.{CommitIndexHealClient, CommitIndexService, Validator}
 
 import org.http4s._
 
@@ -26,12 +26,16 @@ object DataL1Service {
   def make[F[+_]: Async: Parallel: SecurityProvider](
     healClient: Option[CommitIndexHealClient[F]] = None
   ): F[BaseDataApplicationL1Service[F]] = for {
-    validator <- Validator.make[F](healClient)
-    l1Service <- makeBaseApplicationL1Service(validator).pure[F]
+    // one shared cache: the ingestion gate (validateUpdate) and the polled sync surface
+    // (GET /v1/commit-index) must observe the SAME folded view
+    commitIndexService <- CommitIndexService.make[F](healClient)
+    validator          <- Validator.make[F](commitIndexService)
+    l1Service          <- makeBaseApplicationL1Service(validator, commitIndexService).pure[F]
   } yield l1Service
 
   private def makeBaseApplicationL1Service[F[+_]: Async](
-    validator: ValidationService[F, OttochainMessage, OnChain, CalculatedState]
+    validator:          ValidationService[F, OttochainMessage, OnChain, CalculatedState],
+    commitIndexService: CommitIndexService[F]
   ): BaseDataApplicationL1Service[F] =
     BaseDataApplicationL1Service[F, OttochainMessage, OnChain, CalculatedState](
       new MetagraphCommonService[F, OttochainMessage, OnChain, CalculatedState, L1NodeContext[F]]
@@ -43,7 +47,7 @@ object DataL1Service {
           validator.validateUpdate(update)
 
         override def routes(implicit context: L1NodeContext[F]): HttpRoutes[F] =
-          new DataL1CustomRoutes[F].public
+          new DataL1CustomRoutes[F](commitIndexService).public
       }
     )
 }

--- a/modules/data_l1/src/main/scala/xyz/kd5ujc/data_l1/DataL1Service.scala
+++ b/modules/data_l1/src/main/scala/xyz/kd5ujc/data_l1/DataL1Service.scala
@@ -12,14 +12,21 @@ import io.constellationnetwork.security.SecurityProvider
 
 import xyz.kd5ujc.schema.Updates.OttochainMessage
 import xyz.kd5ujc.schema.{CalculatedState, OnChain}
-import xyz.kd5ujc.shared_data.lifecycle.Validator
+import xyz.kd5ujc.shared_data.lifecycle.{CommitIndexHealClient, Validator}
 
 import org.http4s._
 
 object DataL1Service {
 
-  def make[F[+_]: Async: Parallel: SecurityProvider]: F[BaseDataApplicationL1Service[F]] = for {
-    validator <- Validator.make[F]
+  /**
+   * @param healClient transport for re-seeding the commit-index cache from ML0 on ordinal gaps
+   *                   (OnChain v2 carries per-batch deltas only — onchain-incrementals RFC §3.3).
+   *                   `None` degrades gap handling to a loud, possibly-incomplete fold (dev only).
+   */
+  def make[F[+_]: Async: Parallel: SecurityProvider](
+    healClient: Option[CommitIndexHealClient[F]] = None
+  ): F[BaseDataApplicationL1Service[F]] = for {
+    validator <- Validator.make[F](healClient)
     l1Service <- makeBaseApplicationL1Service(validator).pure[F]
   } yield l1Service
 

--- a/modules/data_l1/src/main/scala/xyz/kd5ujc/data_l1/Main.scala
+++ b/modules/data_l1/src/main/scala/xyz/kd5ujc/data_l1/Main.scala
@@ -12,6 +12,7 @@ import io.constellationnetwork.currency.l1.CurrencyL1App
 import io.constellationnetwork.ext.cats.effect.ResourceIO
 import io.constellationnetwork.node.shared.infrastructure.DataL1
 import io.constellationnetwork.schema.cluster.ClusterId
+import io.constellationnetwork.schema.peer.L0Peer
 import io.constellationnetwork.schema.semver.{MetagraphVersion, TessellationVersion}
 import io.constellationnetwork.security.SecurityProvider
 
@@ -21,6 +22,8 @@ import xyz.kd5ujc.data_l1.app.DataL1AppConfigOps._
 import xyz.kd5ujc.shared_data.app._
 
 import com.monovore.decline.Opts
+import org.http4s.Uri
+import org.http4s.ember.client.EmberClientBuilder
 import org.typelevel.log4cats.SelfAwareStructuredLogger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 
@@ -35,6 +38,9 @@ object Main
 
   private object CustomConfig {
     @volatile var configPath: Option[String] = None
+    // the metagraph-L0 peer this node runs against (`--l0-peer`) — reused as the commit-index
+    // heal target (onchain-incrementals RFC §3.3); no extra configuration needed.
+    @volatile var l0Peer: Option[L0Peer] = None
   }
 
   override val opts: Opts[currency.l1.cli.method.Run] = {
@@ -43,6 +49,7 @@ object Main
 
     (currency.l1.cli.method.opts(DataL1), configFileOpt).mapN { (parentOpts, configPath) =>
       CustomConfig.configPath = configPath
+      CustomConfig.l0Peer = Some(parentOpts.l0Peer)
 
       parentOpts
     }
@@ -54,6 +61,10 @@ object Main
     implicit0(supervisor: Supervisor[IO])            <- Supervisor[IO]
     implicit0(sp: SecurityProvider[IO])              <- SecurityProvider.forAsync[IO]
     keyPair                                          <- loadKeyPair[IO](config).asResource
-    l1Service                                        <- DataL1Service.make[IO].asResource
+    httpClient                                       <- EmberClientBuilder.default[IO].build
+    healClient = CustomConfig.l0Peer.map { peer =>
+      CommitIndexHttpClient.make[IO](httpClient, Uri.unsafeFromString(s"http://${peer.ip}:${peer.port}"))
+    }
+    l1Service <- DataL1Service.make[IO](healClient).asResource
   } yield l1Service).some
 }

--- a/modules/l0/src/main/scala/xyz/kd5ujc/metagraph_l0/ML0Routes.scala
+++ b/modules/l0/src/main/scala/xyz/kd5ujc/metagraph_l0/ML0Routes.scala
@@ -47,6 +47,8 @@ class ML0Routes[F[_]: Async](
       req.asR[Signed[OttochainMessage]](m => meta.hash(m.value).flatMap(Ok(_)))
     case GET -> Root / "onchain"    => meta.onChain.toResponse
     case GET -> Root / "checkpoint" => meta.checkpoint.toResponse
+    // full recreated commit maps (v1-onchain back-compat + DL1 heal source; RFC §3.4)
+    case GET -> Root / "commit-index" => meta.commitIndex.toResponse
 
     // --- state machines ---
     case GET -> Root / "state-machines" :? StatusQueryParam(status) => stateMachine.list(status).toResponse

--- a/modules/l0/src/main/scala/xyz/kd5ujc/metagraph_l0/ML0Service.scala
+++ b/modules/l0/src/main/scala/xyz/kd5ujc/metagraph_l0/ML0Service.scala
@@ -5,8 +5,6 @@ import cats.data.NonEmptyList
 import cats.effect.{Async, Ref}
 import cats.syntax.all._
 
-import scala.collection.immutable.SortedMap
-
 import io.constellationnetwork.currency.dataApplication._
 import io.constellationnetwork.currency.dataApplication.dataApplication.DataApplicationValidationErrorOr
 import io.constellationnetwork.currency.schema.currency.CurrencyIncrementalSnapshot
@@ -62,7 +60,7 @@ object ML0Service {
     subscriberRegistry <- SubscriberRegistry.make[F]
     rejectionSink      <- Ref.of[F, List[FiberLogEntry.RejectionReceipt]](List.empty)
     combiner = Combiner.make[F]()
-    validator <- Validator.make[F]
+    validator <- Validator.make[F]()
 
     webhookDispatcher = httpClient.map(client => WebhookDispatcher.make[F](client, subscriberRegistry, metagraphId))
 
@@ -81,10 +79,12 @@ object ML0Service {
   } yield service
 
   /**
-   * Clear `latestLogs`, then sort the batch by the TOTAL `OttochainMessage.signedOrdering` (signature
-   * tiebreak lives in models) so every node folds the identical sequence — the surviving op on a tie
-   * is the same network-wide (no fork), the loser becomes a RejectionReceipt — then delegate to the
-   * registry/fiber combiner. No Hasher in the combine path now that the ordering is total.
+   * Clear the per-batch OnChain delta (`latestLogs` + `touched*` + `burnedAssets` — under OnChain v2
+   * EVERY OnChain field is per-batch; the cumulative maps live in CalculatedState), then sort the
+   * batch by the TOTAL `OttochainMessage.signedOrdering` (signature tiebreak lives in models) so
+   * every node folds the identical sequence — the surviving op on a tie is the same network-wide
+   * (no fork), the loser becomes a RejectionReceipt — then delegate to the registry/fiber combiner.
+   * No Hasher in the combine path now that the ordering is total.
    */
   private def orderedCombiner[F[+_]: Async](
     inner:         CombinerService[F, OttochainMessage, OnChain, CalculatedState],
@@ -104,7 +104,7 @@ object ML0Service {
       )(implicit ctx: L0NodeContext[F]): F[DataState[OnChain, CalculatedState]] =
         inner
           .foldLeft(
-            previous.focus(_.onChain.latestLogs).replace(SortedMap.empty),
+            previous.focus(_.onChain).replace(OnChain.genesis),
             batch.sorted(OttochainMessage.signedOrdering)
           )
           .flatTap { result =>

--- a/modules/l0/src/main/scala/xyz/kd5ujc/metagraph_l0/handlers/MetaHandler.scala
+++ b/modules/l0/src/main/scala/xyz/kd5ujc/metagraph_l0/handlers/MetaHandler.scala
@@ -11,8 +11,8 @@ import io.constellationnetwork.metagraph_sdk.syntax.all.L0ContextOps
 
 import xyz.kd5ujc.buildinfo.BuildInfo
 import xyz.kd5ujc.schema.Updates.OttochainMessage
-import xyz.kd5ujc.schema.api.{HashResult, VersionInfo}
-import xyz.kd5ujc.schema.{CalculatedState, OnChain}
+import xyz.kd5ujc.schema.api.{CommitIndexResponse, HashResult, VersionInfo}
+import xyz.kd5ujc.schema.{CalculatedState, CommitIndex, OnChain}
 
 /** Service meta + raw-state logic: version info, message hashing, on-chain + calculated state. */
 class MetaHandler[F[_]: Async](
@@ -41,4 +41,14 @@ class MetaHandler[F[_]: Async](
 
   def checkpoint: F[Either[DataApplicationValidationError, Checkpoint[CalculatedState]]] =
     checkpointService.get.map(_.asRight[DataApplicationValidationError])
+
+  /**
+   * The full recreated commit maps at the last committed ordinal (onchain-incrementals RFC §3.4):
+   * the back-compat surface for consumers of the v1 cumulative `/v1/onchain`, and the DL1 heal
+   * source. Served from the per-snapshot checkpoint cache — same freshness as `/v1/checkpoint`.
+   */
+  def commitIndex: F[Either[DataApplicationValidationError, CommitIndexResponse]] =
+    checkpointService.get.map { cp =>
+      CommitIndexResponse(cp.ordinal, CommitIndex.fromCalculated(cp.state)).asRight[DataApplicationValidationError]
+    }
 }

--- a/modules/l0/src/main/scala/xyz/kd5ujc/metagraph_l0/openapi/ApiEndpoints.scala
+++ b/modules/l0/src/main/scala/xyz/kd5ujc/metagraph_l0/openapi/ApiEndpoints.scala
@@ -84,6 +84,16 @@ object ApiEndpoints {
       .summary("Current checkpoint (calculated state snapshot)")
       .tag("state")
 
+  val commitIndex: PublicEndpoint[Unit, Unit, CommitIndexResponse, Any] =
+    endpoint.get
+      .in("data-application" / "v1" / "commit-index")
+      .out(jsonBody[CommitIndexResponse])
+      .summary(
+        "Full recreated commit maps at the last committed ordinal (OnChain v2 carries per-batch " +
+        "deltas only; this is the cumulative view — v1-onchain back-compat + the DL1 heal source)"
+      )
+      .tag("state")
+
   // ---- state machines ----
   val stateMachinesList: PublicEndpoint[Option[String], Unit, SortedMap[UUID, Records.StateMachineFiberRecord], Any] =
     endpoint.get
@@ -235,6 +245,7 @@ object ApiEndpoints {
     utilHash,
     onchain,
     checkpoint,
+    commitIndex,
     stateMachinesList,
     stateMachineGet,
     stateMachineEvents,

--- a/modules/l0/src/main/scala/xyz/kd5ujc/metagraph_l0/openapi/DataL1ApiEndpoints.scala
+++ b/modules/l0/src/main/scala/xyz/kd5ujc/metagraph_l0/openapi/DataL1ApiEndpoints.scala
@@ -2,7 +2,7 @@ package xyz.kd5ujc.metagraph_l0.openapi
 
 import xyz.kd5ujc.metagraph_l0.openapi.DomainSchemas._
 import xyz.kd5ujc.schema.OnChain
-import xyz.kd5ujc.schema.api.VersionInfo
+import xyz.kd5ujc.schema.api.{CommitIndexResponse, VersionInfo}
 
 import io.circe.Json
 import io.circe.syntax._
@@ -52,14 +52,24 @@ object DataL1ApiEndpoints {
     endpoint.get
       .in("data-application" / "v1" / "onchain")
       .out(jsonBody[OnChain])
-      .summary("Current on-chain state")
+      .summary("Current on-chain state (OnChain v2: this batch's delta — cumulative view is /commit-index)")
+      .tag("state")
+
+  val commitIndex: PublicEndpoint[Unit, Unit, CommitIndexResponse, Any] =
+    endpoint.get
+      .in("data-application" / "v1" / "commit-index")
+      .out(jsonBody[CommitIndexResponse])
+      .summary(
+        "This node's folded/healed cumulative commit maps — the DL1-sync surface " +
+        "(reading it drives the same refresh the ingestion gate uses)"
+      )
       .tag("state")
 
   /** Deterministic ON PURPOSE — see [[ApiEndpoints.contractVersion]]. */
   val contractVersion = "1.0.0"
 
   /** Every DL1 custom endpoint, in route order. */
-  val all: List[AnyEndpoint] = List(version, utilHash, onchain)
+  val all: List[AnyEndpoint] = List(version, utilHash, onchain, commitIndex)
 
   private def openApiDoc: OpenAPI =
     OpenAPIDocsInterpreter().toOpenAPI(all.map(_.tag("dl1")), "OttoChain Data L1 API", contractVersion)

--- a/modules/l0/src/test/scala/xyz/kd5ujc/metagraph_l0/openapi/OpenApiDocSuite.scala
+++ b/modules/l0/src/test/scala/xyz/kd5ujc/metagraph_l0/openapi/OpenApiDocSuite.scala
@@ -45,6 +45,7 @@ object OpenApiDocSuite extends SimpleIOSuite {
       "/data-application/v1/util/hash",
       "/data-application/v1/onchain",
       "/data-application/v1/checkpoint",
+      "/data-application/v1/commit-index",
       "/data-application/v1/state-machines",
       "/data-application/v1/state-machines/{id}/estimate-fee",
       "/data-application/v1/state-machines/{id}/state-proof",
@@ -70,6 +71,6 @@ object OpenApiDocSuite extends SimpleIOSuite {
   }
 
   pureTest("endpoint catalog matches the documented count") {
-    expect.eql(22, ApiEndpoints.all.size)
+    expect.eql(23, ApiEndpoints.all.size)
   }
 }

--- a/modules/l0/src/test/scala/xyz/kd5ujc/metagraph_l0/openapi/OpenApiDocSuite.scala
+++ b/modules/l0/src/test/scala/xyz/kd5ujc/metagraph_l0/openapi/OpenApiDocSuite.scala
@@ -29,10 +29,11 @@ object OpenApiDocSuite extends SimpleIOSuite {
     val dl1Json = DataL1ApiEndpoints.openApiJson
     val dl1Yaml = DataL1ApiEndpoints.openApiYaml
     expect.all(
-      DataL1ApiEndpoints.all.size == 3,
+      DataL1ApiEndpoints.all.size == 4,
       dl1Json.contains("3.1"),
       dl1Json.contains("/data-application/v1/version"),
       dl1Json.contains("/data-application/v1/onchain"),
+      dl1Json.contains("/data-application/v1/commit-index"),
       !dl1Json.contains("/data-application/v1/state-machines"), // ML0-only surface stays out
       dl1Yaml.contains("title: OttoChain Data L1 API"),
       dl1Yaml.contains("- dl1")

--- a/modules/models/src/main/scala/xyz/kd5ujc/schema/CalculatedState.scala
+++ b/modules/models/src/main/scala/xyz/kd5ujc/schema/CalculatedState.scala
@@ -8,6 +8,7 @@ import scala.collection.immutable.{SortedMap, SortedSet}
 
 import io.constellationnetwork.currency.dataApplication.DataCalculatedState
 import io.constellationnetwork.metagraph_sdk.lifecycle.committed.{CommitKey, CommittedView}
+import io.constellationnetwork.security.hash.Hash
 
 import xyz.kd5ujc.schema.CodecConfiguration._
 import xyz.kd5ujc.schema.registry.{RegistryEntry, RegistryName}
@@ -27,7 +28,14 @@ case class CalculatedState(
   // Asset instances (asset-model §5b): UUID -> its AssetRecord (dedicated record, NOT a fiber).
   assets: SortedMap[UUID, Records.AssetRecord] = SortedMap.empty,
   // Used commit-reveal nonces per asset (asset-model §8/§5e), BOUNDED — pruned past expiresAt in combine.
-  usedNonces: SortedMap[UUID, SortedSet[Long]] = SortedMap.empty
+  usedNonces: SortedMap[UUID, SortedSet[Long]] = SortedMap.empty,
+  // Cumulative L1 fast-path commit maps, moved here from OnChain v1 (onchain-incrementals RFC):
+  // CalculatedState is rooted (committed MPT), never wire-shipped, so unbounded growth is safe here.
+  // Written by the SAME DataStateOps/AssetCombiner folds that write the per-batch OnChain.touched*
+  // deltas — the two cannot diverge. Projected as commit/f|a|r/<id> leaves for provable DL1 healing.
+  fiberCommits:    SortedMap[UUID, FiberCommit] = SortedMap.empty,
+  assetCommits:    SortedMap[UUID, AssetCommit] = SortedMap.empty,
+  registryCommits: SortedMap[RegistryName, Hash] = SortedMap.empty
 ) extends DataCalculatedState
 
 object CalculatedState {
@@ -56,6 +64,10 @@ object CalculatedState {
    *   - `asset/<uuid>`    from `assets` (asset-model §5b — instance custody, light-client provable)
    *   - `nonce/<uuid>`    from `usedNonces`; the `SortedSet[Long]` value is committed as a JSON array of
    *                        its sorted elements (total, deterministic)
+   *   - `commit/f/<uuid>` from `fiberCommits`  — the L1 fast-path triple (onchain-incrementals RFC §3.1);
+   *   - `commit/a/<uuid>` from `assetCommits`     these small leaves are what a DL1 heals its CommitIndex
+   *   - `commit/r/<name>` from `registryCommits`  from, batch-proof-verified against the breadcrumb mptRoot
+   *                        (over-long names fall back to `commit/r/h/<sha256>` like `registry/`)
    *
    * Asset POLICIES need no projection of their own — they live in `registry` as `RegistryEntry`s
    * (`AssetPolicyPackage`) and are already covered by the `registry/<name>` key.
@@ -79,13 +91,23 @@ object CalculatedState {
         val nonces = s.usedNonces.toList.map { case (id, ns) =>
           CommitKey.unsafe(s"nonce/$id") -> Json.fromValues(ns.toList.map(Json.fromLong))
         }
-        SortedMap.from(fibers ::: scripts ::: registry ::: reverse ::: assets ::: nonces)
+        val fiberCommits = s.fiberCommits.toList.map { case (id, c) => CommitKey.unsafe(s"commit/f/$id") -> c.asJson }
+        val assetCommits = s.assetCommits.toList.map { case (id, c) => CommitKey.unsafe(s"commit/a/$id") -> c.asJson }
+        val registryCommits = s.registryCommits.toList.map { case (n, h) => commitRegistryKey(n) -> h.asJson }
+        SortedMap.from(
+          fibers ::: scripts ::: registry ::: reverse ::: assets ::: nonces :::
+          fiberCommits ::: assetCommits ::: registryCommits
+        )
       }
     }
 
   /** `registry/<name>`, or `registry/h/<sha256hex(name)>` when the name overflows a CommitKey segment. */
   private def registryKey(name: RegistryName): CommitKey =
     CommitKey.from(s"registry/${name.render}").getOrElse(CommitKey.unsafe(s"registry/h/${sha256Hex(name.render)}"))
+
+  /** `commit/r/<name>`, with the same hashed fallback as `registryKey` (key derivation must stay TOTAL). */
+  private def commitRegistryKey(name: RegistryName): CommitKey =
+    CommitKey.from(s"commit/r/${name.render}").getOrElse(CommitKey.unsafe(s"commit/r/h/${sha256Hex(name.render)}"))
 
   private def sha256Hex(s: String): String =
     MessageDigest.getInstance("SHA-256").digest(s.getBytes(StandardCharsets.UTF_8)).map("%02x".format(_)).mkString

--- a/modules/models/src/main/scala/xyz/kd5ujc/schema/CommitIndex.scala
+++ b/modules/models/src/main/scala/xyz/kd5ujc/schema/CommitIndex.scala
@@ -1,0 +1,62 @@
+package xyz.kd5ujc.schema
+
+import java.util.UUID
+
+import scala.collection.immutable.SortedMap
+
+import io.constellationnetwork.security.hash.Hash
+
+import xyz.kd5ujc.schema.CodecConfiguration._
+import xyz.kd5ujc.schema.registry.RegistryName
+
+import derevo.circe.magnolia.{customizableDecoder, customizableEncoder}
+import derevo.derive
+
+/**
+ * The recreated cumulative commit maps that the L1 structural gate reads (onchain-incrementals
+ * RFC §3.3) — exactly the maps OnChain v1 used to carry on the wire.
+ *
+ * Provenance differs by node role:
+ *   - ML0: `CommitIndex.fromCalculated(current.calculated)` — a cheap re-wrap of the DataState the
+ *     framework already passes to `validateSignedUpdate`. Same triple, same freshness as v1.
+ *   - DL1: maintained by `CommitIndexService` — `fold`ed from each contiguous snapshot's `touched*`
+ *     delta, healed from ML0 (verified against the signed breadcrumb) on any ordinal gap.
+ *
+ * SECURITY NOTE (fail-open gate): `sequenceNumberMatches`/`cidNotUsed` treat a MISSING id as
+ * pass-through — an incomplete index silently accepts what it should filter. Folding across an
+ * ordinal gap can lose `touched*` writes, so `fold` must only ever be applied at
+ * `index.ordinal + 1`; anything else requires a heal. The combiner remains the authoritative
+ * stateful gate either way (invariant #2) — an index defect degrades spam filtering, never
+ * consensus state.
+ */
+@derive(customizableDecoder, customizableEncoder)
+case class CommitIndex(
+  fiberCommits:    SortedMap[UUID, FiberCommit] = SortedMap.empty,
+  assetCommits:    SortedMap[UUID, AssetCommit] = SortedMap.empty,
+  registryCommits: SortedMap[RegistryName, Hash] = SortedMap.empty
+)
+
+object CommitIndex {
+
+  val empty: CommitIndex = CommitIndex()
+
+  /** ML0 view: the cumulative maps live in CalculatedState (rooted, not wire-shipped). */
+  def fromCalculated(cs: CalculatedState): CommitIndex =
+    CommitIndex(cs.fiberCommits, cs.assetCommits, cs.registryCommits)
+
+  /**
+   * Apply one snapshot's per-batch delta. ONLY valid for the immediately-next ordinal — the
+   * caller (`CommitIndexService`) enforces contiguity; folding across a gap loses writes and the
+   * gate fails open (see class doc).
+   *
+   * Order matters for a touch+burn in the same batch: upserts first, then burn removals win
+   * (`DataStateOps`/`AssetCombiner` keep `touchedAssetCommits` and `burnedAssets` disjoint, but
+   * the fold is defensive about it).
+   */
+  def fold(prev: CommitIndex, delta: OnChain): CommitIndex =
+    CommitIndex(
+      fiberCommits = prev.fiberCommits ++ delta.touchedFiberCommits,
+      assetCommits = (prev.assetCommits ++ delta.touchedAssetCommits) -- delta.burnedAssets,
+      registryCommits = prev.registryCommits ++ delta.touchedRegistryCommits
+    )
+}

--- a/modules/models/src/main/scala/xyz/kd5ujc/schema/OnChain.scala
+++ b/modules/models/src/main/scala/xyz/kd5ujc/schema/OnChain.scala
@@ -2,7 +2,7 @@ package xyz.kd5ujc.schema
 
 import java.util.UUID
 
-import scala.collection.immutable.SortedMap
+import scala.collection.immutable.{SortedMap, SortedSet}
 
 import io.constellationnetwork.currency.dataApplication.DataOnChainState
 import io.constellationnetwork.security.hash.Hash
@@ -41,14 +41,35 @@ case class AssetCommit(
   origin:         Option[Hash] = None
 )
 
+/**
+ * OnChain v2 (docs/proposals/onchain-incrementals.md): PER-BATCH deltas only, never cumulative.
+ *
+ * tessellation serializes this struct into `dataApplication.onChainState` of EVERY incremental
+ * snapshot, and the whole snapshot binary is hard-capped at 512,000 bytes
+ * (`max-state-channel-snapshot-binary-size-in-bytes`; enforced in `CurrencySnapshotCreator`).
+ * The v1 cumulative maps ran into that cap at ~2,265 fibers (measured, `OnChainWireSizeSuite`)
+ * with a PERMANENT-HALT failure mode (`UnableToReduceProposalByCutting` — the events-cutter
+ * cannot shed non-event state). v2 keeps snapshot bytes O(batch churn): churn IS events, so an
+ * oversized batch degrades gracefully (data blocks deferred to the next snapshot).
+ *
+ * The cumulative maps now live in `CalculatedState.fiberCommits/assetCommits/registryCommits`
+ * (rooted under the committed MPT as `commit/f|a|r/<id>`, never wire-shipped). Every `touched*`
+ * write goes to BOTH (same `DataStateOps` fold, same hash) — the delta here is exactly what a
+ * DL1 `CommitIndex` folds to recreate the full maps (see `CommitIndex.fold`).
+ *
+ * `touched*` maps use the SAME clear-then-accumulate mechanism as `latestLogs`: cleared at the
+ * top of `orderedCombiner`'s fold, repopulated by this batch's writes only.
+ */
 @derive(customizableDecoder, customizableEncoder)
 case class OnChain(
-  fiberCommits:    SortedMap[UUID, FiberCommit],
-  latestLogs:      SortedMap[UUID, List[FiberLogEntry]],
-  registryCommits: SortedMap[RegistryName, Hash] = SortedMap.empty,
-  assetCommits:    SortedMap[UUID, AssetCommit] = SortedMap.empty
+  touchedFiberCommits:    SortedMap[UUID, FiberCommit],
+  latestLogs:             SortedMap[UUID, List[FiberLogEntry]],
+  touchedRegistryCommits: SortedMap[RegistryName, Hash] = SortedMap.empty,
+  touchedAssetCommits:    SortedMap[UUID, AssetCommit] = SortedMap.empty,
+  // burns are removals — they cannot ride an upsert map (asset-model §5d Burn morphism)
+  burnedAssets: SortedSet[UUID] = SortedSet.empty
 ) extends DataOnChainState
 
 object OnChain {
-  val genesis: OnChain = OnChain(SortedMap.empty, SortedMap.empty, SortedMap.empty, SortedMap.empty)
+  val genesis: OnChain = OnChain(SortedMap.empty, SortedMap.empty, SortedMap.empty, SortedMap.empty, SortedSet.empty)
 }

--- a/modules/models/src/main/scala/xyz/kd5ujc/schema/api/CommitIndexResponse.scala
+++ b/modules/models/src/main/scala/xyz/kd5ujc/schema/api/CommitIndexResponse.scala
@@ -1,0 +1,29 @@
+package xyz.kd5ujc.schema.api
+
+import io.constellationnetwork.schema.SnapshotOrdinal
+
+import xyz.kd5ujc.schema.CommitIndex
+
+import io.circe.generic.semiauto._
+import io.circe.{Decoder, Encoder}
+
+/**
+ * Response of `GET /v1/commit-index` (onchain-incrementals RFC §3.4): the full recreated
+ * cumulative commit maps at `ordinal` — the back-compat surface for consumers that previously
+ * read the v1 cumulative `/v1/onchain`, and the DL1 heal transport
+ * (`CommitIndexHealClient`) for re-seeding its folded index after an ordinal gap or restart.
+ *
+ * TRUST NOTE: served from the ML0's committed calculated state. A healing DL1 currently trusts
+ * the ML0 peer it is already configured against (the same peer that feeds it snapshots);
+ * batch-proof verification of this payload against the signed breadcrumb `mptRoot` (via the
+ * `commit/` MPT namespace) is the hardening step tracked in RFC §3.3 step 2.
+ */
+final case class CommitIndexResponse(
+  ordinal: SnapshotOrdinal,
+  index:   CommitIndex
+)
+
+object CommitIndexResponse {
+  implicit val decoder: Decoder[CommitIndexResponse] = deriveDecoder[CommitIndexResponse]
+  implicit val encoder: Encoder[CommitIndexResponse] = deriveEncoder[CommitIndexResponse]
+}

--- a/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/genesis/GenesisBuilder.scala
+++ b/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/genesis/GenesisBuilder.scala
@@ -98,8 +98,10 @@ object GenesisBuilder {
         val registry = SortedMap.from(built.map { case (n, e, _) => n -> e })
         val commits = SortedMap.from(built.map { case (n, _, h) => n -> h })
         DataState(
-          OnChain.genesis.copy(registryCommits = commits),
-          CalculatedState.genesis.copy(registry = registry)
+          // seed entries are also the genesis snapshot's touched* delta, so a from-genesis
+          // CommitIndex fold starts complete (onchain-incrementals RFC §3.4)
+          OnChain.genesis.copy(touchedRegistryCommits = commits),
+          CalculatedState.genesis.copy(registry = registry, registryCommits = commits)
         )
       }
 }

--- a/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/CommitIndexHealClient.scala
+++ b/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/CommitIndexHealClient.scala
@@ -1,0 +1,23 @@
+package xyz.kd5ujc.shared_data.lifecycle
+
+import xyz.kd5ujc.schema.api.CommitIndexResponse
+
+/**
+ * DL1-side heal transport (onchain-incrementals RFC §3.3): fetch the full recreated commit index
+ * from an ML0 node's `GET /v1/commit-index`.
+ *
+ * Used by `Validator`'s commit-index cache whenever the per-batch delta fold cannot proceed —
+ * first sync after start, or any ordinal gap (the fold is only sound at `checkpoint.ordinal + 1`;
+ * folding across a gap loses writes and the structural gate FAILS OPEN for unknown ids).
+ *
+ * The trait is transport-agnostic; the http4s implementation lives in the data_l1 module (it
+ * targets the same `--l0-peer` the node is already configured against). Batch-proof verification
+ * of the healed payload against the signed breadcrumb `mptRoot` is the hardening follow-up
+ * (RFC §3.3 step 2) — until then the heal trusts the configured ML0 peer, which already feeds
+ * this node its snapshots; the combiner remains the authoritative stateful gate regardless.
+ */
+trait CommitIndexHealClient[F[_]] {
+
+  /** Fetch the ML0's current full commit index and its ordinal. */
+  def fetch: F[CommitIndexResponse]
+}

--- a/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/CommitIndexService.scala
+++ b/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/CommitIndexService.scala
@@ -1,0 +1,154 @@
+package xyz.kd5ujc.shared_data.lifecycle
+
+import cats.effect.Async
+import cats.syntax.all._
+
+import io.constellationnetwork.currency.dataApplication.{DataApplicationValidationError, L1NodeContext}
+import io.constellationnetwork.metagraph_sdk.lifecycle.CheckpointService
+import io.constellationnetwork.metagraph_sdk.lifecycle.committed.CommittedOnChain
+import io.constellationnetwork.metagraph_sdk.std.Checkpoint
+import io.constellationnetwork.metagraph_sdk.syntax.all.L1ContextOps
+import io.constellationnetwork.schema.SnapshotOrdinal
+
+import xyz.kd5ujc.schema.{CommitIndex, OnChain}
+
+import org.typelevel.log4cats.SelfAwareStructuredLogger
+import org.typelevel.log4cats.slf4j.Slf4jLogger
+
+/**
+ * The DL1's recreated commit-index cache (onchain-incrementals RFC §3.3).
+ *
+ * OnChain v2 carries only per-batch deltas, so the cumulative view the L1 structural gate needs
+ * is a FOLD over contiguous deltas:
+ *   - `snapshot.ordinal == cache.ordinal + 1` → fold the observed delta (no extra I/O);
+ *   - anything else (first sync, skipped ordinals, restart) → HEAL from ML0's
+ *     `/v1/commit-index`. Folding across a gap is never allowed: lost `touched*` writes make the
+ *     structural gate FAIL OPEN for unknown ids (create-dup passes, and transitions of
+ *     gap-created fibers get spuriously rejected).
+ *   - heal failure keeps the checkpoint UNCHANGED (stale-or-unsynced, retried on the next call)
+ *     rather than silently adopting an incomplete base. The combiner remains the authoritative
+ *     stateful gate either way.
+ *
+ * Shared by `Validator.validateUpdate` (refresh-then-validate) and the DL1's
+ * `GET /v1/commit-index` route (refresh-then-serve) — so both the ingestion gate and the surface
+ * the e2e harness/SDK polls for DL1 sync observe the SAME folded view, and polling the route
+ * drives the same fold/heal the gate relies on.
+ */
+trait CommitIndexService[F[_]] {
+
+  /** Refresh from the latest snapshot (fold or heal), then return the current view. */
+  def refreshed(implicit ctx: L1NodeContext[F]): F[Either[DataApplicationValidationError, Checkpoint[CommitIndex]]]
+}
+
+object CommitIndexService {
+
+  def make[F[_]: Async](healClient: Option[CommitIndexHealClient[F]]): F[CommitIndexService[F]] =
+    // `None` = never synced: deltas can only be folded from a complete base, so the very first
+    // refresh must heal (or degrade) — the initial ordinal is a sentinel, not a base.
+    CheckpointService.make[F, Option[CommitIndex]](None).map { checkpointService =>
+      new CommitIndexService[F] {
+
+        private val logger: SelfAwareStructuredLogger[F] =
+          Slf4jLogger.getLoggerFromClass(CommitIndexService.getClass)
+
+        def refreshed(implicit
+          ctx: L1NodeContext[F]
+        ): F[Either[DataApplicationValidationError, Checkpoint[CommitIndex]]] =
+          checkpointService
+            .evalModify[DataApplicationValidationError] { checkpoint =>
+              ctx.getLatestCurrencySnapshot.flatMap {
+                case Right(snapshot) if snapshot.ordinal > checkpoint.ordinal || checkpoint.state.isEmpty =>
+                  // ML0 commits CommittedOnChain[OnChain] (makeL0 wraps OnChain with the committed
+                  // breadcrumb); unwrap .inner to get the per-batch delta.
+                  ctx.getOnChainState[CommittedOnChain[OnChain]].flatMap {
+                    case Right(committed) =>
+                      val delta = committed.inner
+                      checkpoint.state match {
+                        case Some(index) if snapshot.ordinal.value.value === checkpoint.ordinal.value.value + 1L =>
+                          val folded = CommitIndex.fold(index, delta)
+                          logger
+                            .info(
+                              s"[DL1-cache] FOLDED delta: ordinal=${snapshot.ordinal} " +
+                              s"touchedFibers=${delta.touchedFiberCommits.size} " +
+                              s"touchedAssets=${delta.touchedAssetCommits.size} burns=${delta.burnedAssets.size} " +
+                              s"indexFibers=${folded.fiberCommits.size}"
+                            )
+                            .as(
+                              Checkpoint(snapshot.ordinal, (folded: CommitIndex).some)
+                                .asRight[DataApplicationValidationError]
+                            )
+                        case Some(_) if snapshot.ordinal === checkpoint.ordinal =>
+                          // only reachable via the isEmpty guard, which excludes Some — keep as-is
+                          checkpoint.asRight[DataApplicationValidationError].pure[F]
+                        case _ =>
+                          heal(snapshot.ordinal, delta, checkpoint)
+                      }
+                    case Left(err) =>
+                      logger.warn(s"[DL1-cache] REFRESH FAILED: $err").as(err.asLeft[Checkpoint[Option[CommitIndex]]])
+                  }
+                case Right(snapshot) =>
+                  logger.debug(
+                    s"[DL1-cache] NO REFRESH: snapshotOrdinal=${snapshot.ordinal} == cacheOrdinal=${checkpoint.ordinal}"
+                  ) *> checkpoint.asRight[DataApplicationValidationError].pure[F]
+                case Left(err) =>
+                  logger.warn(s"[DL1-cache] SNAPSHOT ERROR: $err").as(err.asLeft[Checkpoint[Option[CommitIndex]]])
+              }
+            }
+            .map(_.map(cp => Checkpoint(cp.ordinal, cp.state.getOrElse(CommitIndex.empty))))
+
+        /**
+         * Re-seed the index from ML0 (gap / first sync). Adoption cases relative to the locally
+         * observed `snapshotOrdinal`:
+         *   - healed at or ahead of it → adopt verbatim (the gate tolerates a fresher index);
+         *   - healed exactly one behind → adopt + fold the locally observed delta on top;
+         *   - healed further behind → adopt what we got and let the next refresh retry (ordinal
+         *     stays behind, so the `>` guard fires again).
+         */
+        private def heal(
+          snapshotOrdinal: SnapshotOrdinal,
+          observedDelta:   OnChain,
+          prev:            Checkpoint[Option[CommitIndex]]
+        ): F[Either[DataApplicationValidationError, Checkpoint[Option[CommitIndex]]]] =
+          healClient match {
+            case Some(client) =>
+              client.fetch.attempt.flatMap {
+                case Right(res) =>
+                  val adopted =
+                    if (res.ordinal.value.value + 1L === snapshotOrdinal.value.value)
+                      Checkpoint(snapshotOrdinal, (CommitIndex.fold(res.index, observedDelta): CommitIndex).some)
+                    else
+                      Checkpoint(res.ordinal, res.index.some)
+                  logger
+                    .info(
+                      s"[DL1-cache] HEALED: ml0Ordinal=${res.ordinal} localOrdinal=$snapshotOrdinal " +
+                      s"indexFibers=${adopted.state.map(_.fiberCommits.size).getOrElse(0)} " +
+                      s"(prev=${prev.ordinal}${if (prev.state.isEmpty) ", unsynced" else ""})"
+                    )
+                    .as(adopted.asRight[DataApplicationValidationError])
+                case Left(e) =>
+                  logger
+                    .error(
+                      s"[DL1-cache] HEAL FAILED (${e.getMessage}): keeping " +
+                      s"${if (prev.state.isEmpty) "UNSYNCED (validating against an empty index!)"
+                        else s"stale ordinal=${prev.ordinal}"}; " +
+                      "will retry on next update"
+                    )
+                    .as(prev.asRight[DataApplicationValidationError])
+              }
+            case None =>
+              // transport-less dev mode: fold onto whatever base we have and advance, accepting
+              // potential incompleteness — loudly, every gap.
+              val base = prev.state.getOrElse(CommitIndex.empty)
+              logger
+                .error(
+                  s"[DL1-cache] ORDINAL GAP with NO heal client: ${prev.ordinal} -> $snapshotOrdinal; " +
+                  "folding onto a possibly-incomplete index (structural gate degraded; dev mode only)"
+                )
+                .as(
+                  Checkpoint(snapshotOrdinal, (CommitIndex.fold(base, observedDelta): CommitIndex).some)
+                    .asRight[DataApplicationValidationError]
+                )
+          }
+      }
+    }
+}

--- a/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/Validator.scala
+++ b/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/Validator.scala
@@ -6,11 +6,8 @@ import cats.syntax.all._
 
 import io.constellationnetwork.currency.dataApplication._
 import io.constellationnetwork.currency.dataApplication.dataApplication.DataApplicationValidationErrorOr
-import io.constellationnetwork.metagraph_sdk.lifecycle.committed.CommittedOnChain
-import io.constellationnetwork.metagraph_sdk.lifecycle.{CheckpointService, ValidationService}
+import io.constellationnetwork.metagraph_sdk.lifecycle.ValidationService
 import io.constellationnetwork.metagraph_sdk.std.Checkpoint
-import io.constellationnetwork.metagraph_sdk.syntax.all.L1ContextOps
-import io.constellationnetwork.schema.SnapshotOrdinal
 import io.constellationnetwork.security.SecurityProvider
 import io.constellationnetwork.security.signature.Signed
 
@@ -47,7 +44,7 @@ import org.typelevel.log4cats.slf4j.Slf4jLogger
 object Validator {
 
   /**
-   * Creates a ValidationService instance.
+   * Creates a ValidationService instance with its own private commit-index cache.
    *
    * @param healClient DL1-only heal transport for the commit-index cache (RFC §3.3). `None` on
    *                   ML0 (which never calls `validateUpdate`) and in transport-less dev setups —
@@ -57,9 +54,17 @@ object Validator {
   def make[F[_]: Async: Parallel: SecurityProvider](
     healClient: Option[CommitIndexHealClient[F]] = None
   ): F[ValidationService[F, OttochainMessage, OnChain, CalculatedState]] =
-    // `None` = never synced: OnChain v2 deltas can only be folded from a complete base, so the
-    // very first refresh must heal (or degrade) — the initial ordinal is a sentinel, not a base.
-    CheckpointService.make[F, Option[CommitIndex]](None).map { checkpointService =>
+    CommitIndexService.make[F](healClient).flatMap(make(_))
+
+  /**
+   * Creates a ValidationService sharing an externally-owned [[CommitIndexService]] — the DL1
+   * passes the same instance to its `/v1/commit-index` route so the ingestion gate and the
+   * polled sync surface observe one folded view.
+   */
+  def make[F[_]: Async: Parallel: SecurityProvider](
+    commitIndexService: CommitIndexService[F]
+  ): F[ValidationService[F, OttochainMessage, OnChain, CalculatedState]] =
+    Async[F].pure {
       new ValidationService[F, OttochainMessage, OnChain, CalculatedState] {
 
         private val logger: SelfAwareStructuredLogger[F] =
@@ -191,123 +196,14 @@ object Validator {
         }
 
         /**
-         * Executes validation with the recreated commit-index cache (onchain-incrementals RFC §3.3).
-         *
-         * OnChain v2 carries only per-batch deltas, so the cache can no longer be replaced from the
-         * latest snapshot — it is a FOLD over contiguous deltas:
-         *   - `snapshot.ordinal == cache.ordinal + 1` → fold the observed delta (no extra I/O);
-         *   - anything else (first sync, skipped ordinals, restart) → HEAL from ML0's
-         *     `/v1/commit-index`. Folding across a gap is never allowed: lost `touched*` writes make
-         *     the structural gate FAIL OPEN for unknown ids (create-dup passes, and transitions of
-         *     gap-created fibers get spuriously rejected).
-         *   - heal failure keeps the checkpoint UNCHANGED (stale-or-unsynced, retried on the next
-         *     call) rather than silently adopting an incomplete base; validation proceeds against
-         *     the stale index (empty if never synced), loudly logged. The combiner remains the
-         *     authoritative gate either way.
+         * Executes validation with the recreated commit-index cache — refresh (fold or heal) via the
+         * shared [[CommitIndexService]], then validate against the returned view. The same service
+         * backs the DL1's `GET /v1/commit-index` route, so the gate and the polled surface agree.
          */
         private def withCommitIndexCache(context: L1NodeContext[F])(
           f: Checkpoint[CommitIndex] => F[DataApplicationValidationErrorOr[Unit]]
         ): F[DataApplicationValidationErrorOr[Unit]] =
-          checkpointService
-            .evalModify[DataApplicationValidationError] { checkpoint =>
-              context.getLatestCurrencySnapshot.flatMap {
-                case Right(snapshot) if snapshot.ordinal > checkpoint.ordinal || checkpoint.state.isEmpty =>
-                  // ML0 commits CommittedOnChain[OnChain] (makeL0 wraps OnChain with the committed
-                  // breadcrumb); unwrap .inner to get the per-batch delta.
-                  context.getOnChainState[CommittedOnChain[OnChain]].flatMap {
-                    case Right(committed) =>
-                      val delta = committed.inner
-                      checkpoint.state match {
-                        case Some(index) if snapshot.ordinal.value.value === checkpoint.ordinal.value.value + 1L =>
-                          val folded = CommitIndex.fold(index, delta)
-                          logger
-                            .info(
-                              s"[DL1-cache] FOLDED delta: ordinal=${snapshot.ordinal} " +
-                              s"touchedFibers=${delta.touchedFiberCommits.size} " +
-                              s"touchedAssets=${delta.touchedAssetCommits.size} burns=${delta.burnedAssets.size} " +
-                              s"indexFibers=${folded.fiberCommits.size}"
-                            )
-                            .as(
-                              Checkpoint(snapshot.ordinal, (folded: CommitIndex).some)
-                                .asRight[DataApplicationValidationError]
-                            )
-                        case Some(_) if snapshot.ordinal === checkpoint.ordinal =>
-                          // only reachable via the isEmpty guard, which excludes Some — keep as-is
-                          checkpoint.asRight[DataApplicationValidationError].pure[F]
-                        case _ =>
-                          heal(snapshot.ordinal, delta, checkpoint)
-                      }
-                    case Left(err) =>
-                      logger.warn(s"[DL1-cache] REFRESH FAILED: $err").as(err.asLeft[Checkpoint[Option[CommitIndex]]])
-                  }
-                case Right(snapshot) =>
-                  logger.debug(
-                    s"[DL1-cache] NO REFRESH: snapshotOrdinal=${snapshot.ordinal} == cacheOrdinal=${checkpoint.ordinal}"
-                  ) *> checkpoint.asRight[DataApplicationValidationError].pure[F]
-                case Left(err) =>
-                  logger.warn(s"[DL1-cache] SNAPSHOT ERROR: $err").as(err.asLeft[Checkpoint[Option[CommitIndex]]])
-              }
-            }
-            .flatMap(
-              _.fold(
-                _.invalidNec[Unit].pure[F],
-                cp => f(Checkpoint(cp.ordinal, cp.state.getOrElse(CommitIndex.empty)))
-              )
-            )
-
-        /**
-         * Re-seed the index from ML0 (gap / first sync). Adoption cases relative to the locally
-         * observed `snapshotOrdinal`:
-         *   - healed at or ahead of it → adopt verbatim (the gate tolerates a fresher index);
-         *   - healed exactly one behind → adopt + fold the locally observed delta on top;
-         *   - healed further behind → adopt what we got and let the next refresh retry (ordinal
-         *     stays behind, so the `>` guard fires again).
-         */
-        private def heal(
-          snapshotOrdinal: SnapshotOrdinal,
-          observedDelta:   OnChain,
-          prev:            Checkpoint[Option[CommitIndex]]
-        ): F[Either[DataApplicationValidationError, Checkpoint[Option[CommitIndex]]]] =
-          healClient match {
-            case Some(client) =>
-              client.fetch.attempt.flatMap {
-                case Right(res) =>
-                  val adopted =
-                    if (res.ordinal.value.value + 1L === snapshotOrdinal.value.value)
-                      Checkpoint(snapshotOrdinal, (CommitIndex.fold(res.index, observedDelta): CommitIndex).some)
-                    else
-                      Checkpoint(res.ordinal, res.index.some)
-                  logger
-                    .info(
-                      s"[DL1-cache] HEALED: ml0Ordinal=${res.ordinal} localOrdinal=$snapshotOrdinal " +
-                      s"indexFibers=${adopted.state.map(_.fiberCommits.size).getOrElse(0)} " +
-                      s"(prev=${prev.ordinal}${if (prev.state.isEmpty) ", unsynced" else ""})"
-                    )
-                    .as(adopted.asRight[DataApplicationValidationError])
-                case Left(e) =>
-                  logger
-                    .error(
-                      s"[DL1-cache] HEAL FAILED (${e.getMessage}): keeping " +
-                      s"${if (prev.state.isEmpty) "UNSYNCED (validating against an empty index!)"
-                        else s"stale ordinal=${prev.ordinal}"}; " +
-                      "will retry on next update"
-                    )
-                    .as(prev.asRight[DataApplicationValidationError])
-              }
-            case None =>
-              // transport-less dev mode: fold onto whatever base we have and advance, accepting
-              // potential incompleteness — loudly, every gap.
-              val base = prev.state.getOrElse(CommitIndex.empty)
-              logger
-                .error(
-                  s"[DL1-cache] ORDINAL GAP with NO heal client: ${prev.ordinal} -> $snapshotOrdinal; " +
-                  "folding onto a possibly-incomplete index (structural gate degraded; dev mode only)"
-                )
-                .as(
-                  Checkpoint(snapshotOrdinal, (CommitIndex.fold(base, observedDelta): CommitIndex).some)
-                    .asRight[DataApplicationValidationError]
-                )
-          }
+          commitIndexService.refreshed(context).flatMap(_.fold(_.invalidNec[Unit].pure[F], f))
       }
     }
 }

--- a/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/Validator.scala
+++ b/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/Validator.scala
@@ -10,11 +10,12 @@ import io.constellationnetwork.metagraph_sdk.lifecycle.committed.CommittedOnChai
 import io.constellationnetwork.metagraph_sdk.lifecycle.{CheckpointService, ValidationService}
 import io.constellationnetwork.metagraph_sdk.std.Checkpoint
 import io.constellationnetwork.metagraph_sdk.syntax.all.L1ContextOps
+import io.constellationnetwork.schema.SnapshotOrdinal
 import io.constellationnetwork.security.SecurityProvider
 import io.constellationnetwork.security.signature.Signed
 
 import xyz.kd5ujc.schema.Updates._
-import xyz.kd5ujc.schema.{CalculatedState, OnChain}
+import xyz.kd5ujc.schema.{CalculatedState, CommitIndex, OnChain}
 import xyz.kd5ujc.shared_data.lifecycle.validate.{AssetValidator, FiberValidator, RegistryValidator, ScriptValidator}
 
 import org.typelevel.log4cats.SelfAwareStructuredLogger
@@ -48,11 +49,17 @@ object Validator {
   /**
    * Creates a ValidationService instance.
    *
+   * @param healClient DL1-only heal transport for the commit-index cache (RFC §3.3). `None` on
+   *                   ML0 (which never calls `validateUpdate`) and in transport-less dev setups —
+   *                   there a gap degrades to folding onto the possibly-incomplete index, loudly.
    * @return A ValidationService that validates OttochainMessage updates
    */
-  def make[F[_]: Async: Parallel: SecurityProvider]
-    : F[ValidationService[F, OttochainMessage, OnChain, CalculatedState]] =
-    CheckpointService.make[F, OnChain](OnChain.genesis).map { checkpointService =>
+  def make[F[_]: Async: Parallel: SecurityProvider](
+    healClient: Option[CommitIndexHealClient[F]] = None
+  ): F[ValidationService[F, OttochainMessage, OnChain, CalculatedState]] =
+    // `None` = never synced: OnChain v2 deltas can only be folded from a complete base, so the
+    // very first refresh must heal (or degrade) — the initial ordinal is a sentinel, not a base.
+    CheckpointService.make[F, Option[CommitIndex]](None).map { checkpointService =>
       new ValidationService[F, OttochainMessage, OnChain, CalculatedState] {
 
         private val logger: SelfAwareStructuredLogger[F] =
@@ -67,11 +74,12 @@ object Validator {
         override def validateUpdate(
           update: OttochainMessage
         )(implicit ctx: L1NodeContext[F]): F[DataApplicationValidationErrorOr[Unit]] =
-          withOnChainCache(ctx) { checkpoint =>
-            val fiberL1 = new FiberValidator.L1Validator[F](checkpoint.state)
-            val scriptL1 = new ScriptValidator.L1Validator[F](checkpoint.state)
+          withCommitIndexCache(ctx) { checkpoint =>
+            val index = checkpoint.state
+            val fiberL1 = new FiberValidator.L1Validator[F](index)
+            val scriptL1 = new ScriptValidator.L1Validator[F](index)
             val registryL1 = new RegistryValidator.L1Validator[F]
-            val assetL1 = new AssetValidator.L1Validator[F](checkpoint.state)
+            val assetL1 = new AssetValidator.L1Validator[F](index)
 
             val updateName = update.getClass.getSimpleName
             val fiberId = update match {
@@ -91,7 +99,7 @@ object Validator {
               case u: ApplyMorphism          => u.fiberId.toString
               case u: AuthorizeCompose       => u.fiberId.toString
             }
-            val cids = checkpoint.state.fiberCommits.keys.map(_.toString.take(8)).mkString(", ")
+            val cids = index.fiberCommits.keys.map(_.toString.take(8)).mkString(", ")
 
             for {
               _ <- logger.info(
@@ -158,8 +166,10 @@ object Validator {
           // block-poisoning hazard — a concurrent publish/mint/yank flips a once-valid op to Invalid at ML0
           // re-validation and tessellation drops the ENTIRE DL1 block (all-or-nothing). Those checks live
           // ONLY in the AssetCombiner (Phase 4) as graceful CombineRejected -> RejectionReceipt. ApplyMorphism
-          // L1 reads only OnChain.assetCommits (the safe behavior bitmask + sequence number), never lineage.
-          val assetL1 = new AssetValidator.L1Validator[F](current.onChain)
+          // L1 reads only the commit index (the safe behavior bitmask + sequence number), never lineage —
+          // under OnChain v2 the cumulative maps live in CalculatedState (same triple, same freshness as the
+          // v1 OnChain read; the relocation does NOT widen this gate's reads — RFC §3.2).
+          val assetL1 = new AssetValidator.L1Validator[F](CommitIndex.fromCalculated(current.calculated))
 
           signedUpdate.value match {
             case u: CreateStateMachine     => fiberCombined.createFiber(u)
@@ -181,44 +191,123 @@ object Validator {
         }
 
         /**
-         * Executes validation with cached on-chain state.
+         * Executes validation with the recreated commit-index cache (onchain-incrementals RFC §3.3).
          *
-         * The checkpoint is refreshed when a new snapshot is available,
-         * avoiding redundant state fetches during batch processing.
+         * OnChain v2 carries only per-batch deltas, so the cache can no longer be replaced from the
+         * latest snapshot — it is a FOLD over contiguous deltas:
+         *   - `snapshot.ordinal == cache.ordinal + 1` → fold the observed delta (no extra I/O);
+         *   - anything else (first sync, skipped ordinals, restart) → HEAL from ML0's
+         *     `/v1/commit-index`. Folding across a gap is never allowed: lost `touched*` writes make
+         *     the structural gate FAIL OPEN for unknown ids (create-dup passes, and transitions of
+         *     gap-created fibers get spuriously rejected).
+         *   - heal failure keeps the checkpoint UNCHANGED (stale-or-unsynced, retried on the next
+         *     call) rather than silently adopting an incomplete base; validation proceeds against
+         *     the stale index (empty if never synced), loudly logged. The combiner remains the
+         *     authoritative gate either way.
          */
-        private def withOnChainCache(context: L1NodeContext[F])(
-          f: Checkpoint[OnChain] => F[DataApplicationValidationErrorOr[Unit]]
+        private def withCommitIndexCache(context: L1NodeContext[F])(
+          f: Checkpoint[CommitIndex] => F[DataApplicationValidationErrorOr[Unit]]
         ): F[DataApplicationValidationErrorOr[Unit]] =
           checkpointService
             .evalModify[DataApplicationValidationError] { checkpoint =>
               context.getLatestCurrencySnapshot.flatMap {
-                case Right(snapshot) if snapshot.ordinal > checkpoint.ordinal =>
-                  logger.info(
-                    s"[DL1-cache] REFRESHING: snapshotOrdinal=${snapshot.ordinal} > cacheOrdinal=${checkpoint.ordinal}"
-                  ) *>
-                  // ML0 now commits CommittedOnChain[OnChain] (makeL0 wraps OnChain with the committed
-                  // breadcrumb); unwrap .inner to get the plain OnChain the fiber sequence checks need.
+                case Right(snapshot) if snapshot.ordinal > checkpoint.ordinal || checkpoint.state.isEmpty =>
+                  // ML0 commits CommittedOnChain[OnChain] (makeL0 wraps OnChain with the committed
+                  // breadcrumb); unwrap .inner to get the per-batch delta.
                   context.getOnChainState[CommittedOnChain[OnChain]].flatMap {
                     case Right(committed) =>
-                      val newState = committed.inner
-                      val cids = newState.fiberCommits.keys.map(_.toString.take(8)).mkString(", ")
-                      logger
-                        .info(
-                          s"[DL1-cache] REFRESHED: ordinal=${snapshot.ordinal} fiberCommits=${newState.fiberCommits.size} cids=[$cids]"
-                        )
-                        .as(Checkpoint(snapshot.ordinal, newState).asRight[DataApplicationValidationError])
+                      val delta = committed.inner
+                      checkpoint.state match {
+                        case Some(index) if snapshot.ordinal.value.value === checkpoint.ordinal.value.value + 1L =>
+                          val folded = CommitIndex.fold(index, delta)
+                          logger
+                            .info(
+                              s"[DL1-cache] FOLDED delta: ordinal=${snapshot.ordinal} " +
+                              s"touchedFibers=${delta.touchedFiberCommits.size} " +
+                              s"touchedAssets=${delta.touchedAssetCommits.size} burns=${delta.burnedAssets.size} " +
+                              s"indexFibers=${folded.fiberCommits.size}"
+                            )
+                            .as(
+                              Checkpoint(snapshot.ordinal, (folded: CommitIndex).some)
+                                .asRight[DataApplicationValidationError]
+                            )
+                        case Some(_) if snapshot.ordinal === checkpoint.ordinal =>
+                          // only reachable via the isEmpty guard, which excludes Some — keep as-is
+                          checkpoint.asRight[DataApplicationValidationError].pure[F]
+                        case _ =>
+                          heal(snapshot.ordinal, delta, checkpoint)
+                      }
                     case Left(err) =>
-                      logger.warn(s"[DL1-cache] REFRESH FAILED: $err").as(err.asLeft[Checkpoint[OnChain]])
+                      logger.warn(s"[DL1-cache] REFRESH FAILED: $err").as(err.asLeft[Checkpoint[Option[CommitIndex]]])
                   }
                 case Right(snapshot) =>
                   logger.debug(
                     s"[DL1-cache] NO REFRESH: snapshotOrdinal=${snapshot.ordinal} == cacheOrdinal=${checkpoint.ordinal}"
                   ) *> checkpoint.asRight[DataApplicationValidationError].pure[F]
                 case Left(err) =>
-                  logger.warn(s"[DL1-cache] SNAPSHOT ERROR: $err").as(err.asLeft[Checkpoint[OnChain]])
+                  logger.warn(s"[DL1-cache] SNAPSHOT ERROR: $err").as(err.asLeft[Checkpoint[Option[CommitIndex]]])
               }
             }
-            .flatMap(_.fold(_.invalidNec[Unit].pure[F], f))
+            .flatMap(
+              _.fold(
+                _.invalidNec[Unit].pure[F],
+                cp => f(Checkpoint(cp.ordinal, cp.state.getOrElse(CommitIndex.empty)))
+              )
+            )
+
+        /**
+         * Re-seed the index from ML0 (gap / first sync). Adoption cases relative to the locally
+         * observed `snapshotOrdinal`:
+         *   - healed at or ahead of it → adopt verbatim (the gate tolerates a fresher index);
+         *   - healed exactly one behind → adopt + fold the locally observed delta on top;
+         *   - healed further behind → adopt what we got and let the next refresh retry (ordinal
+         *     stays behind, so the `>` guard fires again).
+         */
+        private def heal(
+          snapshotOrdinal: SnapshotOrdinal,
+          observedDelta:   OnChain,
+          prev:            Checkpoint[Option[CommitIndex]]
+        ): F[Either[DataApplicationValidationError, Checkpoint[Option[CommitIndex]]]] =
+          healClient match {
+            case Some(client) =>
+              client.fetch.attempt.flatMap {
+                case Right(res) =>
+                  val adopted =
+                    if (res.ordinal.value.value + 1L === snapshotOrdinal.value.value)
+                      Checkpoint(snapshotOrdinal, (CommitIndex.fold(res.index, observedDelta): CommitIndex).some)
+                    else
+                      Checkpoint(res.ordinal, res.index.some)
+                  logger
+                    .info(
+                      s"[DL1-cache] HEALED: ml0Ordinal=${res.ordinal} localOrdinal=$snapshotOrdinal " +
+                      s"indexFibers=${adopted.state.map(_.fiberCommits.size).getOrElse(0)} " +
+                      s"(prev=${prev.ordinal}${if (prev.state.isEmpty) ", unsynced" else ""})"
+                    )
+                    .as(adopted.asRight[DataApplicationValidationError])
+                case Left(e) =>
+                  logger
+                    .error(
+                      s"[DL1-cache] HEAL FAILED (${e.getMessage}): keeping " +
+                      s"${if (prev.state.isEmpty) "UNSYNCED (validating against an empty index!)"
+                        else s"stale ordinal=${prev.ordinal}"}; " +
+                      "will retry on next update"
+                    )
+                    .as(prev.asRight[DataApplicationValidationError])
+              }
+            case None =>
+              // transport-less dev mode: fold onto whatever base we have and advance, accepting
+              // potential incompleteness — loudly, every gap.
+              val base = prev.state.getOrElse(CommitIndex.empty)
+              logger
+                .error(
+                  s"[DL1-cache] ORDINAL GAP with NO heal client: ${prev.ordinal} -> $snapshotOrdinal; " +
+                  "folding onto a possibly-incomplete index (structural gate degraded; dev mode only)"
+                )
+                .as(
+                  Checkpoint(snapshotOrdinal, (CommitIndex.fold(base, observedDelta): CommitIndex).some)
+                    .asRight[DataApplicationValidationError]
+                )
+          }
       }
     }
 }

--- a/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/combine/AssetCombiner.scala
+++ b/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/combine/AssetCombiner.scala
@@ -1167,7 +1167,12 @@ class AssetCombiner[F[_]: Async: SecurityProvider](
   // State write helpers (assets + assetCommits, atomic)
   // ════════════════════════════════════════════════════════════════════════════════════════════════
 
-  /** Write an `AssetRecord` into `CalculatedState.assets` and its `AssetCommit` into `OnChain.assetCommits`. */
+  /**
+   * Write an `AssetRecord` into `CalculatedState.assets`, its `AssetCommit` into the cumulative
+   * `CalculatedState.assetCommits`, and the same commit into the per-batch
+   * `OnChain.touchedAssetCommits` delta. A write also clears any same-batch burn of the id so the
+   * delta stays consistent (`touched`/`burned` disjoint — see `CommitIndex.fold`).
+   */
   private def writeAsset(
     st:     DataState[OnChain, CalculatedState],
     record: AssetRecord
@@ -1175,19 +1180,31 @@ class AssetCombiner[F[_]: Async: SecurityProvider](
     record.computeDigest.map { recordHash =>
       val commit = AssetCommit(record.behavior.bits, record.sequenceNumber, recordHash, origin = None)
       st
-        .focus(_.onChain.assetCommits)
+        .focus(_.onChain.touchedAssetCommits)
+        .modify(_.updated(record.assetId, commit))
+        .focus(_.onChain.burnedAssets)
+        .modify(_ - record.assetId)
+        .focus(_.calculated.assetCommits)
         .modify(_.updated(record.assetId, commit))
         .focus(_.calculated.assets)
         .modify(_.updated(record.assetId, record))
     }
 
-  /** Remove an asset from both `CalculatedState.assets` and `OnChain.assetCommits`. */
+  /**
+   * Remove an asset (burn / compose-consume): drop it from `CalculatedState.assets` + the
+   * cumulative `CalculatedState.assetCommits`, record the removal in the per-batch
+   * `OnChain.burnedAssets` delta, and clear any same-batch touch of the id.
+   */
   private def removeAsset(
     st:      DataState[OnChain, CalculatedState],
     assetId: UUID
   ): DataState[OnChain, CalculatedState] =
     st
-      .focus(_.onChain.assetCommits)
+      .focus(_.onChain.touchedAssetCommits)
+      .modify(_ - assetId)
+      .focus(_.onChain.burnedAssets)
+      .modify(_ + assetId)
+      .focus(_.calculated.assetCommits)
       .modify(_ - assetId)
       .focus(_.calculated.assets)
       .modify(_ - assetId)

--- a/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/validate/AssetValidator.scala
+++ b/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/validate/AssetValidator.scala
@@ -2,7 +2,7 @@ package xyz.kd5ujc.shared_data.lifecycle.validate
 
 import cats.Applicative
 
-import xyz.kd5ujc.schema.OnChain
+import xyz.kd5ujc.schema.CommitIndex
 import xyz.kd5ujc.schema.Updates.{ApplyMorphism, AuthorizeCompose, CreateAssetPolicy, MintAsset}
 import xyz.kd5ujc.shared_data.lifecycle.validate.rules.AssetRules
 
@@ -19,8 +19,8 @@ import xyz.kd5ujc.shared_data.lifecycle.validate.rules.AssetRules
  */
 object AssetValidator {
 
-  /** L1 structural checks (OnChain only; no CalculatedState, no registry/asset lineage). */
-  class L1Validator[F[_]: Applicative](state: OnChain) {
+  /** L1 structural checks (recreated CommitIndex only; no registry/asset lineage). */
+  class L1Validator[F[_]: Applicative](index: CommitIndex) {
 
     def createAssetPolicy(update: CreateAssetPolicy): F[ValidationResult] =
       AssetRules.L1.createPolicyStructural(update)
@@ -29,7 +29,7 @@ object AssetValidator {
       AssetRules.L1.mintStructural(update)
 
     def applyMorphism(update: ApplyMorphism): F[ValidationResult] =
-      AssetRules.L1.applyMorphismStructural(update, state)
+      AssetRules.L1.applyMorphismStructural(update, index)
 
     def authorizeCompose(update: AuthorizeCompose): F[ValidationResult] =
       AssetRules.L1.authorizeComposeStructural(update)

--- a/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/validate/FiberValidator.scala
+++ b/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/validate/FiberValidator.scala
@@ -10,7 +10,7 @@ import io.constellationnetwork.security.SecurityProvider
 import io.constellationnetwork.security.signature.signature.SignatureProof
 
 import xyz.kd5ujc.schema.Updates.{ArchiveStateMachine, CreateStateMachine, TransitionStateMachine, UpgradeFiber}
-import xyz.kd5ujc.schema.{CalculatedState, OnChain}
+import xyz.kd5ujc.schema.{CalculatedState, CommitIndex, OnChain}
 import xyz.kd5ujc.shared_data.lifecycle.validate.rules.{CommonRules, FiberRules}
 
 /**
@@ -24,17 +24,18 @@ object FiberValidator {
   /**
    * L1 Validator - Structural validations at Data-L1 layer.
    *
-   * These validations run during API ingestion with only OnChain state available.
-   * They check structural validity without needing signature proofs or CalculatedState.
+   * These validations run during API ingestion against the recreated [[CommitIndex]] (OnChain v2
+   * carries only per-batch deltas; the DL1 folds/heals them into the index — onchain-incrementals
+   * RFC §3.3). They check structural validity without needing signature proofs or CalculatedState.
    *
-   * @param state The current OnChain state for existence checks
+   * @param index The recreated cumulative commit index for existence/sequence checks
    */
-  class L1Validator[F[_]: Monad](state: OnChain) {
+  class L1Validator[F[_]: Monad](index: CommitIndex) {
 
     /** Validates a CreateStateMachineFiber update */
     def createFiber(update: CreateStateMachine): F[ValidationResult] =
       for {
-        cidCheck       <- CommonRules.cidNotUsed(update.fiberId, state)
+        cidCheck       <- CommonRules.cidNotUsed(update.fiberId, index)
         definitionOk   <- FiberRules.L1.validStateMachineDefinition(update.definition)
         limitsOk       <- FiberRules.L1.definitionWithinLimits(update.definition)
         expressionsOk  <- FiberRules.L1.definitionExpressionsWithinDepthLimits(update.definition)
@@ -45,7 +46,7 @@ object FiberValidator {
           Limits.MaxInitialDataBytes,
           "initialData"
         )
-        parentExists <- FiberRules.L1.parentFiberExistsInOnChain(update.parentFiberId, state)
+        parentExists <- FiberRules.L1.parentFiberExistsInOnChain(update.parentFiberId, index)
       } yield List(
         cidCheck,
         definitionOk,
@@ -60,8 +61,8 @@ object FiberValidator {
     /** Validates a ProcessFiberEvent update */
     def processEvent(update: TransitionStateMachine): F[ValidationResult] =
       for {
-        cidExists      <- CommonRules.cidIsFound(update.fiberId, state)
-        seqNumOk       <- FiberRules.L1.sequenceNumberMatches(update.fiberId, update.targetSequenceNumber, state)
+        cidExists      <- CommonRules.cidIsFound(update.fiberId, index)
+        seqNumOk       <- FiberRules.L1.sequenceNumberMatches(update.fiberId, update.targetSequenceNumber, index)
         payloadNotNull <- CommonRules.isNotNull(update.payload, "payload")
         payloadSize <- CommonRules.valueWithinSizeLimit(
           update.payload,
@@ -74,19 +75,19 @@ object FiberValidator {
     /** Validates an ArchiveFiber update */
     def archiveFiber(update: ArchiveStateMachine): F[ValidationResult] =
       for {
-        cidExists <- CommonRules.cidIsFound(update.fiberId, state)
-        seqNumOk  <- FiberRules.L1.sequenceNumberMatches(update.fiberId, update.targetSequenceNumber, state)
+        cidExists <- CommonRules.cidIsFound(update.fiberId, index)
+        seqNumOk  <- FiberRules.L1.sequenceNumberMatches(update.fiberId, update.targetSequenceNumber, index)
       } yield List(cidExists, seqNumOk).combineAll
 
     /** Validates an UpgradeFiber update (structural: fiber exists, new definition valid, sequence) */
     def upgrade(update: UpgradeFiber): F[ValidationResult] =
       for {
-        cidExists     <- CommonRules.cidIsFound(update.fiberId, state)
+        cidExists     <- CommonRules.cidIsFound(update.fiberId, index)
         definitionOk  <- FiberRules.L1.validStateMachineDefinition(update.newDefinition)
         limitsOk      <- FiberRules.L1.definitionWithinLimits(update.newDefinition)
         expressionsOk <- FiberRules.L1.definitionExpressionsWithinDepthLimits(update.newDefinition)
         reservedOk    <- FiberRules.L1.noReservedOperatorFieldNames(update.newDefinition)
-        seqNumOk      <- FiberRules.L1.sequenceNumberMatches(update.fiberId, update.targetSequenceNumber, state)
+        seqNumOk      <- FiberRules.L1.sequenceNumberMatches(update.fiberId, update.targetSequenceNumber, index)
       } yield List(cidExists, definitionOk, limitsOk, expressionsOk, reservedOk, seqNumOk).combineAll
   }
 
@@ -157,7 +158,10 @@ object FiberValidator {
     state:  DataState[OnChain, CalculatedState],
     proofs: NonEmptySet[SignatureProof]
   ) {
-    private val l1 = new L1Validator[F](state.onChain)
+    // OnChain v2 carries only this batch's delta — the cumulative maps the structural checks need
+    // live in CalculatedState (same triple, same freshness as the v1 OnChain read; RFC §3.2).
+    private val index = CommitIndex.fromCalculated(state.calculated)
+    private val l1 = new L1Validator[F](index)
     private val l0 = new L0Validator[F](state, proofs)
 
     /** Validates a CreateStateMachineFiber update (all checks) */
@@ -182,7 +186,7 @@ object FiberValidator {
      */
     def processEvent(update: TransitionStateMachine): F[ValidationResult] =
       for {
-        cidExists        <- CommonRules.cidIsFound(update.fiberId, state.onChain)
+        cidExists        <- CommonRules.cidIsFound(update.fiberId, index)
         payloadNotNull   <- CommonRules.isNotNull(update.payload, "payload")
         payloadSize      <- CommonRules.valueWithinSizeLimit(update.payload, Limits.MaxEventPayloadBytes, "payload")
         payloadStructure <- CommonRules.payloadStructureValid(update.payload, "payload")
@@ -195,7 +199,7 @@ object FiberValidator {
      */
     def archiveFiber(update: ArchiveStateMachine): F[ValidationResult] =
       for {
-        cidExists <- CommonRules.cidIsFound(update.fiberId, state.onChain)
+        cidExists <- CommonRules.cidIsFound(update.fiberId, index)
         l0Result  <- l0.archiveFiber(update)
       } yield List(cidExists, l0Result).combineAll
 
@@ -209,7 +213,7 @@ object FiberValidator {
      */
     def upgrade(update: UpgradeFiber): F[ValidationResult] =
       for {
-        cidExists     <- CommonRules.cidIsFound(update.fiberId, state.onChain)
+        cidExists     <- CommonRules.cidIsFound(update.fiberId, index)
         definitionOk  <- FiberRules.L1.validStateMachineDefinition(update.newDefinition)
         limitsOk      <- FiberRules.L1.definitionWithinLimits(update.newDefinition)
         expressionsOk <- FiberRules.L1.definitionExpressionsWithinDepthLimits(update.newDefinition)

--- a/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/validate/ScriptValidator.scala
+++ b/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/validate/ScriptValidator.scala
@@ -10,7 +10,7 @@ import io.constellationnetwork.security.SecurityProvider
 import io.constellationnetwork.security.signature.signature.SignatureProof
 
 import xyz.kd5ujc.schema.Updates.{CreateScript, InvokeScript, UpgradeScript}
-import xyz.kd5ujc.schema.{CalculatedState, OnChain}
+import xyz.kd5ujc.schema.{CalculatedState, CommitIndex, OnChain}
 import xyz.kd5ujc.shared_data.lifecycle.validate.rules.{CommonRules, ScriptRules}
 
 /**
@@ -24,16 +24,17 @@ object ScriptValidator {
   /**
    * L1 Validator - Structural validations at Data-L1 layer.
    *
-   * These validations run during API ingestion with only OnChain state available.
+   * These validations run during API ingestion against the recreated [[CommitIndex]] (OnChain v2
+   * carries only per-batch deltas — onchain-incrementals RFC §3.3).
    *
-   * @param state The current OnChain state for existence checks
+   * @param index The recreated cumulative commit index for existence/sequence checks
    */
-  class L1Validator[F[_]: Monad](state: OnChain) {
+  class L1Validator[F[_]: Monad](index: CommitIndex) {
 
     /** Validates a CreateScript update */
     def createScript(update: CreateScript): F[ValidationResult] =
       for {
-        cidCheck       <- CommonRules.cidNotUsed(update.fiberId, state)
+        cidCheck       <- CommonRules.cidNotUsed(update.fiberId, index)
         initialStateOk <- CommonRules.isMapValueOrNull(update.initialState, "initialState")
         scriptDepthOk <- CommonRules.expressionWithinDepthLimit(
           update.scriptProgram,
@@ -50,8 +51,8 @@ object ScriptValidator {
     /** Validates an InvokeScript update */
     def invokeScript(update: InvokeScript): F[ValidationResult] =
       for {
-        cidExists     <- CommonRules.cidIsFound(update.fiberId, state)
-        seqNumOk      <- ScriptRules.L1.sequenceNumberMatches(update.fiberId, update.targetSequenceNumber, state)
+        cidExists     <- CommonRules.cidIsFound(update.fiberId, index)
+        seqNumOk      <- ScriptRules.L1.sequenceNumberMatches(update.fiberId, update.targetSequenceNumber, index)
         argsStructure <- CommonRules.payloadStructureValid(update.args, "args")
         argsSize <- CommonRules.valueWithinSizeLimit(
           update.args,
@@ -63,8 +64,8 @@ object ScriptValidator {
     /** Validates an UpgradeScript update (structural: script exists, new program depth, sequence) */
     def upgradeScript(update: UpgradeScript): F[ValidationResult] =
       for {
-        cidExists <- CommonRules.cidIsFound(update.fiberId, state)
-        seqNumOk  <- ScriptRules.L1.sequenceNumberMatches(update.fiberId, update.targetSequenceNumber, state)
+        cidExists <- CommonRules.cidIsFound(update.fiberId, index)
+        seqNumOk  <- ScriptRules.L1.sequenceNumberMatches(update.fiberId, update.targetSequenceNumber, index)
         programOk <- CommonRules.expressionWithinDepthLimit(update.newProgram, "newProgram", Limits.MaxExpressionDepth)
       } yield List(cidExists, seqNumOk, programOk).combineAll
   }
@@ -124,7 +125,10 @@ object ScriptValidator {
     state:  DataState[OnChain, CalculatedState],
     proofs: NonEmptySet[SignatureProof]
   ) {
-    private val l1 = new L1Validator[F](state.onChain)
+    // OnChain v2 carries only this batch's delta — the cumulative maps the structural checks need
+    // live in CalculatedState (same triple, same freshness as the v1 OnChain read; RFC §3.2).
+    private val index = CommitIndex.fromCalculated(state.calculated)
+    private val l1 = new L1Validator[F](index)
     private val l0 = new L0Validator[F](state, proofs)
 
     /** Validates a CreateScript update (all checks) */
@@ -144,7 +148,7 @@ object ScriptValidator {
      */
     def invokeScript(update: InvokeScript): F[ValidationResult] =
       for {
-        cidExists     <- CommonRules.cidIsFound(update.fiberId, state.onChain)
+        cidExists     <- CommonRules.cidIsFound(update.fiberId, index)
         argsStructure <- CommonRules.payloadStructureValid(update.args, "args")
         argsSize      <- CommonRules.valueWithinSizeLimit(update.args, Limits.MaxEventPayloadBytes, "args")
         l0Result      <- l0.invokeScript(update)
@@ -157,7 +161,7 @@ object ScriptValidator {
      */
     def upgradeScript(update: UpgradeScript): F[ValidationResult] =
       for {
-        cidExists <- CommonRules.cidIsFound(update.fiberId, state.onChain)
+        cidExists <- CommonRules.cidIsFound(update.fiberId, index)
         programOk <- CommonRules.expressionWithinDepthLimit(update.newProgram, "newProgram", Limits.MaxExpressionDepth)
         l0Result  <- l0.upgradeScript(update)
       } yield List(cidExists, programOk, l0Result).combineAll

--- a/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/validate/rules/AssetRules.scala
+++ b/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/validate/rules/AssetRules.scala
@@ -8,7 +8,7 @@ import cats.syntax.all._
 
 import io.constellationnetwork.currency.dataApplication.DataApplicationValidationError
 
-import xyz.kd5ujc.schema.OnChain
+import xyz.kd5ujc.schema.CommitIndex
 import xyz.kd5ujc.schema.Updates.{ApplyMorphism, AuthorizeCompose, CreateAssetPolicy, MintAsset}
 import xyz.kd5ujc.schema.asset.{MorphismKind, TokenBehavior}
 import xyz.kd5ujc.schema.fiber.FiberOrdinal
@@ -49,9 +49,9 @@ object AssetRules {
      */
     def applyMorphismStructural[F[_]: Applicative](
       update: ApplyMorphism,
-      state:  OnChain
+      index:  CommitIndex
     ): F[ValidationResult] =
-      state.assetCommits.get(update.assetId) match {
+      index.assetCommits.get(update.assetId) match {
         case None =>
           (Errors.AssetNotFound(update.assetId): DataApplicationValidationError).invalidNec[Unit].pure[F]
         case Some(commit) =>

--- a/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/validate/rules/CommonRules.scala
+++ b/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/validate/rules/CommonRules.scala
@@ -10,7 +10,7 @@ import io.constellationnetwork.currency.dataApplication.DataApplicationValidatio
 import io.constellationnetwork.metagraph_sdk.json_logic._
 import io.constellationnetwork.metagraph_sdk.numerics.RatioOps.implicits._
 
-import xyz.kd5ujc.schema.OnChain
+import xyz.kd5ujc.schema.CommitIndex
 import xyz.kd5ujc.shared_data.lifecycle.validate.{Limits, ValidationResult}
 
 /**
@@ -24,20 +24,20 @@ object CommonRules {
   // ============== CID Rules ==============
 
   /** Validates that a CID is not already in use (for create operations) */
-  def cidNotUsed[F[_]: Applicative](cid: UUID, state: OnChain): F[ValidationResult] =
+  def cidNotUsed[F[_]: Applicative](cid: UUID, index: CommitIndex): F[ValidationResult] =
     Validated
       .condNec(
-        !state.fiberCommits.contains(cid),
+        !index.fiberCommits.contains(cid),
         (),
         Errors.CidAlreadyExists(cid): DataApplicationValidationError
       )
       .pure[F]
 
   /** Validates that a CID exists (for update operations) */
-  def cidIsFound[F[_]: Applicative](cid: UUID, state: OnChain): F[ValidationResult] =
+  def cidIsFound[F[_]: Applicative](cid: UUID, index: CommitIndex): F[ValidationResult] =
     Validated
       .condNec(
-        state.fiberCommits.contains(cid),
+        index.fiberCommits.contains(cid),
         (),
         Errors.CidNotFound(cid): DataApplicationValidationError
       )

--- a/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/validate/rules/FiberRules.scala
+++ b/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/validate/rules/FiberRules.scala
@@ -14,7 +14,7 @@ import io.constellationnetwork.security.SecurityProvider
 import io.constellationnetwork.security.signature.signature.SignatureProof
 
 import xyz.kd5ujc.schema.fiber.{FiberOrdinal, FiberStatus, StateId, StateMachineDefinition}
-import xyz.kd5ujc.schema.{CalculatedState, OnChain, Records}
+import xyz.kd5ujc.schema.{CalculatedState, CommitIndex, Records}
 import xyz.kd5ujc.shared_data.lifecycle.validate.{Limits, ValidationResult}
 import xyz.kd5ujc.shared_data.syntax.calculatedState._
 
@@ -196,9 +196,9 @@ object FiberRules {
     def sequenceNumberMatches[F[_]: Applicative](
       fiberId:              UUID,
       targetSequenceNumber: FiberOrdinal,
-      state:                OnChain
+      index:                CommitIndex
     ): F[ValidationResult] =
-      state.fiberCommits
+      index.fiberCommits
         .get(fiberId)
         .fold(
           // Fiber not found — cidIsFound already catches this, pass here
@@ -217,15 +217,15 @@ object FiberRules {
             .pure[F]
         }
 
-    /** Validates parent fiber exists in on-chain state (L1 structural check) */
+    /** Validates parent fiber exists in the recreated commit index (L1 structural check) */
     def parentFiberExistsInOnChain[F[_]: Applicative](
       parentFiberId: Option[UUID],
-      state:         OnChain
+      index:         CommitIndex
     ): F[ValidationResult] =
       parentFiberId.fold(().validNec[DataApplicationValidationError].pure[F]) { parentId =>
         Validated
           .condNec(
-            state.fiberCommits.contains(parentId),
+            index.fiberCommits.contains(parentId),
             (),
             Errors.ParentFiberNotFound(parentId): DataApplicationValidationError
           )

--- a/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/validate/rules/ScriptRules.scala
+++ b/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/validate/rules/ScriptRules.scala
@@ -14,7 +14,7 @@ import io.constellationnetwork.security.signature.signature.SignatureProof
 
 import xyz.kd5ujc.schema.fiber.{AccessControlPolicy, FiberOrdinal, FiberStatus}
 import xyz.kd5ujc.schema.registry.RegistryName
-import xyz.kd5ujc.schema.{CalculatedState, OnChain}
+import xyz.kd5ujc.schema.{CalculatedState, CommitIndex}
 import xyz.kd5ujc.shared_data.lifecycle.validate.ValidationResult
 import xyz.kd5ujc.shared_data.syntax.all._
 
@@ -37,9 +37,9 @@ object ScriptRules {
     def sequenceNumberMatches[F[_]: Applicative](
       fiberId:              UUID,
       targetSequenceNumber: FiberOrdinal,
-      state:                OnChain
+      index:                CommitIndex
     ): F[ValidationResult] =
-      FiberRules.L1.sequenceNumberMatches(fiberId, targetSequenceNumber, state)
+      FiberRules.L1.sequenceNumberMatches(fiberId, targetSequenceNumber, index)
   }
 
   // ============================================================================

--- a/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/syntax/DataStateOps.scala
+++ b/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/syntax/DataStateOps.scala
@@ -17,9 +17,11 @@ import monocle.Monocle.toAppliedFocusOps
 /**
  * Extension methods for DataState to simplify state updates.
  *
- * These operations ensure that both OnChain (hashes) and CalculatedState (records)
- * are updated atomically. RecordHash and stateDataHash are computed internally —
- * callers only provide the record.
+ * These operations ensure that OnChain (the per-batch `touched*` delta), the cumulative
+ * CalculatedState commit maps, and the CalculatedState records are updated atomically — the
+ * same fold writes all three from the same computed hash, so delta and cumulative state cannot
+ * diverge (onchain-incrementals RFC §3.1). RecordHash and stateDataHash are computed
+ * internally — callers only provide the record.
  */
 trait DataStateOps {
 
@@ -44,7 +46,9 @@ trait DataStateOps {
           sm.computeDigest.map { recordHash =>
             val commit = FiberCommit(recordHash, Some(sm.stateDataHash), sm.sequenceNumber)
             state
-              .focus(_.onChain.fiberCommits)
+              .focus(_.onChain.touchedFiberCommits)
+              .modify(_.updated(id, commit))
+              .focus(_.calculated.fiberCommits)
               .modify(_.updated(id, commit))
               .focus(_.calculated.stateMachines)
               .modify(_.updated(id, sm))
@@ -53,7 +57,9 @@ trait DataStateOps {
           script.computeDigest.map { recordHash =>
             val commit = FiberCommit(recordHash, script.stateDataHash, script.sequenceNumber)
             state
-              .focus(_.onChain.fiberCommits)
+              .focus(_.onChain.touchedFiberCommits)
+              .modify(_.updated(id, commit))
+              .focus(_.calculated.fiberCommits)
               .modify(_.updated(id, commit))
               .focus(_.calculated.scripts)
               .modify(_.updated(id, script))
@@ -83,7 +89,9 @@ trait DataStateOps {
           o.computeDigest.map(recordHash => id -> FiberCommit(recordHash, o.stateDataHash, o.sequenceNumber))
         }
       } yield state
-        .focus(_.onChain.fiberCommits)
+        .focus(_.onChain.touchedFiberCommits)
+        .modify(_ ++ smHashes.toMap ++ scriptHashes.toMap)
+        .focus(_.calculated.fiberCommits)
         .modify(_ ++ smHashes.toMap ++ scriptHashes.toMap)
         .focus(_.calculated.stateMachines)
         .modify(_ ++ sms)
@@ -105,9 +113,10 @@ trait DataStateOps {
       withRecords(fibers ++ scripts)
 
     /**
-     * Commit a registry entry atomically: store the entry in CalculatedState.registry and its hash in
-     * OnChain.registryCommits. The chain commits only the entry's hash + metadata, never schema/definition
-     * bytes.
+     * Commit a registry entry atomically: store the entry in CalculatedState.registry, its hash in the
+     * cumulative CalculatedState.registryCommits, and the same hash in the per-batch
+     * OnChain.touchedRegistryCommits delta. The chain commits only the entry's hash + metadata, never
+     * schema/definition bytes.
      */
     def withRegistryEntry[F[_]: Async](
       name:  RegistryName,
@@ -115,7 +124,9 @@ trait DataStateOps {
     ): F[DataState[OnChain, CalculatedState]] =
       entry.computeDigest.map { entryHash =>
         state
-          .focus(_.onChain.registryCommits)
+          .focus(_.onChain.touchedRegistryCommits)
+          .modify(_.updated(name, entryHash))
+          .focus(_.calculated.registryCommits)
           .modify(_.updated(name, entryHash))
           .focus(_.calculated.registry)
           .modify(_.updated(name, entry))

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/AssetFiberTransferSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/AssetFiberTransferSuite.scala
@@ -155,7 +155,7 @@ object AssetFiberTransferSuite extends SimpleIOSuite {
       // the channel works: holder is now Bob's wallet, sequence bumped, commit updated
       expect(moved.map(_.holder).contains(AssetHolder.Wallet(bobAddr))) and
       expect(moved.map(_.sequenceNumber).contains(FiberOrdinal.MinValue.next)) and
-      expect(after.onChain.assetCommits.get(assetId).map(_.sequenceNumber).contains(FiberOrdinal.MinValue.next)) and
+      expect(after.calculated.assetCommits.get(assetId).map(_.sequenceNumber).contains(FiberOrdinal.MinValue.next)) and
       // the escrow advanced to RELEASED
       expect(escrowAfter.map(_.currentState).contains(StateId("RELEASED")))
     }

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/AssetOpCombinerSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/AssetOpCombinerSuite.scala
@@ -24,7 +24,7 @@ import xyz.kd5ujc.schema.Updates.{
 import xyz.kd5ujc.schema.asset._
 import xyz.kd5ujc.schema.fiber.{FiberLogEntry, FiberOrdinal}
 import xyz.kd5ujc.schema.registry._
-import xyz.kd5ujc.schema.{AssetCommit, CalculatedState, OnChain}
+import xyz.kd5ujc.schema.{AssetCommit, CalculatedState, CommitIndex, OnChain}
 import xyz.kd5ujc.shared_data.lifecycle.validate.AssetValidator
 import xyz.kd5ujc.shared_data.lifecycle.{Combiner, Validator}
 import xyz.kd5ujc.shared_test.Participant._
@@ -94,9 +94,9 @@ object AssetOpCombinerSuite extends SimpleIOSuite {
       case _                                 => false
     }
 
-  // An OnChain carrying a single AssetCommit for `assetId` at sequence 0 with the given behavior bits.
-  private def onChainWithAsset(behavior: TokenBehavior, seq: FiberOrdinal = FiberOrdinal.MinValue): OnChain =
-    OnChain.genesis.copy(
+  // A CommitIndex carrying a single AssetCommit for `assetId` at sequence 0 with the given behavior bits.
+  private def onChainWithAsset(behavior: TokenBehavior, seq: FiberOrdinal = FiberOrdinal.MinValue): CommitIndex =
+    CommitIndex.empty.copy(
       assetCommits = SortedMap(assetId -> AssetCommit(behavior.bits, seq, Hash("asset-record-hash")))
     )
 
@@ -153,7 +153,7 @@ object AssetOpCombinerSuite extends SimpleIOSuite {
   }
 
   test("ApplyMorphism is INVALID when the asset is unknown (no on-chain commit)") {
-    val l1 = new AssetValidator.L1Validator[IO](OnChain.genesis) // empty assetCommits
+    val l1 = new AssetValidator.L1Validator[IO](CommitIndex.empty) // empty assetCommits
     l1.applyMorphism(ApplyMorphism(assetId, MorphismKind.Burn, FiberOrdinal.MinValue)).map { r =>
       expect(r.isInvalid)
     }
@@ -169,7 +169,7 @@ object AssetOpCombinerSuite extends SimpleIOSuite {
   }
 
   test("MintAsset is INVALID when amount <= 0, VALID when amount > 0") {
-    val l1 = new AssetValidator.L1Validator[IO](OnChain.genesis)
+    val l1 = new AssetValidator.L1Validator[IO](CommitIndex.empty)
     val zero = MintAsset(assetId, SchemaRef(asset("gold"), VersionReq.Latest), AssetHolder.Fiber(assetId), 0L)
     val pos = MintAsset(assetId, SchemaRef(asset("gold"), VersionReq.Latest), AssetHolder.Fiber(assetId), 1L)
     for {
@@ -217,7 +217,7 @@ object AssetOpCombinerSuite extends SimpleIOSuite {
       val p1 = createPolicy("gold", SemVer(1, 0, 0))
       val p2 = createPolicy("gold", SemVer(1, 1, 0))
       for {
-        validator <- Validator.make[IO]
+        validator <- Validator.make[IO]()
         pr1       <- fixture.registry.generateProofs(p1, Set(Alice))
         valid     <- validator.validateSignedUpdate(genesis, Signed(p1, pr1))
         s1        <- combiner.insert(genesis, Signed(p1, pr1))
@@ -231,7 +231,7 @@ object AssetOpCombinerSuite extends SimpleIOSuite {
           .exists(_.isInstanceOf[RegistryShape.AssetPolicy])
       } yield expect(valid.isValid) and
       expect(policyVersions(s2, "gold").contains(Set(SemVer(1, 0, 0), SemVer(1, 1, 0)))) and
-      expect(s2.onChain.registryCommits.contains(asset("gold"))) and
+      expect(s2.calculated.registryCommits.contains(asset("gold"))) and
       expect(shapeIsAssetPolicy)
     }
   }
@@ -244,7 +244,7 @@ object AssetOpCombinerSuite extends SimpleIOSuite {
       val p1 = createPolicy("gold", SemVer(1, 0, 0)) // Alice claims + owns
       val p2 = createPolicy("gold", SemVer(1, 1, 0)) // Bob (not an owner) tries to publish
       for {
-        validator     <- Validator.make[IO]
+        validator     <- Validator.make[IO]()
         pr1           <- fixture.registry.generateProofs(p1, Set(Alice))
         s1            <- combiner.insert(genesis, Signed(p1, pr1))
         pr2           <- fixture.registry.generateProofs(p2, Set(Bob))

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/AssetPolicyPackageSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/AssetPolicyPackageSuite.scala
@@ -134,7 +134,7 @@ object AssetPolicyPackageSuite extends SimpleIOSuite {
   }
 
   test("OnChain carrying an asset-policy registry commit round-trips") {
-    val oc = OnChain.genesis.copy(registryCommits = SortedMap(policyEntry.name -> Hash("assethash")))
+    val oc = OnChain.genesis.copy(touchedRegistryCommits = SortedMap(policyEntry.name -> Hash("assethash")))
     val json = oc.asJson.noSpaces
     IO.pure(expect(decode[OnChain](json) == Right(oc)))
   }

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/CommitIndexFoldSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/CommitIndexFoldSuite.scala
@@ -1,0 +1,86 @@
+package xyz.kd5ujc.shared_data
+
+import java.util.UUID
+
+import cats.effect.IO
+
+import scala.collection.immutable.{SortedMap, SortedSet}
+
+import io.constellationnetwork.security.hash.Hash
+
+import xyz.kd5ujc.schema.fiber.FiberOrdinal
+import xyz.kd5ujc.schema.registry.RegistryName
+import xyz.kd5ujc.schema.{AssetCommit, CalculatedState, CommitIndex, FiberCommit, OnChain}
+
+import weaver.SimpleIOSuite
+
+/**
+ * `CommitIndex.fold` is the DL1's recreation of the cumulative commit maps from per-batch OnChain
+ * v2 deltas (onchain-incrementals RFC §3.3). The genuinely load-bearing semantics:
+ *   - upserts overwrite (a later touch of the same id wins — sequence bumps must land);
+ *   - burns REMOVE, and burn-then-later-remint works (the maps are keyed state, not a log);
+ *   - fold(fromCalculated(prev), delta) == fromCalculated(next) — the DL1's folded view must be
+ *     extensionally identical to the ML0's CalculatedState-derived view, else the two gates drift.
+ */
+object CommitIndexFoldSuite extends SimpleIOSuite {
+
+  private def uuid(i: Int): UUID = new UUID(0L, i.toLong)
+  private def h(s:    String): Hash = Hash(s * 64 take 64)
+  private def fc(seq: Long): FiberCommit = FiberCommit(h("a"), Some(h("b")), FiberOrdinal.unsafeApply(seq))
+  private def ac(seq: Long): AssetCommit = AssetCommit(21, FiberOrdinal.unsafeApply(seq), h("c"), None)
+
+  private val pkgName = RegistryName.unsafe("escrow.package")
+
+  test("fold applies upserts, overwrites on re-touch, and removes burns") {
+    val base = CommitIndex(
+      fiberCommits = SortedMap(uuid(1) -> fc(1)),
+      assetCommits = SortedMap(uuid(10) -> ac(1), uuid(11) -> ac(5)),
+      registryCommits = SortedMap(pkgName -> h("d"))
+    )
+    val delta = OnChain.genesis.copy(
+      touchedFiberCommits = SortedMap(uuid(1) -> fc(2), uuid(2) -> fc(0)), // bump + create
+      touchedAssetCommits = SortedMap(uuid(12) -> ac(0)), // mint
+      burnedAssets = SortedSet(uuid(10)) // burn
+    )
+    val next = CommitIndex.fold(base, delta)
+    IO.pure(
+      expect(next.fiberCommits(uuid(1)).sequenceNumber == FiberOrdinal.unsafeApply(2L)) and
+      expect(next.fiberCommits.contains(uuid(2))) and
+      expect(!next.assetCommits.contains(uuid(10))) and
+      expect(next.assetCommits.contains(uuid(11)) && next.assetCommits.contains(uuid(12))) and
+      expect(next.registryCommits == base.registryCommits)
+    )
+  }
+
+  test("a same-batch touch+burn resolves to burned (writers keep the two disjoint; fold is defensive)") {
+    val delta = OnChain.genesis.copy(
+      touchedAssetCommits = SortedMap(uuid(10) -> ac(0)),
+      burnedAssets = SortedSet(uuid(10))
+    )
+    IO.pure(expect(!CommitIndex.fold(CommitIndex.empty, delta).assetCommits.contains(uuid(10))))
+  }
+
+  test("folded DL1 view == ML0 fromCalculated view after the same writes") {
+    // simulate what DataStateOps/AssetCombiner do: identical commits written to CalculatedState
+    // (cumulative) and to the OnChain delta (touched) in the same fold
+    val cs = CalculatedState.genesis.copy(
+      fiberCommits = SortedMap(uuid(1) -> fc(3), uuid(2) -> fc(0)),
+      assetCommits = SortedMap(uuid(12) -> ac(0)),
+      registryCommits = SortedMap(pkgName -> h("d"))
+    )
+    val replayedDeltas = List(
+      OnChain.genesis.copy(
+        touchedFiberCommits = SortedMap(uuid(1) -> fc(1), uuid(2) -> fc(0)),
+        touchedAssetCommits = SortedMap(uuid(10) -> ac(0)),
+        touchedRegistryCommits = SortedMap(pkgName -> h("d"))
+      ),
+      OnChain.genesis.copy(
+        touchedFiberCommits = SortedMap(uuid(1) -> fc(3)),
+        touchedAssetCommits = SortedMap(uuid(12) -> ac(0)),
+        burnedAssets = SortedSet(uuid(10))
+      )
+    )
+    val folded = replayedDeltas.foldLeft(CommitIndex.empty)(CommitIndex.fold)
+    IO.pure(expect(folded == CommitIndex.fromCalculated(cs)))
+  }
+}

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/CommittedViewSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/CommittedViewSuite.scala
@@ -93,4 +93,27 @@ object CommittedViewSuite extends SimpleIOSuite {
       expect(CalculatedState.committedView.entries(s).size == s.assets.size + s.usedNonces.size)
     )
   }
+
+  // ── commit/ projections (onchain-incrementals RFC §3.1) — the provable DL1 heal namespace ──
+
+  test("entries projects commit/f|a|r keys; over-long registry names take the hashed fallback") {
+    import xyz.kd5ujc.schema.{AssetCommit, FiberCommit}
+    import xyz.kd5ujc.schema.fiber.FiberOrdinal
+
+    val s = CalculatedState.genesis.copy(
+      fiberCommits = SortedMap(rid -> FiberCommit(Hash("rh"), Some(Hash("sh")), FiberOrdinal.MinValue)),
+      assetCommits = SortedMap(assetId -> AssetCommit(21, FiberOrdinal.MinValue, Hash("ah"))),
+      registryCommits = SortedMap(escrow -> Hash("eh"), longName -> Hash("lh"))
+    )
+    val keys = CalculatedState.committedView.entries(s).keySet.map(_.value)
+    IO.pure(
+      expect(keys.contains(s"commit/f/$rid")) and
+      expect(keys.contains(s"commit/a/$assetId")) and
+      expect(keys.contains("commit/r/escrow.package")) and
+      // key derivation stays TOTAL: the 79-char name overflows a segment -> hashed fallback
+      expect(keys.exists(k => k.startsWith("commit/r/h/") && k.stripPrefix("commit/r/h/").matches("[0-9a-f]{64}"))) and
+      // one leaf per commit entry, nothing dropped
+      expect(CalculatedState.committedView.entries(s).size == 1 + 1 + 2)
+    )
+  }
 }

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/DirectiveInjectionHardeningSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/DirectiveInjectionHardeningSuite.scala
@@ -170,7 +170,7 @@ object DirectiveInjectionHardeningSuite extends SimpleIOSuite {
       // and CRUCIALLY the asset never moved — still fiber-held by the victim at the original sequence
       expect(assetAfter.map(_.holder).contains(AssetHolder.Fiber(victimId))) and
       expect(assetAfter.map(_.sequenceNumber).contains(FiberOrdinal.MinValue)) and
-      expect(after.onChain.assetCommits.get(assetId).isEmpty)
+      expect(after.calculated.assetCommits.get(assetId).isEmpty)
     }
   }
 

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/E2eSignedPayloadCompatSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/E2eSignedPayloadCompatSuite.scala
@@ -10,7 +10,7 @@ import cats.effect.IO
 import io.constellationnetwork.metagraph_sdk.std.{JsonBinaryCodec, JsonCanonicalizer}
 
 import xyz.kd5ujc.schema.Updates._
-import xyz.kd5ujc.schema.{OnChain, Updates}
+import xyz.kd5ujc.schema.{CommitIndex, Updates}
 import xyz.kd5ujc.shared_data.lifecycle.validate.{FiberValidator, ScriptValidator}
 
 import io.circe.parser.parse
@@ -124,7 +124,7 @@ object E2eSignedPayloadCompatSuite extends SimpleIOSuite {
     val update = decodeMessage(votingCreateJson)
     update match {
       case u: CreateStateMachine =>
-        new FiberValidator.L1Validator[IO](OnChain.genesis).createFiber(u).map { result =>
+        new FiberValidator.L1Validator[IO](CommitIndex.empty).createFiber(u).map { result =>
           expect(
             result.isValid,
             s"L1 validation failed: ${result.fold(_.toNonEmptyList.toList.map(_.message).mkString("; "), _ => "")}"
@@ -138,7 +138,7 @@ object E2eSignedPayloadCompatSuite extends SimpleIOSuite {
     val update = decodeMessage(counterCreateScriptJson)
     update match {
       case u: CreateScript =>
-        new ScriptValidator.L1Validator[IO](OnChain.genesis).createScript(u).map { result =>
+        new ScriptValidator.L1Validator[IO](CommitIndex.empty).createScript(u).map { result =>
           expect(
             result.isValid,
             s"L1 validation failed: ${result.fold(_.toNonEmptyList.toList.map(_.message).mkString("; "), _ => "")}"

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/GenesisBuilderSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/GenesisBuilderSuite.scala
@@ -50,10 +50,10 @@ object GenesisBuilderSuite extends SimpleIOSuite {
     for {
       genesis <- GenesisBuilder.withPackages[IO](List(spec("identity"), spec("governance")))
       entry = genesis.calculated.registry.get(idName)
-      commit = genesis.onChain.registryCommits.get(idName)
+      commit = genesis.calculated.registryCommits.get(idName)
       expectedCommit <- entry.traverse(_.computeDigest)
     } yield expect(genesis.calculated.registry.size == 2) and
-    expect(genesis.onChain.registryCommits.size == 2) and
+    expect(genesis.calculated.registryCommits.size == 2) and
     expect(commit == expectedCommit) and
     expect(entry.exists(_.target match {
       case RegistryTarget.SchemaPackage(lineage) => lineage.versions.contains(SemVer(1, 0, 0))
@@ -78,7 +78,7 @@ object GenesisBuilderSuite extends SimpleIOSuite {
 
   test("an empty spec list yields the empty genesis") {
     GenesisBuilder.withPackages[IO](Nil).map { g =>
-      expect(g.calculated.registry.isEmpty) and expect(g.onChain.registryCommits.isEmpty)
+      expect(g.calculated.registry.isEmpty) and expect(g.calculated.registryCommits.isEmpty)
     }
   }
 
@@ -94,7 +94,7 @@ object GenesisBuilderSuite extends SimpleIOSuite {
             case _                                => false
           })
       ) and
-      expect(g.onChain.registryCommits.contains(aliasName)) and
+      expect(g.calculated.registryCommits.contains(aliasName)) and
       expect(g.calculated.reverseNames.get(fid).contains(aliasName))
     }
   }
@@ -125,7 +125,7 @@ object GenesisBuilderSuite extends SimpleIOSuite {
     ) and
     expect(genesis.calculated.reverseNames.get(fid).contains(aliasName)) and
     expect(genesis.calculated.stateMachines.get(fid).contains(fiber)) and
-    expect(genesis.onChain.fiberCommits.get(fid).exists(_.recordHash == expectedCommit)) and
-    expect(genesis.onChain.registryCommits.contains(aliasName))
+    expect(genesis.calculated.fiberCommits.get(fid).exists(_.recordHash == expectedCommit)) and
+    expect(genesis.calculated.registryCommits.contains(aliasName))
   }
 }

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/GenesisDataSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/GenesisDataSuite.scala
@@ -47,7 +47,7 @@ object GenesisDataSuite extends SimpleIOSuite {
 
   private val nonEmptyGenesis: GenesisData =
     GenesisData(
-      onChain = OnChain.genesis.copy(registryCommits = SortedMap(entry.name -> Hash("entryhash"))),
+      onChain = OnChain.genesis.copy(touchedRegistryCommits = SortedMap(entry.name -> Hash("entryhash"))),
       calculated = CalculatedState.genesis.copy(registry = SortedMap(entry.name -> entry))
     )
 

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/GenesisLoaderSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/GenesisLoaderSuite.scala
@@ -48,7 +48,7 @@ object GenesisLoaderSuite extends SimpleIOSuite {
 
   private val populatedState: DataState[OnChain, CalculatedState] =
     DataState(
-      OnChain.genesis.copy(registryCommits = SortedMap(entry.name -> Hash("entryhash"))),
+      OnChain.genesis.copy(touchedRegistryCommits = SortedMap(entry.name -> Hash("entryhash"))),
       CalculatedState.genesis.copy(registry = SortedMap(entry.name -> entry))
     )
 
@@ -70,7 +70,7 @@ object GenesisLoaderSuite extends SimpleIOSuite {
     GenesisLoader.load[IO](None).map { ds =>
       expect(ds == emptyState) and
       expect(ds.calculated.registry.isEmpty) and
-      expect(ds.onChain.registryCommits.isEmpty)
+      expect(ds.calculated.registryCommits.isEmpty)
     }
   }
 

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/GenesisManifestLoaderSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/GenesisManifestLoaderSuite.scala
@@ -32,7 +32,7 @@ object GenesisManifestLoaderSuite extends SimpleIOSuite {
       genesis  <- GenesisManifestLoader.fromManifest[IO](manifest)
     } yield expect(manifest.packages.size == 1) and
     expect(genesis.calculated.registry.contains(idName)) and
-    expect(genesis.onChain.registryCommits.contains(idName)) and
+    expect(genesis.calculated.registryCommits.contains(idName)) and
     expect(
       genesis.calculated.registry
         .get(idName)

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/MultiPartyTransitionSigningSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/MultiPartyTransitionSigningSuite.scala
@@ -200,7 +200,7 @@ object MultiPartyTransitionSigningSuite extends SimpleIOSuite {
       implicit val l0ctx: L0NodeContext[IO] = fixture.l0Context
       for {
         combiner  <- Combiner.make[IO]().pure[IO]
-        validator <- Validator.make[IO]
+        validator <- Validator.make[IO]()
 
         contractFiberId <- UUIDGen.randomUUID[IO]
 

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/OnChainWireSizeSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/OnChainWireSizeSuite.scala
@@ -1,0 +1,127 @@
+package xyz.kd5ujc.shared_data
+
+import java.util.UUID
+
+import cats.effect.IO
+
+import scala.collection.immutable.SortedMap
+
+import io.constellationnetwork.metagraph_sdk.crypto.smt.SparseMerkleRoot
+import io.constellationnetwork.metagraph_sdk.lifecycle.committed.{CommittedBreadcrumb, CommittedOnChain, CommittedRoots}
+import io.constellationnetwork.metagraph_sdk.std.JsonBinaryCodec._
+import io.constellationnetwork.schema.SnapshotOrdinal
+import io.constellationnetwork.security.hash.Hash
+
+import xyz.kd5ujc.schema.fiber.FiberOrdinal
+import xyz.kd5ujc.schema.registry.RegistryName
+import xyz.kd5ujc.schema.{AssetCommit, FiberCommit, OnChain}
+
+import weaver.SimpleIOSuite
+
+/**
+ * Phase-0 probe for the onchain-incrementals migration (docs/proposals/onchain-incrementals.md).
+ *
+ * tessellation caps the whole state-channel snapshot binary at 512,000 bytes
+ * (`max-state-channel-snapshot-binary-size-in-bytes`, node-shared application.conf; enforced in
+ * `CurrencySnapshotCreator.createProposalArtifact`). The cumulative `OnChain` maps ride inside
+ * `dataApplication.onChainState` of EVERY incremental snapshot, and the framework's events-cutter
+ * cannot shrink them — once the cumulative maps alone exceed the budget, the metagraph can no
+ * longer produce any snapshot (`UnableToReduceProposalByCutting`): a permanent halt.
+ *
+ * These tests pin the marginal wire cost of each cumulative entry via the production
+ * serialization path (`CommittedOnChain[OnChain].toBinary`, the exact bytes embedded in the
+ * snapshot). Serialization is deterministic, so the bands are tight regression guards: if one
+ * breaks, a codec change either bloated the wire format (burning ceiling headroom) or shrank it —
+ * either way the RFC numbers and this suite must be re-derived together. When OnChain v2 lands
+ * (per-batch deltas), the ceiling test below is expected to become obsolete and should be
+ * replaced by an O(churn) assertion.
+ */
+object OnChainWireSizeSuite extends SimpleIOSuite {
+
+  private val TessellationBudgetBytes = 512000
+
+  // constant-size breadcrumb, same shape makeL0 wraps around OnChain (value irrelevant to marginals)
+  private val breadcrumb =
+    CommittedBreadcrumb(SnapshotOrdinal.MinValue, CommittedRoots(Hash.empty, SparseMerkleRoot.empty))
+
+  // deterministic 64-hex digests / uuids so every run serializes byte-identically
+  private def hex64(salt: Int, i: Int): Hash = {
+    val h = (BigInt(salt) * 1000003 + BigInt(i)).toString(16)
+    Hash(("0" * (64 - h.length)) + h)
+  }
+
+  private def uuid(i: Int): UUID = new UUID(0L, i.toLong)
+
+  private def withFibers(n: Int): OnChain =
+    OnChain.genesis.copy(fiberCommits = SortedMap.from((0 until n).map { i =>
+      uuid(i) -> FiberCommit(hex64(1, i), Some(hex64(2, i)), FiberOrdinal.unsafeApply(1000L + i))
+    }))
+
+  private def withAssets(n: Int): OnChain =
+    OnChain.genesis.copy(assetCommits = SortedMap.from((0 until n).map { i =>
+      uuid(i) -> AssetCommit(behavior = 21, FiberOrdinal.unsafeApply(1000L + i), hex64(3, i), origin = None)
+    }))
+
+  private def withRegistry(n: Int): OnChain =
+    OnChain.genesis.copy(registryCommits = SortedMap.from((0 until n).map { i =>
+      RegistryName.unsafe(s"vendor$i.escrow.package") -> hex64(4, i)
+    }))
+
+  private def wireBytes(oc: OnChain): IO[Int] =
+    CommittedOnChain(oc, breadcrumb).toBinary.map(_.length)
+
+  // marginal cost measured over a 1000-entry span, offset past small-n JSON framing noise
+  private def marginalPerEntry(build: Int => OnChain): IO[Double] =
+    for {
+      atSmall <- wireBytes(build(64))
+      atBig   <- wireBytes(build(1064))
+    } yield (atBig - atSmall).toDouble / 1000
+
+  test("fixed overhead (empty OnChain + breadcrumb) is negligible against the budget") {
+    wireBytes(OnChain.genesis).map { fixed =>
+      expect(fixed < 1000)
+    }
+  }
+
+  test("fiber-commit marginal wire cost stays in band; cumulative ceiling is O(low thousands)") {
+    for {
+      perFiber <- marginalPerEntry(withFibers)
+      ceiling = (TessellationBudgetBytes / perFiber).toInt
+      _ <- IO.println(
+        f"[wire-size probe] perFiberCommit=$perFiber%.1f B → fiber-only ceiling ≈ $ceiling entries under $TessellationBudgetBytes B cap"
+      )
+    } yield expect(perFiber >= 150 && perFiber <= 350) and
+    // the motivating fact for OnChain v2: the cumulative wire format cannot address
+    // more than a few thousand fibers before the chain can no longer snapshot
+    expect(ceiling < 5000)
+  }
+
+  test("asset-commit marginal wire cost stays in band") {
+    for {
+      perAsset <- marginalPerEntry(withAssets)
+      _        <- IO.println(f"[wire-size probe] perAssetCommit=$perAsset%.1f B")
+    } yield expect(perAsset >= 100 && perAsset <= 300)
+  }
+
+  test("registry-commit marginal wire cost stays in band") {
+    for {
+      perReg <- marginalPerEntry(withRegistry)
+      _      <- IO.println(f"[wire-size probe] perRegistryCommit=$perReg%.1f B")
+    } yield expect(perReg >= 80 && perReg <= 250)
+  }
+
+  test("a modest mixed economy already consumes a large fraction of the snapshot budget") {
+    // 1500 fibers + 750 assets + 50 registry entries — a small production economy, far from web-scale
+    val mixed = OnChain.genesis.copy(
+      fiberCommits = withFibers(1500).fiberCommits,
+      assetCommits = withAssets(750).assetCommits,
+      registryCommits = withRegistry(50).registryCommits
+    )
+    wireBytes(mixed).map { total =>
+      val pct = 100.0 * total / TessellationBudgetBytes
+      println(f"[wire-size probe] mixed(1500 fibers, 750 assets, 50 registry)=$total B = $pct%.1f%% of budget")
+      // documents that the ceiling binds well before any interesting scale
+      expect(total > TessellationBudgetBytes / 2)
+    }
+  }
+}

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/OnChainWireSizeSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/OnChainWireSizeSuite.scala
@@ -4,7 +4,7 @@ import java.util.UUID
 
 import cats.effect.IO
 
-import scala.collection.immutable.SortedMap
+import scala.collection.immutable.{SortedMap, SortedSet}
 
 import io.constellationnetwork.metagraph_sdk.crypto.smt.SparseMerkleRoot
 import io.constellationnetwork.metagraph_sdk.lifecycle.committed.{CommittedBreadcrumb, CommittedOnChain, CommittedRoots}
@@ -19,22 +19,25 @@ import xyz.kd5ujc.schema.{AssetCommit, FiberCommit, OnChain}
 import weaver.SimpleIOSuite
 
 /**
- * Phase-0 probe for the onchain-incrementals migration (docs/proposals/onchain-incrementals.md).
+ * Wire-size guard for OnChain v2 (docs/proposals/onchain-incrementals.md).
  *
  * tessellation caps the whole state-channel snapshot binary at 512,000 bytes
  * (`max-state-channel-snapshot-binary-size-in-bytes`, node-shared application.conf; enforced in
- * `CurrencySnapshotCreator.createProposalArtifact`). The cumulative `OnChain` maps ride inside
- * `dataApplication.onChainState` of EVERY incremental snapshot, and the framework's events-cutter
- * cannot shrink them — once the cumulative maps alone exceed the budget, the metagraph can no
- * longer produce any snapshot (`UnableToReduceProposalByCutting`): a permanent halt.
+ * `CurrencySnapshotCreator.createProposalArtifact`). Under the v1 CUMULATIVE OnChain that cap was
+ * an existential ceiling: at the marginal costs pinned here (226 B per FiberCommit entry) the
+ * chain could never address more than ~2,265 fibers before `UnableToReduceProposalByCutting`
+ * halted it permanently — the events-cutter cannot shed non-event state.
  *
- * These tests pin the marginal wire cost of each cumulative entry via the production
- * serialization path (`CommittedOnChain[OnChain].toBinary`, the exact bytes embedded in the
- * snapshot). Serialization is deterministic, so the bands are tight regression guards: if one
- * breaks, a codec change either bloated the wire format (burning ceiling headroom) or shrank it —
- * either way the RFC numbers and this suite must be re-derived together. When OnChain v2 lands
- * (per-batch deltas), the ceiling test below is expected to become obsolete and should be
- * replaced by an O(churn) assertion.
+ * OnChain v2 carries only per-batch `touched*` deltas, so wire size is O(batch churn), never
+ * O(total state) — cumulative entity count CANNOT appear in the struct at all. Churn IS events,
+ * so an oversized batch is gracefully shed by the cutter (data blocks deferred). These tests pin:
+ *   1. the per-touched-entry marginal costs via the production serialization path
+ *      (`CommittedOnChain[OnChain].toBinary`) — deterministic, so the bands are tight
+ *      codec-bloat regression guards (a band break means the wire format grew/shrank and the
+ *      RFC numbers need re-deriving);
+ *   2. the O(churn) property: an empty delta is near-fixed-size, and even an absurdly large
+ *      single-batch churn (1,000 touched fibers — far beyond a realistic batch) still fits the
+ *      budget with room for the cutter to work.
  */
 object OnChainWireSizeSuite extends SimpleIOSuite {
 
@@ -52,20 +55,23 @@ object OnChainWireSizeSuite extends SimpleIOSuite {
 
   private def uuid(i: Int): UUID = new UUID(0L, i.toLong)
 
-  private def withFibers(n: Int): OnChain =
-    OnChain.genesis.copy(fiberCommits = SortedMap.from((0 until n).map { i =>
+  private def withTouchedFibers(n: Int): OnChain =
+    OnChain.genesis.copy(touchedFiberCommits = SortedMap.from((0 until n).map { i =>
       uuid(i) -> FiberCommit(hex64(1, i), Some(hex64(2, i)), FiberOrdinal.unsafeApply(1000L + i))
     }))
 
-  private def withAssets(n: Int): OnChain =
-    OnChain.genesis.copy(assetCommits = SortedMap.from((0 until n).map { i =>
+  private def withTouchedAssets(n: Int): OnChain =
+    OnChain.genesis.copy(touchedAssetCommits = SortedMap.from((0 until n).map { i =>
       uuid(i) -> AssetCommit(behavior = 21, FiberOrdinal.unsafeApply(1000L + i), hex64(3, i), origin = None)
     }))
 
-  private def withRegistry(n: Int): OnChain =
-    OnChain.genesis.copy(registryCommits = SortedMap.from((0 until n).map { i =>
+  private def withTouchedRegistry(n: Int): OnChain =
+    OnChain.genesis.copy(touchedRegistryCommits = SortedMap.from((0 until n).map { i =>
       RegistryName.unsafe(s"vendor$i.escrow.package") -> hex64(4, i)
     }))
+
+  private def withBurns(n: Int): OnChain =
+    OnChain.genesis.copy(burnedAssets = SortedSet.from((0 until n).map(uuid)))
 
   private def wireBytes(oc: OnChain): IO[Int] =
     CommittedOnChain(oc, breadcrumb).toBinary.map(_.length)
@@ -77,51 +83,55 @@ object OnChainWireSizeSuite extends SimpleIOSuite {
       atBig   <- wireBytes(build(1064))
     } yield (atBig - atSmall).toDouble / 1000
 
-  test("fixed overhead (empty OnChain + breadcrumb) is negligible against the budget") {
+  test("an empty delta (idle batch) is near-fixed-size — cumulative state cannot bloat the wire") {
     wireBytes(OnChain.genesis).map { fixed =>
       expect(fixed < 1000)
     }
   }
 
-  test("fiber-commit marginal wire cost stays in band; cumulative ceiling is O(low thousands)") {
+  test("touched-fiber-commit marginal wire cost stays in band") {
     for {
-      perFiber <- marginalPerEntry(withFibers)
-      ceiling = (TessellationBudgetBytes / perFiber).toInt
-      _ <- IO.println(
-        f"[wire-size probe] perFiberCommit=$perFiber%.1f B → fiber-only ceiling ≈ $ceiling entries under $TessellationBudgetBytes B cap"
-      )
-    } yield expect(perFiber >= 150 && perFiber <= 350) and
-    // the motivating fact for OnChain v2: the cumulative wire format cannot address
-    // more than a few thousand fibers before the chain can no longer snapshot
-    expect(ceiling < 5000)
+      perFiber <- marginalPerEntry(withTouchedFibers)
+      _        <- IO.println(f"[wire-size probe] perTouchedFiberCommit=$perFiber%.1f B")
+    } yield expect(perFiber >= 150 && perFiber <= 350)
   }
 
-  test("asset-commit marginal wire cost stays in band") {
+  test("touched-asset-commit marginal wire cost stays in band") {
     for {
-      perAsset <- marginalPerEntry(withAssets)
-      _        <- IO.println(f"[wire-size probe] perAssetCommit=$perAsset%.1f B")
+      perAsset <- marginalPerEntry(withTouchedAssets)
+      _        <- IO.println(f"[wire-size probe] perTouchedAssetCommit=$perAsset%.1f B")
     } yield expect(perAsset >= 100 && perAsset <= 300)
   }
 
-  test("registry-commit marginal wire cost stays in band") {
+  test("touched-registry-commit marginal wire cost stays in band") {
     for {
-      perReg <- marginalPerEntry(withRegistry)
-      _      <- IO.println(f"[wire-size probe] perRegistryCommit=$perReg%.1f B")
+      perReg <- marginalPerEntry(withTouchedRegistry)
+      _      <- IO.println(f"[wire-size probe] perTouchedRegistryCommit=$perReg%.1f B")
     } yield expect(perReg >= 80 && perReg <= 250)
   }
 
-  test("a modest mixed economy already consumes a large fraction of the snapshot budget") {
-    // 1500 fibers + 750 assets + 50 registry entries — a small production economy, far from web-scale
-    val mixed = OnChain.genesis.copy(
-      fiberCommits = withFibers(1500).fiberCommits,
-      assetCommits = withAssets(750).assetCommits,
-      registryCommits = withRegistry(50).registryCommits
+  test("burned-asset marginal wire cost stays in band (bare uuids)") {
+    for {
+      perBurn <- marginalPerEntry(withBurns)
+      _       <- IO.println(f"[wire-size probe] perBurnedAsset=$perBurn%.1f B")
+    } yield expect(perBurn >= 30 && perBurn <= 60)
+  }
+
+  test("O(churn): even an absurdly large single-batch churn fits the budget with cutter headroom") {
+    // 1,000 touched fibers + 500 touched assets + 100 burns in ONE batch — far beyond any
+    // realistic snapshot's churn (each touch is driven by an event in the same snapshot).
+    val hugeChurn = OnChain.genesis.copy(
+      touchedFiberCommits = withTouchedFibers(1000).touchedFiberCommits,
+      touchedAssetCommits = withTouchedAssets(500).touchedAssetCommits,
+      burnedAssets = withBurns(100).burnedAssets
     )
-    wireBytes(mixed).map { total =>
+    wireBytes(hugeChurn).map { total =>
       val pct = 100.0 * total / TessellationBudgetBytes
-      println(f"[wire-size probe] mixed(1500 fibers, 750 assets, 50 registry)=$total B = $pct%.1f%% of budget")
-      // documents that the ceiling binds well before any interesting scale
-      expect(total > TessellationBudgetBytes / 2)
+      println(f"[wire-size probe] hugeChurn(1000 fibers, 500 assets, 100 burns)=$total B = $pct%.1f%% of budget")
+      // ~60% of the budget (308,725 B measured) for a batch far beyond realistic churn — and
+      // unlike v1 it does NOT compound: the next idle batch is back to fixed-size, and a batch
+      // that DID overflow is churn the events-cutter can shed. 75% = headroom regression bound.
+      expect(total < TessellationBudgetBytes * 3 / 4)
     }
   }
 }

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/RegistryCodecSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/RegistryCodecSuite.scala
@@ -57,7 +57,7 @@ object RegistryCodecSuite extends SimpleIOSuite {
   }
 
   test("OnChain carrying a registry commit round-trips") {
-    val oc = OnChain.genesis.copy(registryCommits = SortedMap(entry.name -> Hash("entryhash")))
+    val oc = OnChain.genesis.copy(touchedRegistryCommits = SortedMap(entry.name -> Hash("entryhash")))
     val json = oc.asJson.noSpaces
     IO.pure(expect(decode[OnChain](json) == Right(oc)))
   }

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/RegistryCombinerSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/RegistryCombinerSuite.scala
@@ -127,7 +127,7 @@ object RegistryCombinerSuite extends SimpleIOSuite {
         pr2 <- fixture.registry.generateProofs(p2, Set(Alice))
         s2  <- combiner.insert(s1, Signed(p2, pr2))
       } yield expect(versionsOf(s2, "escrow").contains(Set(SemVer(1, 0, 0), SemVer(1, 1, 0)))) and
-      expect(s2.onChain.registryCommits.contains(pkg("escrow")))
+      expect(s2.calculated.registryCommits.contains(pkg("escrow")))
     }
   }
 
@@ -143,7 +143,7 @@ object RegistryCombinerSuite extends SimpleIOSuite {
       val p1 = publish("escrow", SemVer(1, 0, 0)) // Alice creates + owns
       val p2 = publish("escrow", SemVer(1, 1, 0)) // Bob (not an owner) tries to publish
       for {
-        validator     <- Validator.make[IO]
+        validator     <- Validator.make[IO]()
         pr1           <- fixture.registry.generateProofs(p1, Set(Alice))
         s1            <- combiner.insert(genesis, Signed(p1, pr1))
         pr2           <- fixture.registry.generateProofs(p2, Set(Bob))
@@ -161,7 +161,7 @@ object RegistryCombinerSuite extends SimpleIOSuite {
       val p1 = publish("escrow", SemVer(1, 0, 0))
       val pLow = publish("escrow", SemVer(0, 9, 0))
       for {
-        validator     <- Validator.make[IO]
+        validator     <- Validator.make[IO]()
         pr1           <- fixture.registry.generateProofs(p1, Set(Alice))
         s1            <- combiner.insert(genesis, Signed(p1, pr1))
         prLow         <- fixture.registry.generateProofs(pLow, Set(Alice))
@@ -236,7 +236,7 @@ object RegistryCombinerSuite extends SimpleIOSuite {
         schemaRef = Some(SchemaRef(pkg("escrow"), VersionReq.Exact(SemVer(1, 0, 0))))
       )
       for {
-        validator     <- Validator.make[IO]
+        validator     <- Validator.make[IO]()
         pr1           <- fixture.registry.generateProofs(p1, Set(Alice))
         s1            <- combiner.insert(genesis, Signed(p1, pr1))
         prC           <- fixture.registry.generateProofs(create, Set(Alice))
@@ -261,7 +261,7 @@ object RegistryCombinerSuite extends SimpleIOSuite {
         schemaRef = Some(SchemaRef(pkg("ghost"), VersionReq.Latest))
       )
       for {
-        validator     <- Validator.make[IO]
+        validator     <- Validator.make[IO]()
         prC           <- fixture.registry.generateProofs(create, Set(Alice))
         valid         <- validator.validateSignedUpdate(genesis, Signed(create, prC))
         combineFailed <- combiner.insert(genesis, Signed(create, prC)).map(wasRejected)
@@ -360,7 +360,7 @@ object RegistryCombinerSuite extends SimpleIOSuite {
         targetSequenceNumber = FiberOrdinal.MinValue
       )
       for {
-        validator     <- Validator.make[IO]
+        validator     <- Validator.make[IO]()
         pr1           <- fixture.registry.generateProofs(p1, Set(Alice))
         s1            <- combiner.insert(genesis, Signed(p1, pr1))
         prC           <- fixture.registry.generateProofs(create, Set(Alice))
@@ -403,7 +403,7 @@ object RegistryCombinerSuite extends SimpleIOSuite {
         targetSequenceNumber = FiberOrdinal.MinValue
       )
       for {
-        validator <- Validator.make[IO]
+        validator <- Validator.make[IO]()
         pr1       <- fixture.registry.generateProofs(p1, Set(Alice))
         s1        <- combiner.insert(genesis, Signed(p1, pr1))
         pr2       <- fixture.registry.generateProofs(p2, Set(Alice))
@@ -600,7 +600,7 @@ object RegistryCombinerSuite extends SimpleIOSuite {
       val create = CreateStateMachine(fiberA, minimalDef, emptyData)
       val alias = RegisterAlias(pkg("escrow"), fiberA) // .package TLD is not a fiber alias
       for {
-        validator     <- Validator.make[IO]
+        validator     <- Validator.make[IO]()
         prC           <- fixture.registry.generateProofs(create, Set(Alice))
         s1            <- combiner.insert(genesis, Signed(create, prC))
         prA           <- fixture.registry.generateProofs(alias, Set(Alice))
@@ -618,7 +618,7 @@ object RegistryCombinerSuite extends SimpleIOSuite {
       val create = CreateStateMachine(fiberA, minimalDef, emptyData) // a state machine
       val alias = RegisterAlias(RegistryName.unsafe("script.script"), fiberA) // .script wants a script fiber
       for {
-        validator     <- Validator.make[IO]
+        validator     <- Validator.make[IO]()
         prC           <- fixture.registry.generateProofs(create, Set(Alice))
         s1            <- combiner.insert(genesis, Signed(create, prC))
         prA           <- fixture.registry.generateProofs(alias, Set(Alice))
@@ -637,7 +637,7 @@ object RegistryCombinerSuite extends SimpleIOSuite {
       val create = CreateStateMachine(fiberA, minimalDef, emptyData) // Alice owns
       val alias = RegisterAlias(RegistryName.unsafe("hostile.machine"), fiberA)
       for {
-        validator     <- Validator.make[IO]
+        validator     <- Validator.make[IO]()
         prC           <- fixture.registry.generateProofs(create, Set(Alice))
         s1            <- combiner.insert(genesis, Signed(create, prC))
         prB           <- fixture.registry.generateProofs(alias, Set(Bob)) // Bob, not an owner, signs
@@ -669,7 +669,7 @@ object RegistryCombinerSuite extends SimpleIOSuite {
       val combiner = Combiner.make[IO]()
       val p = publish("std", SemVer(1, 0, 0)) // -> std.package; "std" is reserved
       for {
-        validator     <- Validator.make[IO]
+        validator     <- Validator.make[IO]()
         pr            <- fixture.registry.generateProofs(p, Set(Alice))
         valid         <- validator.validateSignedUpdate(genesis, Signed(p, pr))
         combineFailed <- combiner.insert(genesis, Signed(p, pr)).map(wasRejected)
@@ -703,7 +703,7 @@ object RegistryCombinerSuite extends SimpleIOSuite {
         metadata = Some(SortedMap("note" -> ("x" * 200))) // value exceeds 128 chars
       )
       for {
-        validator     <- Validator.make[IO]
+        validator     <- Validator.make[IO]()
         prG           <- fixture.registry.generateProofs(good, Set(Alice))
         s1            <- combiner.insert(genesis, Signed(good, prG))
         prB           <- fixture.registry.generateProofs(bad, Set(Alice))

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/ScriptValidationSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/ScriptValidationSuite.scala
@@ -181,7 +181,7 @@ object ScriptValidationSuite extends SimpleIOSuite {
       implicit val l0ctx: L0NodeContext[IO] = fixture.l0Context
       for {
         combiner  <- Combiner.make[IO]().pure[IO]
-        validator <- Validator.make[IO]
+        validator <- Validator.make[IO]()
         fiberId   <- IO.randomUUID
 
         createUpdate = Updates.CreateScript(

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/StdManifestContractSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/StdManifestContractSuite.scala
@@ -37,7 +37,7 @@ object StdManifestContractSuite extends SimpleIOSuite {
     } yield expect(manifest.packages.size == 3) and
     expect(stdNames.forall { n =>
       val name = RegistryName.unsafe(n)
-      genesis.calculated.registry.contains(name) && genesis.onChain.registryCommits.contains(name)
+      genesis.calculated.registry.contains(name) && genesis.calculated.registryCommits.contains(name)
     }) and
     expect(genesis.calculated.registry.values.forall(_.target match {
       case RegistryTarget.SchemaPackage(lineage) =>

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/TransitionValidatorGateSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/TransitionValidatorGateSuite.scala
@@ -70,7 +70,7 @@ object TransitionValidatorGateSuite extends SimpleIOSuite {
       implicit val l0ctx: L0NodeContext[IO] = fixture.l0Context
       for {
         combiner  <- Combiner.make[IO]().pure[IO]
-        validator <- Validator.make[IO]
+        validator <- Validator.make[IO]()
         fiberId   <- UUIDGen.randomUUID[IO]
 
         machineDef <- IO.fromEither(decode[StateMachineDefinition](defJson)) // policy absent ⇒ Open
@@ -102,7 +102,7 @@ object TransitionValidatorGateSuite extends SimpleIOSuite {
       implicit val l0ctx: L0NodeContext[IO] = fixture.l0Context
       for {
         combiner  <- Combiner.make[IO]().pure[IO]
-        validator <- Validator.make[IO]
+        validator <- Validator.make[IO]()
         fiberId   <- UUIDGen.randomUUID[IO]
 
         baseDef <- IO.fromEither(decode[StateMachineDefinition](defJson))

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/ValidatorSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/ValidatorSuite.scala
@@ -279,7 +279,7 @@ object ValidatorSuite extends SimpleIOSuite {
       implicit val s: SecurityProvider[IO] = fixture.securityProvider
       implicit val _l1ctx: L1NodeContext[IO] = fixture.l1Context
       for {
-        validator <- Validator.make[IO]
+        validator <- Validator.make[IO]()
         fiberId   <- UUIDGen.randomUUID[IO]
         update = Updates.CreateStateMachine(fiberId, Fixtures.minimalDefinition(), MapValue(Map.empty))
         result <- validator.validateUpdate(update)
@@ -294,7 +294,7 @@ object ValidatorSuite extends SimpleIOSuite {
       implicit val _l1ctx: L1NodeContext[IO] = fixture.l1Context
       for {
         combiner  <- Combiner.make[IO]().pure[IO]
-        validator <- Validator.make[IO]
+        validator <- Validator.make[IO]()
         fiberId   <- UUIDGen.randomUUID[IO]
 
         createUpdate = Updates.CreateStateMachine(fiberId, Fixtures.minimalDefinition(), MapValue(Map.empty))
@@ -317,7 +317,7 @@ object ValidatorSuite extends SimpleIOSuite {
       implicit val s: SecurityProvider[IO] = fixture.securityProvider
       implicit val _l1ctx: L1NodeContext[IO] = fixture.l1Context
       for {
-        validator <- Validator.make[IO]
+        validator <- Validator.make[IO]()
         fiberId   <- UUIDGen.randomUUID[IO]
         update = Updates.CreateStateMachine(fiberId, Fixtures.emptyDefinition(), MapValue(Map.empty))
         result <- validator.validateUpdate(update)
@@ -331,7 +331,7 @@ object ValidatorSuite extends SimpleIOSuite {
       implicit val s: SecurityProvider[IO] = fixture.securityProvider
       implicit val _l1ctx: L1NodeContext[IO] = fixture.l1Context
       for {
-        validator <- Validator.make[IO]
+        validator <- Validator.make[IO]()
         fiberId   <- UUIDGen.randomUUID[IO]
         update = Updates.CreateStateMachine(fiberId, Fixtures.invalidInitialStateDefinition(), MapValue(Map.empty))
         result <- validator.validateUpdate(update)
@@ -345,7 +345,7 @@ object ValidatorSuite extends SimpleIOSuite {
       implicit val s: SecurityProvider[IO] = fixture.securityProvider
       implicit val _l1ctx: L1NodeContext[IO] = fixture.l1Context
       for {
-        validator <- Validator.make[IO]
+        validator <- Validator.make[IO]()
         fiberId   <- UUIDGen.randomUUID[IO]
         update = Updates.CreateStateMachine(fiberId, Fixtures.invalidTransitionFromDefinition(), MapValue(Map.empty))
         result <- validator.validateUpdate(update)
@@ -359,7 +359,7 @@ object ValidatorSuite extends SimpleIOSuite {
       implicit val s: SecurityProvider[IO] = fixture.securityProvider
       implicit val _l1ctx: L1NodeContext[IO] = fixture.l1Context
       for {
-        validator <- Validator.make[IO]
+        validator <- Validator.make[IO]()
         fiberId   <- UUIDGen.randomUUID[IO]
         update = Updates.CreateStateMachine(fiberId, Fixtures.invalidTransitionToDefinition(), MapValue(Map.empty))
         result <- validator.validateUpdate(update)
@@ -373,7 +373,7 @@ object ValidatorSuite extends SimpleIOSuite {
       implicit val s: SecurityProvider[IO] = fixture.securityProvider
       implicit val _l1ctx: L1NodeContext[IO] = fixture.l1Context
       for {
-        validator <- Validator.make[IO]
+        validator <- Validator.make[IO]()
         fiberId   <- UUIDGen.randomUUID[IO]
         update = Updates.CreateStateMachine(fiberId, Fixtures.duplicateTransitionsDefinition(), MapValue(Map.empty))
         result <- validator.validateUpdate(update)
@@ -387,7 +387,7 @@ object ValidatorSuite extends SimpleIOSuite {
       implicit val s: SecurityProvider[IO] = fixture.securityProvider
       implicit val _l1ctx: L1NodeContext[IO] = fixture.l1Context
       for {
-        validator <- Validator.make[IO]
+        validator <- Validator.make[IO]()
         fiberId   <- UUIDGen.randomUUID[IO]
         update = Updates.CreateStateMachine(fiberId, Fixtures.ambiguousTransitionsDefinition(), MapValue(Map.empty))
         result <- validator.validateUpdate(update)
@@ -403,7 +403,7 @@ object ValidatorSuite extends SimpleIOSuite {
       implicit val s: SecurityProvider[IO] = fixture.securityProvider
       implicit val _l1ctx: L1NodeContext[IO] = fixture.l1Context
       for {
-        validator <- Validator.make[IO]
+        validator <- Validator.make[IO]()
         fiberId   <- UUIDGen.randomUUID[IO]
         update = Updates.CreateStateMachine(
           fiberId,
@@ -422,7 +422,7 @@ object ValidatorSuite extends SimpleIOSuite {
       implicit val s: SecurityProvider[IO] = fixture.securityProvider
       implicit val _l1ctx: L1NodeContext[IO] = fixture.l1Context
       for {
-        validator <- Validator.make[IO]
+        validator <- Validator.make[IO]()
         fiberId   <- UUIDGen.randomUUID[IO]
         update = Updates.CreateStateMachine(
           fiberId,
@@ -441,7 +441,7 @@ object ValidatorSuite extends SimpleIOSuite {
       implicit val s: SecurityProvider[IO] = fixture.securityProvider
       implicit val _l1ctx: L1NodeContext[IO] = fixture.l1Context
       for {
-        validator <- Validator.make[IO]
+        validator <- Validator.make[IO]()
         fiberId   <- UUIDGen.randomUUID[IO]
         // simpleDefinitionWithTransition uses "moved" as a field name which is not reserved
         update = Updates.CreateStateMachine(
@@ -461,7 +461,7 @@ object ValidatorSuite extends SimpleIOSuite {
       implicit val s: SecurityProvider[IO] = fixture.securityProvider
       implicit val _l1ctx: L1NodeContext[IO] = fixture.l1Context
       for {
-        validator <- Validator.make[IO]
+        validator <- Validator.make[IO]()
         fiberId   <- UUIDGen.randomUUID[IO]
         update = Updates
           .CreateStateMachine(fiberId, Fixtures.minimalDefinition(), MapValue(Map("key" -> StrValue("value"))))
@@ -475,7 +475,7 @@ object ValidatorSuite extends SimpleIOSuite {
       implicit val s: SecurityProvider[IO] = fixture.securityProvider
       implicit val _l1ctx: L1NodeContext[IO] = fixture.l1Context
       for {
-        validator <- Validator.make[IO]
+        validator <- Validator.make[IO]()
         fiberId   <- UUIDGen.randomUUID[IO]
         update = Updates.CreateStateMachine(fiberId, Fixtures.minimalDefinition(), ArrayValue(List(IntValue(1))))
         result <- validator.validateUpdate(update)
@@ -493,7 +493,7 @@ object ValidatorSuite extends SimpleIOSuite {
       implicit val _l1ctx: L1NodeContext[IO] = fixture.l1Context
       for {
         combiner  <- Combiner.make[IO]().pure[IO]
-        validator <- Validator.make[IO]
+        validator <- Validator.make[IO]()
         fiberId   <- UUIDGen.randomUUID[IO]
 
         createUpdate = Updates
@@ -515,7 +515,7 @@ object ValidatorSuite extends SimpleIOSuite {
       implicit val l0ctx: L0NodeContext[IO] = fixture.l0Context
       implicit val _l1ctx: L1NodeContext[IO] = fixture.l1Context
       for {
-        validator <- Validator.make[IO]
+        validator <- Validator.make[IO]()
         fiberId   <- UUIDGen.randomUUID[IO]
 
         processUpdate = Updates.TransitionStateMachine(fiberId, "advance", MapValue(Map.empty), FiberOrdinal.MinValue)
@@ -539,7 +539,7 @@ object ValidatorSuite extends SimpleIOSuite {
       implicit val _l1ctx: L1NodeContext[IO] = fixture.l1Context
       for {
         combiner  <- Combiner.make[IO]().pure[IO]
-        validator <- Validator.make[IO]
+        validator <- Validator.make[IO]()
         fiberId   <- UUIDGen.randomUUID[IO]
 
         createUpdate = Updates
@@ -563,7 +563,7 @@ object ValidatorSuite extends SimpleIOSuite {
       implicit val _l1ctx: L1NodeContext[IO] = fixture.l1Context
       for {
         combiner  <- Combiner.make[IO]().pure[IO]
-        validator <- Validator.make[IO]
+        validator <- Validator.make[IO]()
         fiberId   <- UUIDGen.randomUUID[IO]
 
         createUpdate = Updates
@@ -589,7 +589,7 @@ object ValidatorSuite extends SimpleIOSuite {
       implicit val _l1ctx: L1NodeContext[IO] = fixture.l1Context
       for {
         combiner  <- Combiner.make[IO]().pure[IO]
-        validator <- Validator.make[IO]
+        validator <- Validator.make[IO]()
         fiberId   <- UUIDGen.randomUUID[IO]
 
         createUpdate = Updates
@@ -616,7 +616,7 @@ object ValidatorSuite extends SimpleIOSuite {
       implicit val _l1ctx: L1NodeContext[IO] = fixture.l1Context
       for {
         combiner  <- Combiner.make[IO]().pure[IO]
-        validator <- Validator.make[IO]
+        validator <- Validator.make[IO]()
         fiberId   <- UUIDGen.randomUUID[IO]
 
         createUpdate = Updates
@@ -651,7 +651,7 @@ object ValidatorSuite extends SimpleIOSuite {
       implicit val _l1ctx: L1NodeContext[IO] = fixture.l1Context
       for {
         combiner  <- Combiner.make[IO]().pure[IO]
-        validator <- Validator.make[IO]
+        validator <- Validator.make[IO]()
         fiberId   <- UUIDGen.randomUUID[IO]
 
         createUpdate = Updates
@@ -678,7 +678,7 @@ object ValidatorSuite extends SimpleIOSuite {
       implicit val _l1ctx: L1NodeContext[IO] = fixture.l1Context
       for {
         combiner  <- Combiner.make[IO]().pure[IO]
-        validator <- Validator.make[IO]
+        validator <- Validator.make[IO]()
         fiberId   <- UUIDGen.randomUUID[IO]
 
         createUpdate = Updates
@@ -703,7 +703,7 @@ object ValidatorSuite extends SimpleIOSuite {
       implicit val _l1ctx: L1NodeContext[IO] = fixture.l1Context
       for {
         combiner  <- Combiner.make[IO]().pure[IO]
-        validator <- Validator.make[IO]
+        validator <- Validator.make[IO]()
         fiberId   <- UUIDGen.randomUUID[IO]
 
         createUpdate = Updates
@@ -729,7 +729,7 @@ object ValidatorSuite extends SimpleIOSuite {
       implicit val _l1ctx: L1NodeContext[IO] = fixture.l1Context
       for {
         combiner  <- Combiner.make[IO]().pure[IO]
-        validator <- Validator.make[IO]
+        validator <- Validator.make[IO]()
         fiberId   <- UUIDGen.randomUUID[IO]
 
         createUpdate = Updates
@@ -760,7 +760,7 @@ object ValidatorSuite extends SimpleIOSuite {
       implicit val _l1ctx: L1NodeContext[IO] = fixture.l1Context
       for {
         combiner  <- Combiner.make[IO]().pure[IO]
-        validator <- Validator.make[IO]
+        validator <- Validator.make[IO]()
         fiberId   <- UUIDGen.randomUUID[IO]
 
         createUpdate = Updates
@@ -794,7 +794,7 @@ object ValidatorSuite extends SimpleIOSuite {
       implicit val s: SecurityProvider[IO] = fixture.securityProvider
       implicit val _l1ctx: L1NodeContext[IO] = fixture.l1Context
       for {
-        validator <- Validator.make[IO]
+        validator <- Validator.make[IO]()
         fiberId   <- UUIDGen.randomUUID[IO]
         update = Updates
           .CreateScript(fiberId, Fixtures.simpleScript(), None, AccessControlPolicy.Public)
@@ -808,7 +808,7 @@ object ValidatorSuite extends SimpleIOSuite {
       implicit val s: SecurityProvider[IO] = fixture.securityProvider
       implicit val _l1ctx: L1NodeContext[IO] = fixture.l1Context
       for {
-        validator <- Validator.make[IO]
+        validator <- Validator.make[IO]()
         fiberId   <- UUIDGen.randomUUID[IO]
         update = Updates.CreateScript(
           fiberId,
@@ -826,7 +826,7 @@ object ValidatorSuite extends SimpleIOSuite {
       implicit val s: SecurityProvider[IO] = fixture.securityProvider
       implicit val _l1ctx: L1NodeContext[IO] = fixture.l1Context
       for {
-        validator <- Validator.make[IO]
+        validator <- Validator.make[IO]()
         fiberId   <- UUIDGen.randomUUID[IO]
         update = Updates.CreateScript(
           fiberId,
@@ -847,7 +847,7 @@ object ValidatorSuite extends SimpleIOSuite {
       implicit val s: SecurityProvider[IO] = fixture.securityProvider
       implicit val _l1ctx: L1NodeContext[IO] = fixture.l1Context
       for {
-        validator <- Validator.make[IO]
+        validator <- Validator.make[IO]()
         fiberId   <- UUIDGen.randomUUID[IO]
         parentId  <- UUIDGen.randomUUID[IO]
 
@@ -865,7 +865,7 @@ object ValidatorSuite extends SimpleIOSuite {
       implicit val _l1ctx: L1NodeContext[IO] = fixture.l1Context
       for {
         combiner  <- Combiner.make[IO]().pure[IO]
-        validator <- Validator.make[IO]
+        validator <- Validator.make[IO]()
         parentId  <- UUIDGen.randomUUID[IO]
         childId   <- UUIDGen.randomUUID[IO]
 
@@ -894,7 +894,7 @@ object ValidatorSuite extends SimpleIOSuite {
       implicit val _l1ctx: L1NodeContext[IO] = fixture.l1Context
       for {
         combiner  <- Combiner.make[IO]().pure[IO]
-        validator <- Validator.make[IO]
+        validator <- Validator.make[IO]()
         parentId  <- UUIDGen.randomUUID[IO]
         childId   <- UUIDGen.randomUUID[IO]
 
@@ -920,7 +920,7 @@ object ValidatorSuite extends SimpleIOSuite {
       implicit val _l1ctx: L1NodeContext[IO] = fixture.l1Context
       for {
         combiner  <- Combiner.make[IO]().pure[IO]
-        validator <- Validator.make[IO]
+        validator <- Validator.make[IO]()
         scriptId  <- UUIDGen.randomUUID[IO]
 
         createScript = Updates
@@ -943,7 +943,7 @@ object ValidatorSuite extends SimpleIOSuite {
       implicit val _l1ctx: L1NodeContext[IO] = fixture.l1Context
       for {
         combiner  <- Combiner.make[IO]().pure[IO]
-        validator <- Validator.make[IO]
+        validator <- Validator.make[IO]()
         scriptId  <- UUIDGen.randomUUID[IO]
         bobAddr   <- fixture.registry.addresses(Bob).pure[IO]
 
@@ -971,7 +971,7 @@ object ValidatorSuite extends SimpleIOSuite {
       implicit val _l1ctx: L1NodeContext[IO] = fixture.l1Context
       for {
         combiner  <- Combiner.make[IO]().pure[IO]
-        validator <- Validator.make[IO]
+        validator <- Validator.make[IO]()
         scriptId  <- UUIDGen.randomUUID[IO]
         bobAddr   <- fixture.registry.addresses(Bob).pure[IO]
 
@@ -1000,7 +1000,7 @@ object ValidatorSuite extends SimpleIOSuite {
       implicit val s: SecurityProvider[IO] = fixture.securityProvider
       implicit val _l1ctx: L1NodeContext[IO] = fixture.l1Context
       for {
-        validator <- Validator.make[IO]
+        validator <- Validator.make[IO]()
         fiberId   <- UUIDGen.randomUUID[IO]
         update = Updates.CreateStateMachine(fiberId, Fixtures.definitionWithStates(101), MapValue(Map.empty))
         result <- validator.validateUpdate(update)
@@ -1014,7 +1014,7 @@ object ValidatorSuite extends SimpleIOSuite {
       implicit val s: SecurityProvider[IO] = fixture.securityProvider
       implicit val _l1ctx: L1NodeContext[IO] = fixture.l1Context
       for {
-        validator <- Validator.make[IO]
+        validator <- Validator.make[IO]()
         fiberId   <- UUIDGen.randomUUID[IO]
         update = Updates.CreateStateMachine(fiberId, Fixtures.definitionWithStates(100), MapValue(Map.empty))
         result <- validator.validateUpdate(update)
@@ -1027,7 +1027,7 @@ object ValidatorSuite extends SimpleIOSuite {
       implicit val s: SecurityProvider[IO] = fixture.securityProvider
       implicit val _l1ctx: L1NodeContext[IO] = fixture.l1Context
       for {
-        validator <- Validator.make[IO]
+        validator <- Validator.make[IO]()
         fiberId   <- UUIDGen.randomUUID[IO]
         update = Updates.CreateStateMachine(fiberId, Fixtures.definitionWithTransitions(501), MapValue(Map.empty))
         result <- validator.validateUpdate(update)
@@ -1041,7 +1041,7 @@ object ValidatorSuite extends SimpleIOSuite {
       implicit val s: SecurityProvider[IO] = fixture.securityProvider
       implicit val _l1ctx: L1NodeContext[IO] = fixture.l1Context
       for {
-        validator <- Validator.make[IO]
+        validator <- Validator.make[IO]()
         fiberId   <- UUIDGen.randomUUID[IO]
         update = Updates.CreateStateMachine(fiberId, Fixtures.definitionWithTransitions(500), MapValue(Map.empty))
         result <- validator.validateUpdate(update)
@@ -1054,7 +1054,7 @@ object ValidatorSuite extends SimpleIOSuite {
       implicit val s: SecurityProvider[IO] = fixture.securityProvider
       implicit val _l1ctx: L1NodeContext[IO] = fixture.l1Context
       for {
-        validator <- Validator.make[IO]
+        validator <- Validator.make[IO]()
         fiberId   <- UUIDGen.randomUUID[IO]
         update = Updates
           .CreateStateMachine(fiberId, Fixtures.definitionWithTransitionsPerState(21), MapValue(Map.empty))
@@ -1069,7 +1069,7 @@ object ValidatorSuite extends SimpleIOSuite {
       implicit val s: SecurityProvider[IO] = fixture.securityProvider
       implicit val _l1ctx: L1NodeContext[IO] = fixture.l1Context
       for {
-        validator <- Validator.make[IO]
+        validator <- Validator.make[IO]()
         fiberId   <- UUIDGen.randomUUID[IO]
         update = Updates
           .CreateStateMachine(fiberId, Fixtures.definitionWithTransitionsPerState(20), MapValue(Map.empty))

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/examples/CounterScriptSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/examples/CounterScriptSuite.scala
@@ -547,7 +547,7 @@ object CounterScriptSuite extends SimpleIOSuite {
         )
 
         // Check onChain has hashes for this script
-        initialOnChainHashes = state1.onChain.fiberCommits.get(cid)
+        initialOnChainHashes = state1.calculated.fiberCommits.get(cid)
         initialStateHash = state1.scriptRecord(cid).flatMap(_.stateDataHash)
 
         invokeScript = Updates.InvokeScript(
@@ -561,7 +561,7 @@ object CounterScriptSuite extends SimpleIOSuite {
         state2      <- combiner.insert(state1, Signed(invokeScript, invokeProof))
 
         // Check onChain hashes were updated
-        updatedOnChainHashes = state2.onChain.fiberCommits.get(cid)
+        updatedOnChainHashes = state2.calculated.fiberCommits.get(cid)
         updatedStateHash = state2.scriptRecord(cid).flatMap(_.stateDataHash)
       } yield expect.all(
         initialOnChainHashes.isDefined,


### PR DESCRIPTION
## Why (the forcing constraint)

tessellation hard-caps the state-channel snapshot binary at **512,000 bytes** (`max-state-channel-snapshot-binary-size-in-bytes`, node-shared `application.conf` on both `develop` and `release/mainnet`; enforced in `CurrencySnapshotCreator.createProposalArtifact`). The v1 cumulative `OnChain` maps ride inside `dataApplication.onChainState` of **every** incremental snapshot, and the framework's events-cutter cannot shed them — once they exceed the budget the round raises `UnableToReduceProposalByCutting` and **the metagraph can never produce another snapshot**. Measured via the production serialization path (first commit's probe): 226 B/`FiberCommit` → **permanent chain halt at ~2,265 fibers**; a modest economy (1,500 fibers + 750 assets) already consumes 90.2% of the budget.

## What (RFC: `docs/proposals/onchain-incrementals.md`, second commit)

**BREAKING wire change, targeting the 0.8.0 window.**

- **OnChain v2 is per-batch only**: `touchedFiberCommits` / `touchedAssetCommits` / `burnedAssets` / `touchedRegistryCommits` + `latestLogs`, cleared at the top of `orderedCombiner`'s fold (the existing `latestLogs` pattern). Snapshot bytes become **O(churn)**: an absurd 1,000-fiber single-batch churn is 60.3% of budget *once*; the next idle batch is back to ~fixed size — and churn IS events, so an oversized batch degrades gracefully via the cutter instead of halting.
- **Cumulative maps move to `CalculatedState`** (rooted under the committed MPT as `commit/f|a|r/<id>` leaves via `CommittedView` — never wire-shipped). The same `DataStateOps`/`AssetCombiner` fold writes delta + cumulative from the same hash, so they cannot diverge (guarded by `CommitIndexFoldSuite`'s DL1==ML0 equivalence test).
- **`CommitIndex`** is the recreated view the L1 structural gates read. ML0: `fromCalculated(current.calculated)` — the same safe triple as the v1 `OnChain` read, merely relocated (TOCTOU rule #3 bars *lineage* reads; CLAUDE.md wording updated). DL1: `withCommitIndexCache` folds contiguous deltas (`ordinal+1` only — folding across a gap loses writes and the seq gate **fails open** for unknown ids) and **heals** from ML0 `GET /v1/commit-index` on first sync / gap / restart, via `CommitIndexHttpClient` targeting the existing `--l0-peer` (zero new config). Heal failure keeps the checkpoint stale-and-retried, never silently incomplete.
- **Routes/contract**: new `GET /v1/commit-index` (typed tapir endpoint, OpenAPI docs regenerated — 23 ML0 endpoints) is the v1-onchain back-compat surface + heal source. Genesis seeds the calculated maps AND emits them as the genesis `touched*` delta.

## Verification

- `sharedData`: **651/651**, `currencyL0`: **8/8** (includes new `CommitIndexFoldSuite`, `commit/` namespace projection tests, and the wire-size suite reworked into O(churn) + codec-bloat regression guards)
- Full compile across all modules; scalafmt clean

## Known follow-ups (tracked in RFC §3.3/§7 + work log)

1. **Heal hardening**: batch-proof verification of healed payloads against the signed breadcrumb `mptRoot` (currently trusts the configured ML0 peer — the same peer that already feeds the node its snapshots; the combiner remains the authoritative stateful gate regardless).
2. DL1 gap→heal **integration test** (kill/restart, skipped ordinal, tampered payload).
3. Golden serde fixture for the v2 wire shape.
4. **Pre-v2 genesis JSONs must be regenerated** (they lack the calculated commit maps).
5. Phase 3: ottochain-sdk decoders + riverdale e2e, riding the 0.8.0 alignment train.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R5TUSJPD8FCtJagf7siXgt