### PR TITLE
refactor(fiber): flatten nested Option/Either matches to chaining

### DIFF
--- a/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/fiber/FiberEngine.scala
+++ b/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/fiber/FiberEngine.scala
@@ -180,10 +180,9 @@ object FiberEngine {
       ): FiberT[F, TransactionResult] = {
         val currentState = script.stateData.getOrElse(NullValue)
         val evalMigration: FiberT[F, Either[FailureReason, JsonLogicValue]] =
-          migration match {
-            case None       => (currentState: JsonLogicValue).asRight[FailureReason].pure[FiberT[F, *]]
-            case Some(expr) => MeteredEvaluator.eval[F, FiberT[F, *]](expr, currentState, GasExhaustionPhase.Migration)
-          }
+          migration.fold(
+            currentState.asRight[FailureReason].pure[FiberT[F, *]]
+          )(MeteredEvaluator.eval[F, FiberT[F, *]](_, currentState, GasExhaustionPhase.Migration))
 
         evalMigration.flatMap {
           case Left(reason)     => aborted(reason)
@@ -295,10 +294,9 @@ object FiberEngine {
         // The migration is metered through the same boundary as every other JLVM evaluation (no direct
         // metakit call); identity (None) leaves the state untouched.
         val evalMigration: FiberT[F, Either[FailureReason, JsonLogicValue]] =
-          migration match {
-            case None       => sm.stateData.asRight[FailureReason].pure[FiberT[F, *]]
-            case Some(expr) => MeteredEvaluator.eval[F, FiberT[F, *]](expr, sm.stateData, GasExhaustionPhase.Migration)
-          }
+          migration.fold(
+            (sm.stateData: JsonLogicValue).asRight[FailureReason].pure[FiberT[F, *]]
+          )(MeteredEvaluator.eval[F, FiberT[F, *]](_, sm.stateData, GasExhaustionPhase.Migration))
 
         evalMigration.flatMap {
           case Left(reason) => aborted(reason)
@@ -496,67 +494,50 @@ object FiberEngine {
         for {
           limits <- ExecutionOps.askLimits[FiberT[F, *]]
           // FiberPolicy dial `dependencyPolicy`: gate WHICH fibers a `_addDependency` may target, BEFORE the
-          // bounded ledger upsert. FAIL-CLOSED (abort the transition). `None` ⇒ Open (legacy, unconstrained).
-          dependencyDenial = checkDependencyPolicy(sm, dependencyMutations)
-          // Apply the append-only dynamic-dependency ledger mutations: a policy denial OR a bounds breach
-          // aborts the transition (fail-closed) before any state or log is committed.
-          result <- dependencyDenial match {
-            case Some(reason) =>
-              ExecutionOps.getGasUsed[FiberT[F, *]].map(g => TransactionResult.Aborted(reason, g): TransactionResult)
-            case None =>
-              DependencyLedger.applyMutations(
-                sm.dynamicDependencies,
-                dependencyMutations,
-                ordinal,
-                limits
-              ) match {
-                case Left(reason) =>
-                  ExecutionOps
-                    .getGasUsed[FiberT[F, *]]
-                    .map(g => TransactionResult.Aborted(reason, g): TransactionResult)
+          // bounded ledger upsert. Then apply the append-only dynamic-dependency ledger mutations: a policy
+          // denial (`None` ⇒ Open, legacy, unconstrained) OR a bounds breach aborts the transition
+          // (fail-closed) before any state or log is committed.
+          ledgerOrDenied = checkDependencyPolicy(sm, dependencyMutations)
+            .toLeft(())
+            .flatMap(_ => DependencyLedger.applyMutations(sm.dynamicDependencies, dependencyMutations, ordinal, limits))
+          result <- ledgerOrDenied.fold(
+            aborted,
+            newLedger =>
+              for {
+                hash    <- newStateData.computeDigest.liftFiber
+                gasUsed <- ExecutionOps.getGasUsed[FiberT[F, *]]
 
-                case Right(newLedger) =>
-                  for {
-                    hash    <- newStateData.computeDigest.liftFiber
-                    gasUsed <- ExecutionOps.getGasUsed[FiberT[F, *]]
+                receipt = EventReceipt.success(
+                  sm = sm,
+                  eventName = input.key,
+                  ordinal = ordinal,
+                  gasUsed = gasUsed,
+                  newStateId = newStateId,
+                  triggers = triggers,
+                  emittedEvents = emittedEvents
+                )
 
-                    receipt = EventReceipt.success(
-                      sm = sm,
-                      eventName = input.key,
-                      ordinal = ordinal,
-                      gasUsed = gasUsed,
-                      newStateId = newStateId,
-                      triggers = triggers,
-                      emittedEvents = emittedEvents
-                    )
+                _ <- ExecutionOps.appendLog[FiberT[F, *]](receipt)
 
-                    _ <- ExecutionOps.appendLog[FiberT[F, *]](receipt)
+                updatedFiber = sm.copy(
+                  previousUpdateOrdinal = sm.latestUpdateOrdinal,
+                  latestUpdateOrdinal = ordinal,
+                  currentState = newStateId.getOrElse(sm.currentState),
+                  stateData = newStateData,
+                  stateDataHash = hash,
+                  sequenceNumber = sm.sequenceNumber.next,
+                  lastReceipt = Some(receipt),
+                  dynamicDependencies = newLedger
+                )
 
-                    updatedFiber = sm.copy(
-                      previousUpdateOrdinal = sm.latestUpdateOrdinal,
-                      latestUpdateOrdinal = ordinal,
-                      currentState = newStateId.getOrElse(sm.currentState),
-                      stateData = newStateData,
-                      stateDataHash = hash,
-                      sequenceNumber = sm.sequenceNumber.next,
-                      lastReceipt = Some(receipt),
-                      dynamicDependencies = newLedger
-                    )
+                spawnResult <- processSpawnsValidated(spawns, updatedFiber, input)
 
-                    spawnResult <- processSpawnsValidated(spawns, updatedFiber, input)
-
-                    r <- spawnResult match {
-                      case Left(errors) =>
-                        ExecutionOps
-                          .getGasUsed[FiberT[F, *]]
-                          .map(g => TransactionResult.Aborted(errors.head, g): TransactionResult)
-
-                      case Right(spawnedFibers) =>
-                        completeStateMachineTransaction(sm, updatedFiber, spawnedFibers, triggers, assetTransfers)
-                    }
-                  } yield r
-              }
-          }
+                r <- spawnResult.fold(
+                  errors => aborted(errors.head),
+                  completeStateMachineTransaction(sm, updatedFiber, _, triggers, assetTransfers)
+                )
+              } yield r
+          )
         } yield result
 
       /**
@@ -661,47 +642,38 @@ object FiberEngine {
        */
       private def checkMaxGenerations(
         fiber: Records.StateMachineFiberRecord
-      ): FiberT[F, Either[FailureReason, Unit]] =
-        fiber.definition.policy.dials.flatMap(_.maxGenerations) match {
-          case None => ().asRight[FailureReason].pure[FiberT[F, *]]
-          case Some(cap) =>
-            fiber.definition.computeDigest.liftFiber.flatMap { selfDigest =>
-              def walk(
-                currentParent: Option[UUID],
-                depth:         Int,
-                visited:       Set[UUID]
-              ): FiberT[F, Either[FailureReason, Unit]] =
-                currentParent match {
-                  case None                               => ().asRight[FailureReason].pure[FiberT[F, *]]
-                  case Some(pid) if visited.contains(pid) =>
-                    // A cycle in the parent chain ⇒ the lineage is unverifiable ⇒ fail closed (and never loop).
-                    (FailureReason
-                      .PolicyViolation("maxGenerations", s"ancestor chain forms a cycle at $pid"): FailureReason)
-                      .asLeft[Unit]
-                      .pure[FiberT[F, *]]
-                  case Some(pid) =>
-                    calculatedState.stateMachines.get(pid) match {
-                      case None =>
-                        (FailureReason
-                          .PolicyViolation("maxGenerations", s"ancestor chain incomplete at $pid"): FailureReason)
-                          .asLeft[Unit]
-                          .pure[FiberT[F, *]]
-                      case Some(ancestor) =>
-                        ancestor.definition.computeDigest.liftFiber.flatMap { ancDigest =>
-                          val nextDepth = if (ancDigest === selfDigest) depth + 1 else depth
-                          if (nextDepth >= cap)
-                            (FailureReason.PolicyViolation(
-                              "maxGenerations",
-                              s"self-definition lineage depth $nextDepth reached cap $cap"
-                            ): FailureReason).asLeft[Unit].pure[FiberT[F, *]]
-                          else walk(ancestor.parentFiberId, nextDepth, visited + pid)
-                        }
+      ): FiberT[F, Either[FailureReason, Unit]] = {
+        val lineageOk = ().asRight[FailureReason].pure[FiberT[F, *]]
+        def deny(detail: String): FiberT[F, Either[FailureReason, Unit]] =
+          (FailureReason.PolicyViolation("maxGenerations", detail): FailureReason).asLeft[Unit].pure[FiberT[F, *]]
+
+        fiber.definition.policy.dials.flatMap(_.maxGenerations).fold(lineageOk) { cap =>
+          fiber.definition.computeDigest.liftFiber.flatMap { selfDigest =>
+            def walk(
+              currentParent: Option[UUID],
+              depth:         Int,
+              visited:       Set[UUID]
+            ): FiberT[F, Either[FailureReason, Unit]] =
+              currentParent.fold(lineageOk) { pid =>
+                if (visited.contains(pid))
+                  // A cycle in the parent chain ⇒ the lineage is unverifiable ⇒ fail closed (and never loop).
+                  deny(s"ancestor chain forms a cycle at $pid")
+                else
+                  calculatedState.stateMachines
+                    .get(pid)
+                    .fold(deny(s"ancestor chain incomplete at $pid")) { ancestor =>
+                      ancestor.definition.computeDigest.liftFiber.flatMap { ancDigest =>
+                        val nextDepth = if (ancDigest === selfDigest) depth + 1 else depth
+                        if (nextDepth >= cap) deny(s"self-definition lineage depth $nextDepth reached cap $cap")
+                        else walk(ancestor.parentFiberId, nextDepth, visited + pid)
+                      }
                     }
-                }
-              // Seed `visited` with the spawning fiber's own id so a direct self-parent (A.parent = A) is caught.
-              walk(fiber.parentFiberId, 0, Set(fiber.fiberId))
-            }
+              }
+            // Seed `visited` with the spawning fiber's own id so a direct self-parent (A.parent = A) is caught.
+            walk(fiber.parentFiberId, 0, Set(fiber.fiberId))
+          }
         }
+      }
 
       private def completeStateMachineTransaction(
         originalFiber:  Records.StateMachineFiberRecord,

--- a/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/fiber/evaluation/EffectExtractor.scala
+++ b/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/fiber/evaluation/EffectExtractor.scala
@@ -382,9 +382,9 @@ object EffectExtractor {
     contextData:   JsonLogicValue,
     sourceFiberId: UUID
   )(implicit S: Stateful[G, ExecutionState], A: Ask[G, FiberContext], lift: F ~> G): G[Option[FiberTrigger]] =
-    extractByKey(effectResult, ReservedKeys.SCRIPT_CALL) match {
-      case None => none[FiberTrigger].pure[G] // absent directive ⇒ no-op (not malformed)
-      case Some(MapValue(scriptCallMap)) =>
+    // absent directive ⇒ no-op (not malformed)
+    extractByKey(effectResult, ReservedKeys.SCRIPT_CALL).fold(none[FiberTrigger].pure[G]) {
+      case MapValue(scriptCallMap) =>
         for {
           cidStr        <- requireString[F, G](scriptCallMap, ReservedKeys.FIBER_ID, "_scriptCall", "fiberId")
           targetId      <- requireUuid[F, G](cidStr, "_scriptCall", "fiberId")
@@ -397,7 +397,7 @@ object EffectExtractor {
           sourceFiberId = Some(sourceFiberId)
         ).some
 
-      case Some(other) =>
+      case other =>
         rejectDirective[F, G, Option[FiberTrigger]]("_scriptCall", s"must be an object, got $other")
     }
 
@@ -460,11 +460,7 @@ object EffectExtractor {
             "assetId"
           )
           assetId <- evaluatedAssetId match {
-            case StrValue(s) =>
-              scala.util.Try(UUID.fromString(s)).toOption match {
-                case Some(uuid) => uuid.pure[G]
-                case None       => rejectDirective[F, G, UUID]("_transferAsset", s"assetId is not a valid UUID: '$s'")
-              }
+            case StrValue(s) => requireUuid[F, G](s, "_transferAsset", "assetId")
             case other => rejectDirective[F, G, UUID]("_transferAsset", s"assetId must be a UUID string, got $other")
           }
           recipientValue <- requireField[F, G](transferMap, ReservedKeys.RECIPIENT, "_transferAsset", "recipient")
@@ -477,14 +473,16 @@ object EffectExtractor {
           )
           recipient <- evaluatedRecipient match {
             case MapValue(_) =>
-              evaluatedRecipient.asJson.as[AssetHolder] match {
-                case Right(holder) => holder.pure[G]
-                case Left(err) =>
-                  rejectDirective[F, G, AssetHolder](
-                    "_transferAsset",
-                    s"recipient is not a valid AssetHolder object {Fiber|Wallet}: ${err.getMessage}"
-                  )
-              }
+              evaluatedRecipient.asJson
+                .as[AssetHolder]
+                .fold(
+                  err =>
+                    rejectDirective[F, G, AssetHolder](
+                      "_transferAsset",
+                      s"recipient is not a valid AssetHolder object {Fiber|Wallet}: ${err.getMessage}"
+                    ),
+                  _.pure[G]
+                )
             case other =>
               rejectDirective[F, G, AssetHolder](
                 "_transferAsset",
@@ -519,10 +517,7 @@ object EffectExtractor {
     directive: String,
     label:     String
   )(implicit lift: F ~> G): G[JsonLogicValue] =
-    map.get(key) match {
-      case Some(v) => v.pure[G]
-      case None    => rejectDirective[F, G, JsonLogicValue](directive, s"missing $label")
-    }
+    map.get(key).fold(rejectDirective[F, G, JsonLogicValue](directive, s"missing $label"))(_.pure[G])
 
   /** A required string `directive` field, or a graceful [[CombineRejected]] (missing / not a string). */
   private def requireString[F[_]: Async, G[_]: Monad](
@@ -542,10 +537,9 @@ object EffectExtractor {
     directive: String,
     label:     String
   )(implicit lift: F ~> G): G[UUID] =
-    scala.util.Try(UUID.fromString(raw)).toOption match {
-      case Some(u) => u.pure[G]
-      case None    => rejectDirective[F, G, UUID](directive, s"$label is not a valid UUID: '$raw'")
-    }
+    ExpressionParser
+      .parseUuid(raw)
+      .fold(rejectDirective[F, G, UUID](directive, s"$label is not a valid UUID: '$raw'"))(_.pure[G])
 
   /** Evaluate a directive sub-expression under `phase`; a `Left` (gas/eval failure) is LOUD (rejects). */
   private def evalOrReject[F[_]: Async, G[_]: Monad](
@@ -561,10 +555,12 @@ object EffectExtractor {
   ): G[JsonLogicValue] =
     MeteredEvaluator
       .eval[F, G](ExpressionParser.valueToExpression(value), contextData, phase)
-      .flatMap {
-        case Right(v)     => v.pure[G]
-        case Left(reason) => rejectDirective[F, G, JsonLogicValue](directive, s"$label did not evaluate: $reason")
-      }
+      .flatMap(
+        _.fold(
+          reason => rejectDirective[F, G, JsonLogicValue](directive, s"$label did not evaluate: $reason"),
+          _.pure[G]
+        )
+      )
 
   /**
    * Extract dynamic-dependency mutations (`_addDependency` / `_setDependencyActive`) with gas metering.
@@ -613,20 +609,16 @@ object EffectExtractor {
             directive,
             "fiberId"
           )
-          fiberIdStr <- evaluatedFiberId match {
-            case StrValue(s) => s.pure[G]
-            case other       => rejectDirective[F, G, String](directive, s"fiberId must be a string, got $other")
+          fiberId <- evaluatedFiberId match {
+            case StrValue(s) => requireUuid[F, G](s, directive, "fiberId")
+            case other       => rejectDirective[F, G, UUID](directive, s"fiberId must be a string, got $other")
           }
-          fiberId <- requireUuid[F, G](fiberIdStr, directive, "fiberId")
-          active <- forcedActive match {
-            case Some(b) => b.pure[G]
-            case None =>
-              depMap.get(ReservedKeys.ACTIVE) match {
-                case Some(BoolValue(b)) => b.pure[G]
-                case Some(other) => rejectDirective[F, G, Boolean](directive, s"active must be a boolean, got $other")
-                case None        => rejectDirective[F, G, Boolean](directive, "missing active")
-              }
-          }
+          active <- forcedActive.fold(
+            requireField[F, G](depMap, ReservedKeys.ACTIVE, directive, "active").flatMap {
+              case BoolValue(b) => b.pure[G]
+              case other        => rejectDirective[F, G, Boolean](directive, s"active must be a boolean, got $other")
+            }
+          )(_.pure[G])
         } yield FiberEffect.DependencyMutated(fiberId, active)
       case other =>
         rejectDirective[F, G, FiberEffect.DependencyMutated](
@@ -658,15 +650,8 @@ object EffectExtractor {
     value match {
       case MapValue(m) =>
         for {
-          name <- m.get(ReservedKeys.NAME) match {
-            case Some(StrValue(n)) => n.pure[G]
-            case Some(other)       => rejectDirective[F, G, String]("_emit", s"name must be a string, got $other")
-            case None              => rejectDirective[F, G, String]("_emit", "missing name")
-          }
-          data <- m.get(ReservedKeys.DATA) match {
-            case Some(d) => d.pure[G]
-            case None    => rejectDirective[F, G, JsonLogicValue]("_emit", "missing data")
-          }
+          name <- requireString[F, G](m, ReservedKeys.NAME, "_emit", "name")
+          data <- requireField[F, G](m, ReservedKeys.DATA, "_emit", "data")
           destination = m.get(ReservedKeys.DESTINATION).collect { case StrValue(d) => d }
         } yield EmittedEvent(name, data, destination, emitterFiberId, emissionIndex)
       case other =>

--- a/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/fiber/evaluation/ExpressionParser.scala
+++ b/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/fiber/evaluation/ExpressionParser.scala
@@ -19,6 +19,10 @@ import xyz.kd5ujc.schema.fiber._
  */
 object ExpressionParser {
 
+  /** Parse a canonical UUID string; malformed → `None`. Shared by every UUID-bearing parse site. */
+  private[evaluation] def parseUuid(raw: String): Option[UUID] =
+    scala.util.Try(UUID.fromString(raw)).toOption
+
   def parseStateMachineDefinitionFromExpression(
     defExpr: JsonLogicExpression
   ): Option[StateMachineDefinition] =
@@ -31,10 +35,7 @@ object ExpressionParser {
           initialState     <- OptionT.fromOption[cats.Id](parseInitialState(initialStateExpr))
           transitionsExpr  <- OptionT.fromOption[cats.Id](defMap.get(ReservedKeys.TRANSITIONS))
           transitions      <- OptionT.fromOption[cats.Id](parseTransitionsFromExpression(transitionsExpr))
-          metadata = defMap.get(ReservedKeys.METADATA).flatMap {
-            case ConstExpression(v) => v.some
-            case _                  => none
-          }
+          metadata = defMap.get(ReservedKeys.METADATA).collect { case ConstExpression(v) => v }
         } yield StateMachineDefinition(states, initialState, transitions, metadata)).value
 
       case ConstExpression(v) =>
@@ -46,12 +47,8 @@ object ExpressionParser {
   private def parseInitialState(expr: JsonLogicExpression): Option[StateId] =
     expr match {
       case ConstExpression(StrValue(s)) => StateId(s).some
-      case MapExpression(m) =>
-        m.get(ReservedKeys.VALUE).flatMap {
-          case ConstExpression(StrValue(s)) => StateId(s).some
-          case _                            => none
-        }
-      case _ => none
+      case MapExpression(m) => m.get(ReservedKeys.VALUE).collect { case ConstExpression(StrValue(s)) => StateId(s) }
+      case _                => none
     }
 
   private def parseStatesFromExpression(
@@ -65,15 +62,9 @@ object ExpressionParser {
               case MapExpression(stateMap) =>
                 val isFinal = stateMap
                   .get(ReservedKeys.IS_FINAL)
-                  .flatMap {
-                    case ConstExpression(BoolValue(b)) => b.some
-                    case _                             => none
-                  }
+                  .collect { case ConstExpression(BoolValue(b)) => b }
                   .getOrElse(false)
-                val metadata = stateMap.get(ReservedKeys.METADATA).flatMap {
-                  case ConstExpression(v) => v.some
-                  case _                  => none
-                }
+                val metadata = stateMap.get(ReservedKeys.METADATA).collect { case ConstExpression(v) => v }
                 (StateId(stateId) -> State(
                   id = StateId(stateId),
                   isFinal = isFinal,
@@ -102,24 +93,16 @@ object ExpressionParser {
               eventName     <- OptionT.fromOption[cats.Id](parseEventName(eventNameExpr))
               guard         <- OptionT.fromOption[cats.Id](transMap.get(ReservedKeys.GUARD))
               effect        <- OptionT.fromOption[cats.Id](transMap.get(ReservedKeys.EFFECT))
-            } yield {
-              val dependencies = transMap
+              dependencies = transMap
                 .get(ReservedKeys.DEPENDENCIES)
-                .flatMap {
-                  case ArrayExpression(deps) =>
-                    deps
-                      .flatMap {
-                        case ConstExpression(StrValue(id)) => scala.util.Try(UUID.fromString(id)).toOption
-                        case _                             => none
-                      }
-                      .toSet
-                      .some
-                  case _ => none
+                .collect { case ArrayExpression(deps) =>
+                  deps.flatMap {
+                    case ConstExpression(StrValue(id)) => parseUuid(id)
+                    case _                             => none
+                  }.toSet
                 }
                 .getOrElse(Set.empty)
-
-              Transition(from, to, eventName, guard, effect, dependencies)
-            }).value
+            } yield Transition(from, to, eventName, guard, effect, dependencies)).value
           case _ => none
         }
       case _ => none
@@ -128,23 +111,15 @@ object ExpressionParser {
   private def parseStateId(expr: JsonLogicExpression): Option[StateId] =
     expr match {
       case ConstExpression(StrValue(s)) => StateId(s).some
-      case MapExpression(m) =>
-        m.get(ReservedKeys.VALUE).flatMap {
-          case ConstExpression(StrValue(s)) => StateId(s).some
-          case _                            => none
-        }
-      case _ => none
+      case MapExpression(m) => m.get(ReservedKeys.VALUE).collect { case ConstExpression(StrValue(s)) => StateId(s) }
+      case _                => none
     }
 
   private def parseEventName(expr: JsonLogicExpression): Option[String] =
     expr match {
       case ConstExpression(StrValue(et)) => et.some
-      case MapExpression(m) =>
-        m.get(ReservedKeys.VALUE).flatMap {
-          case ConstExpression(StrValue(et)) => et.some
-          case _                             => none
-        }
-      case _ => none
+      case MapExpression(m) => m.get(ReservedKeys.VALUE).collect { case ConstExpression(StrValue(et)) => et }
+      case _                => none
     }
 
   def parseStateMachineDefinition(defValue: JsonLogicValue): Option[StateMachineDefinition] =
@@ -226,26 +201,23 @@ object ExpressionParser {
               eventType      <- OptionT.fromOption[cats.Id](parseEventNameValue(eventTypeValue))
               guardValue     <- OptionT.fromOption[cats.Id](transMap.get(ReservedKeys.GUARD))
               effectValue    <- OptionT.fromOption[cats.Id](transMap.get(ReservedKeys.EFFECT))
-            } yield {
-              val dependencies = transMap
+              dependencies = transMap
                 .get(ReservedKeys.DEPENDENCIES)
                 .collect { case ArrayValue(deps) =>
                   deps.flatMap {
-                    case StrValue(id) => scala.util.Try(UUID.fromString(id)).toOption
+                    case StrValue(id) => parseUuid(id)
                     case _            => none
                   }.toSet
                 }
                 .getOrElse(Set.empty)
-
-              Transition(
-                from = from,
-                to = to,
-                eventName = eventType,
-                guard = valueToExpression(guardValue),
-                effect = valueToExpression(effectValue),
-                dependencies = dependencies
-              )
-            }).value
+            } yield Transition(
+              from = from,
+              to = to,
+              eventName = eventType,
+              guard = valueToExpression(guardValue),
+              effect = valueToExpression(effectValue),
+              dependencies = dependencies
+            )).value
           case _ => none
         }
       case _ => none

--- a/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/fiber/evaluation/FiberEvaluator.scala
+++ b/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/fiber/evaluation/FiberEvaluator.scala
@@ -103,9 +103,9 @@ object FiberEvaluator {
       ): G[FiberResult] = {
         val input = FiberInput.Transition(eventName, payload)
 
-        policyShortCircuit(fiber, caller) match {
-          case Some(reason) => reason.pureOutcome[G]
-          case None =>
+        policyShortCircuit(fiber, caller)
+          .map(_.pureOutcome[G])
+          .getOrElse(
             fiber.definition.transitionMap
               .get((fiber.currentState, eventName))
               .fold(
@@ -113,7 +113,7 @@ object FiberEvaluator {
               )(
                 tryTransitions(fiber, input, proofs, _, attemptedGuards = 0, caller)
               )
-        }
+          )
       }
 
       /**
@@ -267,18 +267,19 @@ object FiberEvaluator {
       ): G[FiberResult] =
         fiber.stateData match {
           case currentMap: MapValue =>
-            evaluateEffectExpression(transition, contextData).flatMap {
-              case Left(reason) => reason.pureOutcome[G]
-              case Right(effectResult) =>
+            evaluateEffectExpression(transition, contextData).flatMap(
+              _.fold(
+                _.pureOutcome[G],
                 processEffectResult(
                   fiber.fiberId,
                   currentMap,
                   transition,
-                  effectResult,
+                  _,
                   contextData,
                   fiber.definition.policy.dials.flatMap(_.allowedEffects)
                 )
-            }
+              )
+            )
 
           case _ =>
             FailureReason.EvaluationError(GasExhaustionPhase.Effect, "State data must be MapValue").pureOutcome[G]
@@ -301,11 +302,10 @@ object FiberEvaluator {
         for {
           limits    <- ExecutionOps.askLimits[G]
           sizeCheck <- validateStateSize(effectResult, limits).liftTo[G]
-          result <- sizeCheck match {
-            case Left(reason) => reason.pureOutcome[G]
-            case Right(_) =>
-              buildSuccessOutcome(fiberId, currentMap, transition, effectResult, contextData, allowedEffects)
-          }
+          result <- sizeCheck.fold(
+            _.pureOutcome[G],
+            _ => buildSuccessOutcome(fiberId, currentMap, transition, effectResult, contextData, allowedEffects)
+          )
         } yield result
 
       private def validateStateSize(
@@ -379,20 +379,26 @@ object FiberEvaluator {
                     .GasExhaustedFailure(totalGasUsed, limits.maxGas, GasExhaustionPhase.Effect)
                     .pureOutcome[G]
                 else
-                  StateMerger.make[F].mergeEffectIntoState(currentMap, effectResult).liftTo[G].map[FiberResult] {
-                    case Right(newStateData) =>
-                      FiberResult.Success(
-                        newStateData = newStateData,
-                        newStateId = Some(transition.to),
-                        triggers = allTriggers,
-                        spawns = spawnMachines,
-                        returnValue = None,
-                        emittedEvents = emittedEvents,
-                        assetTransfers = assetTransfers,
-                        dependencyMutations = depMutations
+                  StateMerger
+                    .make[F]
+                    .mergeEffectIntoState(currentMap, effectResult)
+                    .liftTo[G]
+                    .map(
+                      _.fold[FiberResult](
+                        _.asOutcome,
+                        newStateData =>
+                          FiberResult.Success(
+                            newStateData = newStateData,
+                            newStateId = Some(transition.to),
+                            triggers = allTriggers,
+                            spawns = spawnMachines,
+                            returnValue = None,
+                            emittedEvents = emittedEvents,
+                            assetTransfers = assetTransfers,
+                            dependencyMutations = depMutations
+                          )
                       )
-                    case Left(reason) => reason.asOutcome
-                  }
+                    )
             }
         } yield result
 

--- a/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/combine/AssetCombiner.scala
+++ b/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/combine/AssetCombiner.scala
@@ -687,22 +687,23 @@ class AssetCombiner[F[_]: Async: SecurityProvider](
       if (signerOwned) acc.pure[F]
       else {
         val live = acc.calculated.usedNonces.getOrElse(cp.assetId, SortedSet.empty[Long])
-        nonce match {
-          case Some(n) if live.contains(n) =>
-            // Consume linearly: remove the revealed nonce from THIS counter-party's authorization set.
-            val updatedSet = live - n
-            val updatedNonces =
-              if (updatedSet.isEmpty) acc.calculated.usedNonces - cp.assetId
-              else acc.calculated.usedNonces.updated(cp.assetId, updatedSet)
-            acc.focus(_.calculated.usedNonces).replace(updatedNonces).pure[F]
-          case _ =>
+        nonce
+          .filter(live.contains)
+          .fold(
             Async[F].raiseError[DataState[OnChain, CalculatedState]](
               CombineRejected(
                 s"compose counter-party ${cp.assetId} (holder ${cp.holder}) is neither signer-owned nor " +
                 s"covered by a live AuthorizeCompose nonce — cross-holder consent is required"
               )
             )
-        }
+          ) { n =>
+            // Consume linearly: remove the revealed nonce from THIS counter-party's authorization set.
+            val updatedSet = live - n
+            val updatedNonces =
+              if (updatedSet.isEmpty) acc.calculated.usedNonces - cp.assetId
+              else acc.calculated.usedNonces.updated(cp.assetId, updatedSet)
+            acc.focus(_.calculated.usedNonces).replace(updatedNonces).pure[F]
+          }
       }
     }
 
@@ -970,50 +971,47 @@ class AssetCombiner[F[_]: Async: SecurityProvider](
       .get(source.schemaBinding.name)
       .map(_.target)
       .collect { case RegistryTarget.AssetPolicyPackage(l) => l }
-      .flatMap(_.versions.get(source.schemaBinding.version)) match {
-      case Some(rv) =>
-        rv.shape match {
-          case ap: RegistryShape.AssetPolicy => ap.pure[F]
-          case other =>
-            Async[F].raiseError(
-              CombineRejected(
-                s"${source.schemaBinding.name.render} resolves to a non-asset shape ${other.getClass.getSimpleName}"
-              )
-            )
-        }
-      case None =>
-        Async[F].raiseError(
+      .flatMap(_.versions.get(source.schemaBinding.version))
+      .fold(
+        Async[F].raiseError[RegistryShape.AssetPolicy](
           CombineRejected(
             s"asset ${source.assetId} binding ${source.schemaBinding.name.render}@${source.schemaBinding.version.render} did not resolve"
           )
         )
-    }
+      )(rv => requireAssetPolicyShape(rv, source.schemaBinding.name))
 
   /** Resolve the `policyRef` of a mint to (name, version, shape). Missing/yanked → reject. */
   private def resolvePolicy(ref: SchemaRef): F[(RegistryName, RegisteredVersion, RegistryShape.AssetPolicy)] =
-    current.calculated.registry
-      .get(ref.name)
-      .map(_.target)
-      .collect { case RegistryTarget.AssetPolicyPackage(l) => l } match {
-      case None =>
-        Async[F].raiseError(CombineRejected(s"policyRef ${ref.name.render} is not a known asset-policy package"))
-      case Some(lineage) =>
-        lineage
-          .resolve(ref.version)
-          .fold(
-            e =>
-              Async[F].raiseError[(RegistryName, RegisteredVersion, RegistryShape.AssetPolicy)](
-                CombineRejected(s"policyRef unresolvable for ${ref.name.render}: $e")
-              ),
-            rv =>
-              rv.shape match {
-                case ap: RegistryShape.AssetPolicy => (ref.name, rv, ap).pure[F]
-                case other =>
-                  Async[F].raiseError[(RegistryName, RegisteredVersion, RegistryShape.AssetPolicy)](
-                    CombineRejected(s"${ref.name.render} resolves to a non-asset shape ${other.getClass.getSimpleName}")
-                  )
-              }
+    for {
+      lineage <- current.calculated.registry
+        .get(ref.name)
+        .map(_.target)
+        .collect { case RegistryTarget.AssetPolicyPackage(l) => l }
+        .fold(
+          Async[F].raiseError[VersionLineage](
+            CombineRejected(s"policyRef ${ref.name.render} is not a known asset-policy package")
           )
+        )(_.pure[F])
+      rv <- lineage
+        .resolve(ref.version)
+        .fold(
+          e =>
+            Async[F].raiseError[RegisteredVersion](
+              CombineRejected(s"policyRef unresolvable for ${ref.name.render}: $e")
+            ),
+          _.pure[F]
+        )
+      shape <- requireAssetPolicyShape(rv, ref.name)
+    } yield (ref.name, rv, shape)
+
+  /** Narrow a resolved registry version to the [[RegistryShape.AssetPolicy]] shape; anything else → reject. */
+  private def requireAssetPolicyShape(rv: RegisteredVersion, name: RegistryName): F[RegistryShape.AssetPolicy] =
+    rv.shape match {
+      case ap: RegistryShape.AssetPolicy => ap.pure[F]
+      case other =>
+        Async[F].raiseError(
+          CombineRejected(s"${name.render} resolves to a non-asset shape ${other.getClass.getSimpleName}")
+        )
     }
 
   /** Resolve all counter-party asset ids to their authoritative records; any missing → reject. */


### PR DESCRIPTION
## What

Pure-refactor readability pass over the five files with genuine 3+-level nested Option/Either pattern matches, converting them to the codebase's dominant chaining style (`.fold`/`.collect`/`Either.fold`/for-comprehensions). Outcome of the "reduce boxing/unboxing via chaining" investigation — the survey found no in-repo hot loop where boxing matters (the JLVM opcode loop lives in metakit), so this lands as the bounded consistency cleanup, not a perf change.

- `ExpressionParser`: finished the half-converted OptionT methods; shared `parseUuid` helper dedups 4 `Try(UUID.fromString).toOption` sites
- `EffectExtractor`: `parseAssetTransfer`/`parseDependencyMutation`/`parseEmittedEvent`/`extractScriptCall` + the `require*` helpers — byte-identical error messages
- `FiberEngine`: the 3-level transition-commit chain (`commitStateMachineSuccess`), `checkMaxGenerations.walk`, migration `.fold`s — `getGasUsed` reads stay at the same sequence points
- `AssetCombiner`: `consumeComposeConsent`, `resolvePolicy`/`resolveAssetPolicy` (+ shared `requireAssetPolicyShape`)
- `FiberEvaluator`: policy short-circuit, effect-result folds

**Deliberately untouched** (exhaustiveness-load-bearing or clearer as matches, per-site skips listed in the commit body): the 16-way `Combiner` update dispatch, `EffectExtractor.handlerFor`, `FiberEvaluator.evaluate` tuple-ADT dispatch, all AST node walkers, named multi-arm failure matches.

## Verification

- Zero behavioral change intended; identical error messages and effect ordering
- Full `sharedData/test`: **641/641** across 88 suites; targeted fiber/asset suites 138/138
- Downstream `currencyL0` / `currencyL1` / `dataL1` compile; scalafmt clean
- Net **−67 lines** (223+/290−), all in the five target files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R5TUSJPD8FCtJagf7siXgt