### PR TITLE
chore(agents): agent-workflow infra — router, personas, toolbelt

### DIFF
--- a/.claude/skills/commit-sweep/SKILL.md
+++ b/.claude/skills/commit-sweep/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: commit-sweep
+description: Audit a range of recent ottochain commits, one review-persona lens per pass, and file findings as GitHub issues + a worksheet. Never fixes inline. Use to retro-review merged/landed work for defects the original review missed.
+---
+
+# commit-sweep
+
+Retro-review landed commits through each review persona in turn. Output is findings (issues + a
+worksheet), NOT fixes — a fix rides its own PR with its own review.
+
+## Input
+A since-ref or range: `--since 2026-07-01`, or `origin/main~20..origin/main`, or a PR number's merge range.
+
+## Sequence
+1. `bin/worksheet commit-sweep-<date>` — open a worksheet to hold findings.
+2. List the range: `git log --oneline --since=<date>` (or the explicit range). Note the diffs that touch
+   blast-radius files (`docs/agents/blast-radius.md`) — those get the most scrutiny.
+3. **One persona lens per pass.** For each of the five personas, sweep the whole range with ONLY that
+   persona's checklist in mind:
+   - `bin/agent-review consensus-safety <range> --dry-run` (or run it) — signed messages, validators,
+     combiners, determinism, the C1–C3/H1–H2/M1–M3/L-class defects.
+   - `bin/agent-review wire-compat <range>` — OpenAPI/SDK/e2e drift, version lockstep, path prefixes.
+   - `bin/agent-review state-growth-determinism <range>` — unbounded state, 512KB cap, gas, SortedMap.
+   - `bin/agent-review asset-economics <range>` — conservation, consent, custody, nonce linearity.
+   - `bin/agent-review ai-smells-test-integrity <range>` — tautological/self-regenerating tests, claim-vs-reality.
+   Record each pass's findings in the worksheet under a per-persona heading.
+4. For each real finding, file a GitHub issue: `gh issue create` with a clear title (lowercase, ≤72),
+   the persona label, the commit/file:line, the defect class, and why it matters. Add `blast-radius` or
+   `needs-senior` labels where warranted.
+5. Link the issues back into the worksheet. Append a `docs/agents/feedback.md` entry if the sweep revealed
+   a systemic gap (e.g. a missing guard suite).
+
+## Rules
+- **Never fix inline.** A sweep produces findings; fixes are separate, reviewed PRs.
+- Prefer false-positive-tolerant reporting: note uncertain findings as questions, not assertions — a human
+  triages. But do not manufacture findings to look thorough; "range is clean against persona X" is a valid result.
+- The claim-vs-reality check (ai-smells) is the highest-value pass: verify that each commit message's
+  claims are backed by the diff and a runnable command (the #162 lesson).

--- a/.claude/skills/night-shift/SKILL.md
+++ b/.claude/skills/night-shift/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: night-shift
+description: Autonomously pick up and ship low-tier ottochain tasks unattended — pick a cheap-model-ok issue, worksheet-first, small commits, preflight, PR, watch to green, never merge. Use for unattended/batch task execution in the ottochain repo.
+---
+
+# night-shift
+
+Ship small, safe ottochain work unattended. You are a bounded execution worker, not an architect. Route
+by the minimum tier that can safely do the job and STOP the moment the work exceeds it.
+
+## Guardrails (read first)
+- **Read `AGENTS.md`, `CLAUDE.md`, `docs/agents/blast-radius.md` before touching anything.**
+- **Only pick `cheap-model-ok` tasks** (T0–1: tests, docs, `bin/`, worksheets) unless explicitly told
+  otherwise. Never start a `needs-senior` or `blast-radius` task on the night shift.
+- **NEVER merge.** Agents push branches and open PRs; James merges. On Constellation-Labs repos the
+  identity is pull-only.
+
+## Sequence
+1. `bin/tasks cheap-model-ok` — pick ONE issue you can finish. If none fit your tier, stop.
+2. `bin/worksheet <slug>` — open the worksheet FIRST. Fill goal + context links + plan.
+3. `git fetch origin && git checkout -b <type>/<slug> origin/main` — always off fresh origin/main.
+4. Do the work in **small, logical commits**. Before each commit measure the subject:
+   `s="..."; printf '%d %s\n' "${#s}" "$s"` (≤72, lowercase start, no trailing period). Add trailers
+   (Co-Authored-By, Claude-Session, `Worksheet: docs/worksheets/<file>`). Update the worksheet's running log.
+5. `bin/preflight` — must exit 0. (`--fast` while iterating; full before the PR.)
+6. `git push -u origin HEAD` && `gh pr create` (title obeys commitlint too). Name any blast-radius files
+   in the PR body with a safety rationale — but ideally night-shift work touches none.
+7. `bin/pr-watch <pr#>` — **a PR is NOT done until this exits 0.** On failure, read the dumped logs, fix,
+   push, watch again.
+8. Append a `docs/agents/feedback.md` entry (what slowed you down + a fix). Commit the worksheet + feedback.
+
+## Stop conditions (write worksheet state, then STOP)
+- 2 consecutive failed fix attempts on the same failure.
+- ANY blast-radius judgment call, or the task turns out to need a T3 change.
+- A decision that needs a human or senior model (record it in the worksheet's decisions section).
+- Session/time budget exhausted.
+On every stop: update the worksheet's handoff notes so a fresh session can resume, then stop cleanly. Do
+not merge, do not force questionable changes to make CI pass.
+
+## End of shift
+`bin/preflight` green + `bin/pr-watch` exited 0 on every PR you opened + a `feedback.md` entry appended.
+An unwatched PR is an unfinished shift.

--- a/.claude/skills/test-audit/SKILL.md
+++ b/.claude/skills/test-audit/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: test-audit
+description: Sample ottochain test suites and prove they actually test — mutate each suite's subject, confirm the test goes red, then revert. Files issues for decorative/tautological/self-regenerating tests. Use to check test integrity, not just coverage.
+---
+
+# test-audit
+
+Coverage % says a line ran; it does not say a test would catch a bug. This skill proves it the only way
+that counts: break the code the test covers and confirm the test fails. Applies the
+`ai-smells-test-integrity` persona checklist.
+
+## Sequence
+1. `bin/worksheet test-audit-<date>` — open a worksheet for findings.
+2. Pick a sample of suites — prioritize the guards named in `docs/signing-canonical-and-validation.md`
+   and any suite touched by recent diffs. Good starting targets on `main`: `CommittedViewSuite`,
+   signing-canonical suites, `FailureReasonCanonicalSuite`, genesis contract suites.
+3. Confirm each suite is GREEN as-is: `bin/test <module> "*<SuiteName>*"`.
+4. **The mutation check (the core of this skill):** for each suite, make a small, targeted mutation to the
+   PRODUCTION code it covers — flip a comparator (`>`→`>=`), negate a boolean, return a constant, drop a
+   `sortBy`, skip a dedup. Re-run the suite:
+   - **Suite goes RED** → the test is real. Good. **Revert the mutation** (`git checkout -- <file>`).
+   - **Suite stays GREEN** → the test is decorative for that behavior. Record it as a finding, revert.
+   ALWAYS revert every mutation before moving on — leave the tree clean.
+5. Apply the rest of the persona checklist by reading:
+   - self-regenerating golden fixtures (fixture written and asserted in the same run),
+   - tautological assertions (asserting a mock returns what it was told),
+   - vacuous property generators, error-message-string drift, weaver `name` shadowing.
+6. File a `gh issue` per weak suite (title lowercase ≤72, label `test-integrity`), citing the mutation
+   that survived. Link findings in the worksheet. Append a `docs/agents/feedback.md` entry if a whole
+   class of behavior is untested.
+
+## Rules
+- Never leave a mutation in the tree. If interrupted, `git status` + revert before stopping.
+- Do not "fix" the weak test inline during the audit — file it; the fix is a separate reviewed PR.
+- A suite that goes red under every plausible mutation is a PASS — record that too, it's signal.
+
+## Future backbone
+This is manual mutation testing. The durable version is **stryker4s** (mutation testing for Scala) run in
+CI — a mutation score is a deterministic, non-flaky "do the tests catch bugs" gate, unlike the advisory
+70% coverage number. A stryker4s spike is proposed in `docs/agents/process-observations.md` (#4); until it
+lands, this skill is how we get the signal.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,63 @@
+# AGENTS.md — the router for agents working in ottochain
+
+OttoChain is a Constellation metagraph (Scala 2.13, `xyz.kd5ujc`) that turns signed JSON into
+executable multi-party workflows: **state-machine fibers** and **scripts** running on the JLVM.
+Consensus is all-or-nothing per block; a determinism bug forks the chain. Move carefully.
+
+## READ FIRST (non-negotiable)
+1. `CLAUDE.md` — the 3 data-application invariants. They are load-bearing. Do not violate them.
+2. `docs/signing-canonical-and-validation.md` — full rationale for those invariants + the
+   InvalidSignature / block-poisoning mechanics. Read before touching any signed message or validator.
+3. `docs/INDEX.md` — the map of every doc. Navigate the codebase's knowledge through it.
+
+## Route by the minimum tier that can safely do the job
+Do not "let the smart model do everything." Match the work to the cheapest tier that is safe:
+
+| Tier | Scope | Authority |
+|------|-------|-----------|
+| **T0–T1** | tests (new), docs, `bin/`, worksheets, comments, OpenAPI regen | **Do freely.** |
+| **T2** | routes, `handlers/`, the e2e harness (`e2e-test/`), non-consensus wiring | **Review-first.** Small commits, preflight, a persona pass. |
+| **T3+** | anything in `docs/agents/blast-radius.md` (signed schemas, validators, combiners, fiber engine, genesis) | **Cheap models PROPOSE, never decide.** Needs a senior-model session or human sign-off recorded in the worksheet. |
+
+`docs/agents/blast-radius.md` is the authoritative file:why list. If a change touches it, the PR
+description must name each blast-radius file changed and why it is safe.
+
+## Standard workflow
+```
+git fetch origin && git checkout -b <type>/<slug> origin/main   # always branch off fresh origin/main
+bin/worksheet <slug>          # open a worksheet FIRST (docs/worksheets/), update it at every stop
+# ... small, logical commits (conventional, lowercase subject <=72 — MEASURE, see conventions.md) ...
+bin/preflight                 # every CI gate, locally, in CI's order — must exit 0
+git push -u origin HEAD
+gh pr create ...              # PR title obeys commitlint too (lowercase, <=72, no `release` scope)
+bin/pr-watch <pr#>            # a PR is NOT done until this exits 0
+# append a docs/agents/feedback.md entry, then stop
+```
+**Agents NEVER merge.** On `scasplte2/ottochain` the agent identity pushes branches + opens PRs;
+James merges. On canonical Constellation-Labs repos the agent identity is pull-only.
+
+## Tools
+- `bin/` toolbelt — `preflight`, `test`, `regen-openapi`, `pr-watch`, `tasks`, `agent-review`,
+  `wire-size`, `worksheet`. Each has `--help`. See `docs/agents/tools.md`.
+- `just` recipes — `just test`, `just test-only <suite>`, `just build`, `just e2e-up`, `just e2e`,
+  `just e2e-down`, `just health`. bin/ wraps/delegates to these; do not duplicate them.
+- Skills — `tessellation-cluster` (run a local cluster — use this, there is no `bin/cluster`),
+  `pr-workflow`, plus repo skills in `.claude/skills/`: `night-shift`, `commit-sweep`, `test-audit`.
+- Local cluster: `just e2e-up` (resolves the tessellation version from the metakit pin). E2E env
+  knobs that MUST ride any repro: `DATA_PEERS_COUNT=2`, `DATA_L1_TIME_TRIGGER_INTERVAL="8 seconds"`,
+  distinct wallets via `E2E_WALLETS` (multi-party flows fail confusingly on a single wallet).
+
+## Terminology
+The two fiber kinds are **state machines** and **scripts**. "oracle" is DEPRECATED — never put it in
+new code, routes, namespaces, or docs (except a real-world domain oracle noun). Consensus-visible
+names are baked into MPT roots and are near-immutable once shipped.
+
+## Review personas
+Five self-contained persona files live in `docs/agents/review-personas/`. Each is a checklist + defect
+classes a cheap model can apply to a diff with only that file for context. Run one with
+`bin/agent-review <persona>`. Personas own docs and keep them current (see `docs/agents/README.md`).
+
+## Feedback loop
+At the end of every session append an entry to `docs/agents/feedback.md` (what slowed you down +
+the proposed workflow fix). It compounds. When you type a non-obvious incantation twice, script it
+into `bin/` (`docs/agents/tools.md`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-- keep the work log up to date in .workspace/ when we have reached a stopping point or completed a task
+- keep a worksheet up to date in committed `docs/worksheets/` when we reach a stopping point or complete a task (resumable session traces; `bin/worksheet <slug>` to start one). `.workspace/` remains optional private scratch.
 
 ## Data-application invariants (read before touching signed messages or validators)
 
@@ -25,3 +25,5 @@ See `docs/signing-canonical-and-validation.md` for the full rationale. The two r
    `validateSignedUpdate` for fiber upgrade/create ops: structural checks only (field presence,
    expression depth, sequence number against `OnChain`). Guarded by this comment — review every
    new L0Validator method that takes a `SchemaRef` or `SchemaBinding` parameter.
+
+Full agent guide: AGENTS.md

--- a/bin/agent-review
+++ b/bin/agent-review
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+#
+# agent-review — run one review persona over a diff.
+# Assembles docs/agents/review-personas/<persona>.md + `git diff <range>` into a
+# single prompt and pipes it to `claude -p`. Use --dry-run to print the prompt
+# for another harness instead.
+#
+# Usage:
+#   bin/agent-review <persona> [range] [--dry-run]
+#
+#   persona: consensus-safety | wire-compat | state-growth-determinism
+#            | asset-economics | ai-smells-test-integrity
+#   range:   git diff range (default: origin/main...HEAD)
+#
+# Examples:
+#   bin/agent-review consensus-safety
+#   bin/agent-review wire-compat origin/main...HEAD --dry-run
+#
+set -euo pipefail
+
+case "${1:-}" in -h|--help|"") sed -n '2,18p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;; esac
+
+PERSONA="$1"; shift || true
+RANGE="origin/main...HEAD"
+DRY=0
+for a in "$@"; do
+  case "$a" in
+    --dry-run) DRY=1 ;;
+    *) RANGE="$a" ;;
+  esac
+done
+
+ROOT="$(git rev-parse --show-toplevel)"; cd "$ROOT"
+PFILE="docs/agents/review-personas/${PERSONA}.md"
+if [ ! -f "$PFILE" ]; then
+  echo "no such persona: $PFILE" >&2
+  echo "available:" >&2
+  ls docs/agents/review-personas/ 2>/dev/null | sed 's/\.md$//; s/^/  /' >&2
+  exit 2
+fi
+
+prompt="$(mktemp)"
+{
+  echo "You are the review persona defined below. Review ONLY the diff that follows it."
+  echo "Report findings as: SEVERITY (blocker/warn/nit) — file:line — what — why — fix."
+  echo "If the diff is clean against your checklist, say so plainly. Do not flag OUT OF SCOPE items."
+  echo ""
+  echo "================ PERSONA ================"
+  cat "$PFILE"
+  echo ""
+  echo "================ DIFF ($RANGE) ================"
+  git diff "$RANGE"
+} > "$prompt"
+
+if [ "$DRY" -eq 1 ]; then
+  cat "$prompt"; rm -f "$prompt"; exit 0
+fi
+
+if command -v claude >/dev/null 2>&1; then
+  claude -p < "$prompt"
+else
+  echo "claude CLI not found — printing assembled prompt instead:" >&2
+  cat "$prompt"
+fi
+rm -f "$prompt"

--- a/bin/pr-watch
+++ b/bin/pr-watch
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+#
+# pr-watch — poll a PR's checks until they settle; on failure, dump failing logs.
+#
+# THE RULE: a PR is not done until this exits 0. Never end a session with an
+# unmonitored PR (see docs/agents/process-observations.md — #210 shipped red).
+#
+# Usage:
+#   bin/pr-watch <pr#> [--interval 60] [--timeout 1800]
+#
+# Exit code mirrors the outcome: 0 all checks passed, 1 a check failed,
+# 2 timed out while still pending.
+#
+set -euo pipefail
+
+case "${1:-}" in -h|--help|"") sed -n '2,15p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;; esac
+
+PR="$1"; shift || true
+INTERVAL=60; TIMEOUT=1800
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --interval) INTERVAL="$2"; shift 2 ;;
+    --timeout)  TIMEOUT="$2";  shift 2 ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+start=$(date +%s)
+prev=""
+while :; do
+  # gh pr checks exits nonzero when checks fail/pending; capture without tripping set -e.
+  out=$(gh pr checks "$PR" 2>/dev/null || true)
+  state=$(gh pr checks "$PR" --json state --jq '[.[].state] | unique | join(",")' 2>/dev/null || echo "")
+
+  if [ "$out" != "$prev" ]; then
+    printf '\n\033[1m[%s] PR #%s\033[0m\n' "$(date +%H:%M:%S)" "$PR"
+    echo "$out"
+    prev="$out"
+  fi
+
+  # Terminal states.
+  if ! echo "$state" | grep -qiE 'pending|queued|in_progress|waiting'; then
+    if echo "$state" | grep -qiE 'fail|error|cancel'; then
+      echo ""
+      echo "==> checks FAILED — fetching failing job logs"
+      gh pr checks "$PR" --json name,state,link --jq \
+        '.[] | select(.state|test("FAIL|ERROR|CANCEL";"i")) | "\(.name)\t\(.link)"' 2>/dev/null || true
+      # Try to tail the failing run's job logs.
+      run_id=$(gh run list --branch "$(gh pr view "$PR" --json headRefName --jq .headRefName)" \
+                 --json databaseId,conclusion --jq \
+                 'map(select(.conclusion=="failure"))[0].databaseId' 2>/dev/null || true)
+      if [ -n "${run_id:-}" ] && [ "$run_id" != "null" ]; then
+        echo "--- tail of failing run $run_id ---"
+        gh run view "$run_id" --log-failed 2>/dev/null | tail -60 || \
+          gh run view "$run_id" --log 2>/dev/null | tail -60 || true
+      fi
+      exit 1
+    fi
+    echo ""
+    echo "==> all checks passed"
+    exit 0
+  fi
+
+  now=$(date +%s)
+  if [ $((now - start)) -ge "$TIMEOUT" ]; then
+    echo ""
+    echo "==> TIMEOUT after ${TIMEOUT}s with checks still pending"
+    exit 2
+  fi
+  sleep "$INTERVAL"
+done

--- a/bin/preflight
+++ b/bin/preflight
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+#
+# preflight — run every local gate CI will run, in CI's order, before you push.
+# A PR is not worth opening until this exits 0. See docs/agents/tools.md.
+#
+# Usage:
+#   bin/preflight [--fast]
+#
+#   --fast   test sharedData only (quick loop). Default: full `sbt test`.
+#
+# Gates, in order (mirrors .github/workflows/{ci,e2e}.yml):
+#   1. scalafmtCheckAll + scalafixAll --check   (format/lint, check-mode — no cache lies)
+#   2. tests                                     (--fast: sharedData; default: all modules)
+#   3. OpenAPI regen + git diff --exit-code      (drift gate; leaves the diff, does NOT restore)
+#   4. commitlint over origin/main..HEAD         (header<=72, lowercase subject, type-enum)
+#   5. e2e-test tsc --noEmit                      (skipped with a warning if node_modules absent)
+#
+set -euo pipefail
+
+if ! command -v sbt >/dev/null 2>&1 && [ -f "$HOME/.sdkman/bin/sdkman-init.sh" ]; then
+  set +e; source "$HOME/.sdkman/bin/sdkman-init.sh" >/dev/null 2>&1; set -e
+fi
+
+FAST=0
+for a in "$@"; do
+  case "$a" in
+    --fast) FAST=1 ;;
+    -h|--help) sed -n '2,20p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) echo "unknown arg: $a (try --help)" >&2; exit 2 ;;
+  esac
+done
+
+ROOT="$(git rev-parse --show-toplevel)"
+cd "$ROOT"
+
+declare -a NAMES=() RESULTS=()
+record() { NAMES+=("$1"); RESULTS+=("$2"); }
+step()   { printf '\n\033[1m==> %s\033[0m\n' "$1"; }
+
+# ---- 1. format + lint (check-mode) --------------------------------------------
+step "1/5 scalafmtCheckAll + scalafixAll --check"
+if sbt "scalafmtCheckAll" "scalafixAll --check"; then
+  record "format+lint" PASS
+else
+  record "format+lint" FAIL
+fi
+
+# ---- 2. tests -----------------------------------------------------------------
+if [ "$FAST" -eq 1 ]; then
+  step "2/5 sharedData/test (--fast)"
+  TESTCMD='sharedData/test'
+else
+  step "2/5 sbt test (all modules)"
+  TESTCMD='test'
+fi
+if sbt "$TESTCMD"; then
+  record "tests" PASS
+else
+  record "tests" FAIL
+fi
+
+# ---- 3. OpenAPI drift gate -----------------------------------------------------
+step "3/5 OpenAPI regen + drift check"
+if sbt "currencyL0/runMain xyz.kd5ujc.metagraph_l0.openapi.GenerateOpenApi docs"; then
+  if git diff --exit-code -- docs/openapi-*; then
+    record "openapi-drift" PASS
+  else
+    echo ""
+    echo "OpenAPI contract drifted. The regenerated docs/openapi-* differ from what is committed."
+    echo "Commit the regenerated files (they ARE the new contract):"
+    echo "    git add docs/openapi-* && git commit -m 'docs(openapi): regen contract'"
+    echo "If you did NOT change any route/DTO, investigate before committing — this is a real diff."
+    record "openapi-drift" FAIL
+  fi
+else
+  record "openapi-drift" FAIL
+fi
+
+# ---- 4. commitlint over origin/main..HEAD -------------------------------------
+step "4/5 commitlint (origin/main..HEAD)"
+commitlint_bash() {
+  # dependency-free mirror of .githooks/pre-push + .commitlintrc.json rules.
+  local max_len=72 cfg=".commitlintrc.json" bad=0 sha subject short type first
+  if [ -f "$cfg" ]; then
+    local n; n=$(grep 'header-max-length' "$cfg" | grep -oE '[0-9]+' | tail -1)
+    case "$n" in ''|*[!0-9]*) : ;; *) max_len=$n ;; esac
+  fi
+  local allowed=" feat fix docs style refactor perf test build ci chore revert "
+  for sha in $(git rev-list origin/main..HEAD); do
+    [ "$(git rev-list --parents -n1 "$sha" | wc -w)" -gt 2 ] && continue  # skip merges
+    subject=$(git log -1 --format=%s "$sha"); short=$(git log -1 --format=%h "$sha")
+    case "$subject" in Merge\ *|Revert\ *|fixup!\ *|squash!\ *|Release-As:*) continue ;; esac
+    if [ "${#subject}" -gt "$max_len" ]; then
+      printf '  \033[31mx\033[0m %s header %d>%d: %s\n' "$short" "${#subject}" "$max_len" "$subject"; bad=1
+    fi
+    if printf '%s' "$subject" | grep -qE '^[A-Za-z]+(\([^)]+\))?!?: .+'; then
+      type=$(printf '%s' "$subject" | sed -E 's/^([A-Za-z]+).*/\1/' | tr '[:upper:]' '[:lower:]')
+      printf '%s' "$allowed" | grep -q " $type " || { printf '  \033[31mx\033[0m %s bad type: %s\n' "$short" "$type"; bad=1; }
+      first=$(printf '%s' "$subject" | sed -E 's/^[A-Za-z]+(\([^)]+\))?!?: (.).*/\2/')
+      case "$first" in [A-Z]) printf '  \033[31mx\033[0m %s subject must start lower-case: %s\n' "$short" "$subject"; bad=1 ;; esac
+    else
+      printf '  \033[31mx\033[0m %s not "type(scope): subject": %s\n' "$short" "$subject"; bad=1
+    fi
+    case "$subject" in *.) printf '  \033[31mx\033[0m %s subject ends with a period\n' "$short"; bad=1 ;; esac
+  done
+  return $bad
+}
+CL_OK=1
+npx_rc=1
+if timeout 40 npx --yes @commitlint/cli --version >/dev/null 2>&1; then
+  # commitlint reads the range from git via --from/--to; stdin unused.
+  timeout 90 npx --yes @commitlint/cli --config .commitlintrc.json --from origin/main --to HEAD
+  npx_rc=$?
+fi
+# On ANY npx failure (a real violation OR a tooling/offline/missing-config-conventional error) fall
+# back to the dependency-free bash mirror, which is authoritative. A real violation fails both.
+if [ "$npx_rc" -ne 0 ]; then
+  commitlint_bash || CL_OK=0
+fi
+if [ "$CL_OK" -eq 1 ]; then record "commitlint" PASS; else record "commitlint" FAIL; fi
+
+# ---- 5. e2e tsc ----------------------------------------------------------------
+step "5/5 e2e-test tsc --noEmit"
+if [ -d e2e-test/node_modules ]; then
+  if ( cd e2e-test && npx tsc --noEmit ); then record "e2e-tsc" PASS; else record "e2e-tsc" FAIL; fi
+else
+  echo "SKIP: e2e-test/node_modules absent (run: cd e2e-test && npm ci)"
+  record "e2e-tsc" SKIP
+fi
+
+# ---- summary -------------------------------------------------------------------
+printf '\n\033[1m==== preflight summary ====\033[0m\n'
+fail=0
+for i in "${!NAMES[@]}"; do
+  r="${RESULTS[$i]}"
+  case "$r" in
+    PASS) c='\033[32m' ;; FAIL) c='\033[31m'; fail=1 ;; *) c='\033[33m' ;;
+  esac
+  printf '  %b%-6s\033[0m %s\n' "$c" "$r" "${NAMES[$i]}"
+done
+echo ""
+[ "$fail" -eq 0 ] && echo "preflight OK" || { echo "preflight FAILED — fix the red rows above"; exit 1; }

--- a/bin/regen-openapi
+++ b/bin/regen-openapi
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+#
+# regen-openapi — regenerate the OpenAPI contracts and report drift.
+# Mirrors the ci.yml code-quality drift gate. On a same-repo PR, CI auto-commits
+# the regen; locally you commit it yourself. A no-op diff on main is expected.
+#
+# Usage:
+#   bin/regen-openapi
+#
+# Writes: docs/openapi-ml0.{json,yaml}, docs/openapi-dl1.{json,yaml}
+#
+set -euo pipefail
+
+if ! command -v sbt >/dev/null 2>&1 && [ -f "$HOME/.sdkman/bin/sdkman-init.sh" ]; then
+  set +e; source "$HOME/.sdkman/bin/sdkman-init.sh" >/dev/null 2>&1; set -e
+fi
+
+case "${1:-}" in -h|--help) sed -n '2,13p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;; esac
+
+ROOT="$(git rev-parse --show-toplevel)"; cd "$ROOT"
+
+echo "==> GenerateOpenApi docs"
+sbt "currencyL0/runMain xyz.kd5ujc.metagraph_l0.openapi.GenerateOpenApi docs"
+
+ml0=$(grep -oE '"/[^"]*": \{' docs/openapi-ml0.json 2>/dev/null | wc -l | tr -d ' ')
+dl1=$(grep -oE '"/[^"]*": \{' docs/openapi-dl1.json 2>/dev/null | wc -l | tr -d ' ')
+echo ""
+echo "endpoints (approx path count):  ML0=$ml0  DL1=$dl1"
+echo "(OpenApiDocSuite pins the exact counts — update it when adding endpoints)"
+echo ""
+
+if git diff --exit-code -- docs/openapi-*; then
+  echo "no drift — contract matches committed docs"
+else
+  echo ""
+  echo "DRIFT: the regenerated contract differs. If you changed routes/DTOs, commit it:"
+  echo "    git add docs/openapi-* && git commit -m 'docs(openapi): regen contract'"
+fi

--- a/bin/tasks
+++ b/bin/tasks
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# tasks — list open issues an agent can pick up, filtered by label.
+#
+# Usage:
+#   bin/tasks [label]        # default label: agent-ready
+#   bin/tasks cheap-model-ok
+#   bin/tasks --labels       # print the label taxonomy and exit
+#
+# Label taxonomy (route by the minimum tier that can safely do the job):
+#   agent-ready     scoped, acceptance-criteria clear, safe for an agent to start
+#   cheap-model-ok  T0-1 work: tests / docs / bin / worksheets — night-shift picks ONLY these
+#   needs-senior    requires a senior-model session (judgment, cross-cutting)
+#   blast-radius    touches a consensus-critical file — propose only; human/senior decides
+#   size/S size/M size/L   rough effort
+#
+set -euo pipefail
+
+case "${1:-}" in
+  -h|--help) sed -n '2,18p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+  --labels)  sed -n '9,18p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+esac
+
+LABEL="${1:-agent-ready}"
+echo "==> open issues labelled '$LABEL'"
+gh issue list --state open --label "$LABEL" \
+  --json number,title,labels \
+  --jq '.[] | "#\(.number)  \(.title)   [\(.labels|map(.name)|join(","))]"' 2>/dev/null \
+  || gh issue list --state open --label "$LABEL"

--- a/bin/test
+++ b/bin/test
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+#
+# test — run a module's sbt tests by friendly name, batch-mode (no thin client).
+#
+# Usage:
+#   bin/test <module|all> [testOnly-glob]
+#
+#   module: l0 | l1 | data_l1 | dl1 | shared | models   (or the raw sbt id)
+#   all:    root aggregate (every module)
+#   glob:   optional "testOnly" pattern, e.g. "*CommittedViewSuite*"
+#
+# Examples:
+#   bin/test shared                          # sharedData/test (the big suite)
+#   bin/test shared "*CommittedViewSuite*"   # one suite
+#   bin/test l0                              # currencyL0/test
+#   bin/test all                             # sbt test
+#
+# Name map: l0->currencyL0  l1->currencyL1  data_l1|dl1->dataL1  shared->sharedData  models->models
+#
+set -euo pipefail
+
+if ! command -v sbt >/dev/null 2>&1 && [ -f "$HOME/.sdkman/bin/sdkman-init.sh" ]; then
+  set +e; source "$HOME/.sdkman/bin/sdkman-init.sh" >/dev/null 2>&1; set -e
+fi
+
+case "${1:-}" in
+  -h|--help|"") sed -n '2,22p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+esac
+
+mod="$1"; shift || true
+glob="${1:-}"
+
+case "$mod" in
+  l0)            proj=currencyL0 ;;
+  l1)            proj=currencyL1 ;;
+  data_l1|dl1)   proj=dataL1 ;;
+  shared)        proj=sharedData ;;
+  models)        proj=models ;;
+  all)           proj=all ;;
+  *)             proj="$mod" ;;   # raw sbt id passthrough
+esac
+
+if [ "$proj" = "all" ]; then
+  cmd="test"
+elif [ -n "$glob" ]; then
+  cmd="$proj/testOnly $glob"
+else
+  cmd="$proj/test"
+fi
+
+ROOT="$(git rev-parse --show-toplevel)"; cd "$ROOT"
+echo "==> sbt \"$cmd\"  (batch mode)"
+
+log="$(mktemp)"
+set +e
+sbt "$cmd" 2>&1 | tee "$log"
+rc=${PIPESTATUS[0]}
+set -e
+
+if grep -qiE 'server was not detected|failed to connect|Could not connect to sbt server' "$log"; then
+  cat >&2 <<'EOF'
+
+--- stale sbt server detected -------------------------------------------------
+Two sessions/worktrees share one sbt thin client. Recover:
+  pkill -f 'sbt.*server' || true
+  rm -f project/target/active.json
+  # then re-run this command (batch mode, no --client)
+-------------------------------------------------------------------------------
+EOF
+fi
+rm -f "$log"
+exit "$rc"

--- a/bin/wire-size
+++ b/bin/wire-size
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+#
+# wire-size — run the OnChain wire-size regression suite and print the byte probes.
+# Deterministic serialization = tight byte bands that double as a codec-bloat
+# tripwire. This is the RIGHT kind of "perf test" for a consensus codebase
+# (bytes/gas/counts, not wall-clock). The 512KB snapshot cap is the hard ceiling.
+#
+# Usage:
+#   bin/wire-size
+#
+# NOTE: OnChainWireSizeSuite ships with the OnChain-v2 work (PR #210). If it is
+# not on your branch yet, sbt reports "No tests were executed" — that is expected.
+#
+set -euo pipefail
+
+if ! command -v sbt >/dev/null 2>&1 && [ -f "$HOME/.sdkman/bin/sdkman-init.sh" ]; then
+  set +e; source "$HOME/.sdkman/bin/sdkman-init.sh" >/dev/null 2>&1; set -e
+fi
+
+case "${1:-}" in -h|--help) sed -n '2,15p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;; esac
+
+ROOT="$(git rev-parse --show-toplevel)"; cd "$ROOT"
+
+log="$(mktemp)"
+set +e
+sbt "sharedData/testOnly *OnChainWireSizeSuite*" 2>&1 | tee "$log"
+rc=${PIPESTATUS[0]}
+set -e
+
+echo ""
+echo "==> byte probes"
+grep -iE 'bytes|size|KB|budget|margin' "$log" || echo "(no probe lines — suite may be absent on this branch)"
+rm -f "$log"
+exit "$rc"

--- a/bin/worksheet
+++ b/bin/worksheet
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+#
+# worksheet — start a new committed session worksheet from the template.
+# Worksheets are resumable session traces. Open one FIRST, update it at every
+# stopping point. See docs/worksheets/README.md.
+#
+# Usage:
+#   bin/worksheet <slug>
+#
+# Creates docs/worksheets/YYYY-MM-DD-<slug>.md and prints the commit-trailer and
+# tag conventions.
+#
+set -euo pipefail
+
+case "${1:-}" in -h|--help|"") sed -n '2,12p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;; esac
+
+SLUG="$1"
+ROOT="$(git rev-parse --show-toplevel)"; cd "$ROOT"
+DATE="$(date +%Y-%m-%d)"
+FILE="docs/worksheets/${DATE}-${SLUG}.md"
+TEMPLATE="docs/worksheets/TEMPLATE.md"
+
+if [ -e "$FILE" ]; then echo "already exists: $FILE" >&2; exit 1; fi
+[ -f "$TEMPLATE" ] || { echo "missing template: $TEMPLATE" >&2; exit 1; }
+
+cp "$TEMPLATE" "$FILE"
+# stamp the title line
+sed -i "1s|.*|# ${DATE} — ${SLUG}|" "$FILE"
+
+echo "created $FILE"
+echo ""
+echo "Commit trailer (add to every commit for this work):"
+echo "    Worksheet: $FILE"
+echo ""
+echo "Milestone tag (namespaced so release.yml's v* trigger never fires):"
+echo "    git tag ws/${SLUG}"

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -1,0 +1,122 @@
+# docs/ index
+
+The map of OttoChain's documentation. Agents: navigate the codebase's knowledge through this index —
+find the doc, read the doc, then the code. One line per file: `path — summary`. Keep it current when
+you add or move a doc.
+
+Start here: `../CLAUDE.md` (invariants) · `signing-canonical-and-validation.md` (rationale) ·
+`../AGENTS.md` (workflow router) · `agents/` (the agent-infra system).
+
+## Agent infrastructure — `docs/agents/`
+- `agents/README.md` — how the agent-infra system works (personas, worksheets, feedback, bin/, tiers).
+- `agents/blast-radius.md` — consensus-critical file:why list + tier map + escalation protocol.
+- `agents/conventions.md` — the residue linters can't hold (codec/validation/style/commit rules).
+- `agents/tools.md` — how to write bin/ scripts + the bin/ + just + ~/bin toolbelt + sbt gotchas.
+- `agents/process-observations.md` — candid, evidence-based workflow critique.
+- `agents/feedback.md` — append-only log of what slowed agents down + proposed fixes.
+- `agents/review-personas/consensus-safety.md` — signed messages, validators, combiners, determinism.
+- `agents/review-personas/wire-compat.md` — OpenAPI contract, SDK/JAR/metakit version lockstep, e2e coupling.
+- `agents/review-personas/state-growth-determinism.md` — unbounded state, 512KB cap, gas, SortedMap.
+- `agents/review-personas/asset-economics.md` — supply conservation, consent, custody, nonce linearity.
+- `agents/review-personas/ai-smells-test-integrity.md` — dead abstractions, tautological/self-regenerating tests.
+
+## Worksheets — `docs/worksheets/`
+- `worksheets/README.md` — purpose, naming, trailer/tag conventions, worksheet-first rule.
+- `worksheets/TEMPLATE.md` — the worksheet template (copy via `bin/worksheet <slug>`).
+- `worksheets/2026-07-11-onchain-v2.md` — retro trace of the OnChain-v2 session (#210/#211).
+- `worksheets/2026-07-11-agent-infra-scaffold.md` — this scaffold's session trace.
+
+## Signed-message / consensus rationale (top level)
+- `signing-canonical-and-validation.md` — the 3 CLAUDE.md invariants expanded + InvalidSignature / TOCTOU mechanics.
+
+## Top-level
+- `README.md` — documentation hub / start-here.
+- `introduction.md` — what OttoChain is: a metagraph turning JSON into executable multi-party workflows.
+- `API-REFERENCE.md` — all HTTP endpoints across the layer stack (ports, ML0/DL1 routes).
+- `TOPOS-FIBER-CATEGORICAL-ASSESSMENT.md` — read-only categorical investigation of fibers-as-topos.
+- `openapi-ml0.{json,yaml}`, `openapi-dl1.{json,yaml}` — generated OpenAPI 3.1 contracts (CI drift-gate output).
+
+## Architecture — `docs/architecture/`
+- `architecture/ml0-snapshot-webhooks.md` — ML0→subscriber push on snapshot-consensus completion.
+
+## Audit — `docs/audit/`
+- `audit/fiber-engine-permissionless-safety-audit-2026-07-07.md` — baseline permissionless-safety audit (C1–C3/H1–H2/M1–M3/L1–L6).
+- `audit/metakit-sigma-fiat-shamir-audit-2026-06-17.md` — Fiat-Shamir/CDS soundness audit of the sigma opcodes.
+
+## Design — `docs/design/`
+- `design/authenticated-trie-integration-spec.md` — authenticated trie for committed OttoChain state.
+- `design/engine-hardening-spawn-and-effects.md` — selfReproducing dial + spawn/emit/cascade effect audit.
+- `design/fiber-policy.md` — FiberPolicy: a fiber's hash-pinned, externally verifiable constitution.
+- `design/metagraph-integration-analysis.md` — Constellation metagraph integration feasibility.
+- `design/multi-party-signing-spec.md` — TDD spec for multi-party fiber signing.
+- `design/ottochain-new-app-skill-spec.md` — spec for an `ottochain-new-app` agent skill.
+- `design/sigma-message-binding-spec.md` — canonical, domain-separated, nonce-bound sigma_verify message (replay cure).
+
+## Domains — `docs/domains/`
+- `domains/corporate/CORPORATE-GOVERNANCE.md` + 10 `corporate-*.json` — business-entity state machines.
+- `domains/governance/GOVERNANCE.md` + 9 JSON defs — DAO→multi-branch constitutional building blocks.
+
+## E2E — `docs/e2e/`
+- `e2e/riverdale-economy-e2e-design.md` — promoting the in-process RiverdaleEconomy test to a 6-party e2e.
+
+## Examples — `docs/examples/`
+- `examples/README.md` + `clinical-trial.md`, `fuel-logistics.md`, `real-estate.md`, `riverdale-economy.md`, `tictactoe.md` — worked state-machine walkthroughs.
+
+## Fiber engine — `docs/fiber-engine/`
+- `fiber-engine/README.md` — JLVM fiber-engine internal architecture for engine maintainers.
+- `fiber-engine/diagrams/` — component/sequence/state diagrams (`.mmd`/`.dot` sources + rendered PNGs).
+
+## Guides — `docs/guides/`
+- `guides/adding-new-app.md` — build a new app domain (TS + JSON Logic).
+- `guides/deployment.md` — deployment to Digital Ocean + integrationnet.
+- `guides/json-logic-primer.md` — JSON Logic intro for guards/effects.
+- `guides/state-machine-design.md` — writing JSON state-machine defs/events.
+- `guides/terminal-usage.md` — the e2e interactive terminal CLI.
+
+## Proposals / RFCs — `docs/proposals/`
+- `proposals/onchain-incrementals.md` *(arrives with PR #210 — not yet on `main`)* — THE RFC behind OnChain-v2 (deltas, DL1 fold/heal, 512KB-cap avoidance).
+- `proposals/asset-model.md` — Asset Model RFC v2 (TokenBehavior lattice, morphisms, R1 custody).
+- `proposals/asset-model-review-and-interop.md` — 26-agent review of the asset-model RFC (P0/P1/P2).
+- `proposals/asset-model-zk-extension.md` — zk asset-model extension feasibility/roadmap.
+- `proposals/asset-shielded-mode.md` — gated shielded AssetPolicy mode (confidential amounts).
+- `proposals/asset-interop-functor.md` — `F: Ext→Otto` functor + per-standard adapters.
+- `proposals/committed-state-migration.md` — verifiable calculated-state root rooted into the snapshot.
+- `proposals/economics-and-state-rent.md` — fee/rent design; the C1 gating hurdle.
+- `proposals/versionable-contracts.md` — deployed JSON-Logic programs as versioned npm-like packages.
+- `proposals/genesis-and-engine-versioning.md` — pinned `std.*` package set in genesis + engine versioning.
+- `proposals/schema-architecture.md` — typed, versioned, agent-discoverable contract schemas.
+- `proposals/strong-typing-and-conformance.md` — proto↔JLVM↔registry type alignment.
+- `proposals/sharded-ml0-and-commitments.md` — sharded ML0 + succinct state commitments.
+- `proposals/state-commitment-mpt.md` — state commitment + cross-metagraph comms protocol.
+- `proposals/naming-and-fingerprints.md` — human/agent-readable fiber naming + stable fingerprints.
+- `proposals/trust-and-verification-handoff.md` — what the chain verifies vs hands off to curators.
+- `proposals/typed-network-interface.md` — named DTOs → one OpenAPI contract → generated TS SDK.
+- `proposals/jlvm-engine-foundations.md` — engine refactors (gas seam, state unification, error channel).
+- `proposals/ai-agent-protocol-layer.md` — JLVM as a protocol layer for autonomous AI agents.
+- `proposals/amm-proposal.md` — constant-product AMM DEX example.
+- `proposals/evm-comparison-analysis.md` — rebuttal/analysis of EVM-comparison criticisms.
+- `proposals/indexer-explorer-architecture.md` — off-chain indexer/explorer design.
+- `proposals/p2p-prediction-markets.md` — decentralized peer-to-peer prediction markets.
+- `proposals/zk-coin-audit.md` — audit of 8 live ZK/privacy systems vs the asset model.
+- `proposals/fiber-ergonomics/` — README + `00`–`03`: authoring-ergonomics program (F1–F10, mostly landed #193–195).
+
+## Reference — `docs/reference/`
+- `reference/README.md` — DO-deployment doc index.
+- `reference/api-reference.md` — node API endpoints + Swagger pointer.
+- `reference/architecture.md` — metagraph architecture (fibers = state machines + scripts).
+- `reference/deployment-guide.md` — deploy/manage on 3 DO nodes.
+- `reference/jlvm-semantics.md` — full Metakit JLVM semantics (JSON→AST→eval).
+- `reference/script-reference.md` — reference for deployment scripts + config.
+- `reference/troubleshooting.md` — common issues/solutions + diagnostics.
+
+## Trust graph — `docs/trust-graph/`
+- `trust-graph/ARCHITECTURE.md` / `README.md` + JSON building blocks — reputation-gated coordination substrate.
+
+## Whitepaper — `docs/whitepaper/`
+- `whitepaper/ottochain-whitepaper-v0.4.md` / `.tex` / `.pdf` — current whitepaper (OttoWeb thesis).
+- `whitepaper/ottochain-whitepaper-v0.4-outline-notes.md` — outline + anti-AI-writing checklist.
+- `whitepaper/agent-identity-protocol.md` — decentralized identity/reputation for autonomous agents.
+- `whitepaper/interview-questions.md` — founder-interview prompts.
+
+## Archive — `docs/archive/`
+- `archive/ottobot-planning/` — archived agent-bridge microservice plan (ARCHIVED.md explains why).

--- a/docs/agents/README.md
+++ b/docs/agents/README.md
@@ -1,0 +1,50 @@
+# docs/agents — the agent-infra system
+
+This directory externalizes the context a less-capable model needs to be productive and safe in
+ottochain. Everything here is written to be consumed by cheap models: precise, imperative,
+example-rich, short. `../../AGENTS.md` is the entry router; this file explains how the pieces fit.
+
+## The pieces
+
+**Review personas** (`review-personas/*.md`). Five self-contained files. A cheap model can be handed
+ONE persona file + a diff and produce a useful review — no other context required. Each persona
+**owns** a set of docs: keeping those docs current is part of the persona's job. If a review reveals
+that an owned doc has drifted from the code, updating the doc is not optional side-work — it is the
+work. Run one over your branch with `bin/agent-review <persona>`.
+
+- `consensus-safety` — owns `../signing-canonical-and-validation.md`, `../../CLAUDE.md` invariants,
+  the fiber-engine audit. Signed messages, validators, combiners, determinism.
+- `wire-compat` — owns the OpenAPI contracts + `../proposals/typed-network-interface.md`. Version
+  lockstep (JAR↔SDK↔metakit-rc), endpoint-count suites, e2e-harness coupling.
+- `state-growth-determinism` — owns `../proposals/onchain-incrementals.md` (arrives with PR #210), the
+  wire-size suite, `../proposals/economics-and-state-rent.md`. Unbounded state, 512KB cap, gas metering.
+- `asset-economics` — owns `../proposals/asset-model.md`, `../proposals/asset-model-review-and-interop.md`.
+  Supply conservation, consent, custody, nonce linearity.
+- `ai-smells-test-integrity` — owns `conventions.md` + the `test-audit` skill. Dead abstractions,
+  tautological tests, self-regenerating fixtures, unverified claims.
+
+**Worksheets** (`../worksheets/`). Committed, resumable session traces. Open one FIRST
+(`bin/worksheet <slug>`); update it at every stopping point. Because they are committed (not
+gitignored `.workspace/` scratch that died with the machine), another agent — or you next week —
+can resume exactly where the last session stopped. Commit trailer: `Worksheet: docs/worksheets/<file>`.
+
+**Feedback** (`feedback.md`). Append-only. Every session ends with an entry: what slowed you down +
+the proposed workflow fix. This compounds — recurring entries become new bin/ scripts, new lint
+rules, or new process observations.
+
+**The toolbelt** (`../../bin/` + `tools.md`). bin/ should keep growing. The standing instruction: any
+non-obvious incantation you type twice, script it. bin/ wraps `just` recipes where they exist.
+
+**blast-radius + tiers** (`blast-radius.md`). The discipline that keeps cheap models safe: route by
+the minimum tier that can safely do the job. T0–1 (tests/docs/bin/worksheets) freely; T2
+(routes/handlers/e2e) review-first; T3+ (the blast-radius list) propose-only — a senior model or human
+decides, and the decision is recorded in the worksheet.
+
+## The loop
+1. Pick work sized to your tier (`bin/tasks`). 2. Open a worksheet. 3. Branch off fresh `origin/main`.
+4. Small commits (measure the subject). 5. `bin/preflight` to green. 6. PR. 7. `bin/pr-watch` to green
+— agents never merge. 8. Append a `feedback.md` entry. 9. Run a persona pass on anything non-trivial.
+
+## Conventions this system reuses (don't reinvent)
+Commit style, tier vocabulary, and the memory taxonomy (`metadata.type: feedback|reference|project|user`)
+are the user's existing conventions. Worksheet/feedback frontmatter should reuse them, not fork a parallel scheme.

--- a/docs/agents/blast-radius.md
+++ b/docs/agents/blast-radius.md
@@ -1,0 +1,94 @@
+# Blast-radius map — the consensus-critical surface
+
+A subtle mistake in any file below = chain halt / fork / `InvalidSignature` / block-poisoning. All
+paths under `modules/`. Cheap models: **propose, don't decide** here.
+
+## Tiers (route by the minimum tier that can safely do the job)
+- **T0–T1 — do freely.** New tests, docs, `bin/`, worksheets, OpenAPI regen, comments.
+- **T2 — review-first.** Routes, `handlers/`, the e2e harness (`e2e-test/runner.ts` sync gates are
+  coupled to wire shapes), non-consensus wiring. Small commits + a persona pass.
+- **T3+ — propose-only for cheap models.** Every file listed below. A senior-model session or a human
+  decides. Record the decision in the worksheet.
+
+## Escalation protocol
+1. A change touching any T3 file requires a **senior-model session or explicit human sign-off**,
+   recorded in the worksheet's "decisions needing human/senior model" section.
+2. The PR description MUST name **which blast-radius files changed and why each is safe** (which
+   invariant it respects, which guard suite covers it).
+3. When in doubt, split the diff: land the T0–2 parts, isolate the T3 change behind its own PR + review.
+
+---
+
+## Signed-message schemas & canonicals
+- `models/…/schema/Updates.scala` — the `OttochainMessage` variants. EVERY field must be `Option`
+  (omit-safe) or required-no-default, else latent `InvalidSignature` (Inv. 1). Encoder/decoder dispatch
+  must list every variant; the `Sequenced` mixin defines seq ordering.
+- `models/…/schema/CodecConfiguration.scala` — the `customizable{En,De}coder` config (`dropNulls`,
+  field-name policy). A change re-hashes everything signed.
+- `models/…/schema/registry/{SchemaShape,RegisteredVersion,RegistryTarget}.scala` — hand-rolled
+  `RegistryShape` codec (field-name discrimination, `.or` chain). A field-name collision breaks decode/hash.
+- **Guards:** `PublishVersionSigningCanonicalSuite`, `AssetOpSigningCanonicalSuite`,
+  `E2eSignedPayloadCompatSuite`, `SdkCompatibilitySuite` — add a case per new signed message.
+
+## Committed-state / roots (light-client-provable, rooted into the signed snapshot)
+- `models/…/schema/CalculatedState.scala` — the `CommittedView` projection into MPT `CommitKey`s
+  (`fiber/`, `script/`, `registry/`, `reverse/`, `asset/`, `nonce/`, `commit/*`). Key derivation is
+  **TOTAL** — a non-total key throws inside combine = halt. A new field invisible to `entries` is absent
+  from the proof.
+- `models/…/schema/OnChain.scala` — the whole snapshot binary is hard-capped at **512,000 B**; cumulative
+  maps here hit the cap and cause `UnableToReduceProposalByCutting` = permanent halt. `OnChainWireSizeSuite`
+  guards the byte budget.
+- `models/…/schema/CommitIndex.scala` *(arrives with PR #210)* — `fold` is valid ONLY at
+  `index.ordinal+1`; folding across a gap loses `touched*` writes and the gate **fails open**.
+- `shared-data/…/syntax/DataStateOps.scala` — the `.focus(...).modify(...)` folds that write OnChain
+  delta + CalculatedState cumulative + record from ONE computed hash. If the three diverge, delta ≠
+  cumulative and DL1 heal returns wrong state.
+- `shared-data/…/lifecycle/CommitIndexService.scala` + heal clients *(arrive with PR #210)* — DL1
+  contiguous fold + heal-from-ML0; must verify subtree completeness, never fold across a gap.
+
+## Validators (block-acceptance gate — TOCTOU / block-poisoning surface)
+- `shared-data/…/lifecycle/Validator.scala` — `validateSignedUpdate` does L1-structural-only for
+  registry/asset ops (Inv. 3). One `Invalid` drops the whole all-or-nothing block. Read the long
+  comment blocks before editing.
+- `shared-data/…/lifecycle/validate/{Fiber,Script,Registry,Asset}Validator.scala` +
+  `validate/rules/*` — the audit's C3/M1/H1 live here. Any lineage read on a `SchemaRef`/`SchemaBinding`
+  parameter = poisoning hazard. `RegistryValidator.CombinedValidator` MUST NOT be called from `validateSignedUpdate`.
+- `shared-data/…/fiber/spawning/SpawnValidator.scala` — the child-owners ⊆ parent fail-closed floor (H1);
+  relaxing it re-opens owner-forgery.
+
+## Combiners (authoritative deterministic stateful gate; runs the VM on every validator)
+- `shared-data/…/lifecycle/Combiner.scala` — dispatch + the load-bearing `recoverWith { case
+  CombineRejected }`. ONLY `CombineRejected` may escape the fold; any other throwable aborts the whole
+  snapshot combine (halt).
+- `shared-data/…/lifecycle/combine/AssetCombiner.scala` — Σ-amount conservation, holder-ownership (R1),
+  compose-consent, nonce linearity, faithful Decompose witness. C2 lived here (cross-holder theft /
+  unbounded mint if consent/dedup regress).
+- `shared-data/…/lifecycle/combine/FiberCombiner.scala` — exact-sequence check + atomic bump, migration
+  re-bind, asset-transfer application in sorted emitter order. Replay/atomicity anchor.
+- `shared-data/…/lifecycle/combine/{Registry,Script}Combiner.scala` — `RegistryCombiner` holds the C1 fee
+  TODO; `resolveScriptBinding` re-verifies gracefully what C3 removed from L0.
+- `shared-data/…/lifecycle/combine/CombineRejected.scala` — the sole graceful-rejection channel; its
+  message text is committed → use a stable reasonCode (Inv. 2 / L1).
+
+## Fiber engine (execution / determinism)
+- `shared-data/…/fiber/FiberEngine.scala`, `evaluation/{FiberEvaluator,EffectExtractor,StateMerger}.scala`,
+  `core/{MeteredEvaluator,ExecutionState,ExecutionOps}.scala`, `triggers/*`, `spawning/SpawnProcessor.scala`
+  — cascade/spawn bound (`maxDepth=10`), shared `maxGas` threading, `$caller` stamping, fail-silent
+  extraction (L5). Any non-determinism reaching committed bytes forks the chain.
+- `shared-data/…/fiber/UpgradeGate.scala`, `models/…/schema/fiber/{FiberPolicy,ExecutionLimits,FailureReason}.scala`
+  — the `tightens` lattice, the consensus-critical constants, the `reasonCode` (L1 mixed-version fix).
+
+## Genesis
+- `shared-data/…/genesis/{GenesisBuilder,GenesisLoader,GenesisManifestLoader}.scala`,
+  `models/…/schema/{GenesisData,GenesisManifest}.scala`, fixture
+  `modules/shared-data/src/test/resources/genesis/std-manifest.json` — genesis seeds BOTH OnChain and
+  CalculatedState commit maps; a mismatch means DL1 heal returns empty for seeded fibers. Migration =
+  genesis redeploy at 0.8.0. Guards: `GenesisBuilderSuite`, `GenesisManifestLoaderSuite`, `StdManifestContractSuite`.
+
+## ML0 service + e2e coupling (T2/T3 boundary)
+- `l0/…/ML0Service.scala` — orderedCombiner clear semantics, rejection sink.
+- `e2e-test/runner.ts` sync gates — coupled to wire shapes. Any wire-format change must grep `e2e-test/`
+  for consumers (runner.ts sync helpers, terminal.ts queries) in the SAME PR.
+
+## Allowed freely (T0–T1)
+New tests, docs, `bin/`, worksheets, OpenAPI regen, comments.

--- a/docs/agents/conventions.md
+++ b/docs/agents/conventions.md
@@ -1,0 +1,82 @@
+# Conventions — the residue linters can't hold
+
+`scalafmt` and `scalafix` enforce formatting and mechanical lints on every compile (and again in CI
+via `scalafmtCheckAll` + `scalafixAll --check`). This doc is only the discipline they CANNOT
+mechanically enforce. **If a rule here becomes machine-checkable, move it to scalafix/scalafmt and
+delete it from this doc.** A convention that lives only in prose is a convention that will drift.
+
+## Codecs & signed messages (consensus-load-bearing)
+- **Derive codecs, never hand-roll.** `@derive(customizableEncoder, customizableDecoder)` on all
+  schema types. Hand-rolled `Json.obj("field" -> …)` / `downField` is banned — field names are the
+  signed JSON keys; a drift re-hashes a root → `InvalidSignature`. Hand-rolled codecs exist ONLY where
+  derivation is ambiguous (`RegistryShape`/`RegistryTarget`, `ScriptShape` ADT, Nibble seqs) and are
+  then pinned by a golden field-name + round-trip KAT.
+- **Signed fields are `Option[T]` or REQUIRED — never a non-`Option` with a default.** A `Boolean=false`
+  / `SortedMap=empty` default on a signed message is a latent `InvalidSignature`. Server-derived state
+  may default. Every new signed message gets a `*SigningCanonicalSuite` case. (Full rationale:
+  `../signing-canonical-and-validation.md`.)
+- **Strict decoders — do not auto-correct shapes.** Standardize on the canonical form, make fixtures
+  canonical. A lenient decoder that accepts `{"value":"x"}` for a bare string is a signing hazard.
+
+## Validation layering
+- **Two-tier:** `validateUpdate`/`validateSignedUpdate` do STRUCTURAL checks only; stateful rejection
+  goes in the combiner as graceful `CombineRejected` → `RejectionReceipt`. Block acceptance is
+  all-or-nothing.
+- `validateSignedUpdate` must NEVER read `CalculatedState.registry` lineage (TOCTOU block-poison).
+  Reading the relocated commit-index triple is allowed; *lineage* reads are barred.
+- **Only `CombineRejected(reason)` may escape the combine fold.** Every other throwable aborts the whole
+  snapshot combine (a halt). Rejections carry a human `reason` for the receipt — but committed receipts
+  use a **stable `reasonCode` / `ValueKind`**, never version-dependent exception text.
+
+## Style idioms
+- **Prefer chaining over deeply nested `match`.** Flatten nested `match` into chained combinators
+  (cite PR #211 / `refactor/nested-match-cleanup`, commit 81941e7 — a 5-file, −67-line pure refactor).
+- **Monocle `.focus(_.…).modify(...)`** is the idiom for DataState writes (`DataStateOps.scala`);
+  `import monocle.Monocle.toAppliedFocusOps`. Write all of (OnChain delta, CalculatedState cumulative,
+  record) in one focus chain from one computed hash.
+- **Combiner signer idiom:** `update.proofs.toList.traverse(_.id.toAddress)`. JSON-Logic guards run at
+  the metakit boundary via `JsonLogicEvaluator.tailRecursive[F].evaluateWithGas(...)` — pure predicate,
+  no FiberT/StateT stack.
+- **Heavy WHY-scaladoc on consensus code.** Load-bearing invariants get a comment explaining *why*
+  (see `Validator.scala` TOCTOU block, `OnChain.scala` 512KB-cap rationale). Invariants are "guarded by
+  this comment" — the comment tells the next reviewer which new methods to re-check.
+
+## Determinism (committed bytes only)
+- Committed collections are `SortedMap` / `SortedSet`. Apply order is an explicit `sortBy` (asset
+  transfers apply in `sortBy(_._1)` emitter order). No wall-clock, `Random`, floats, `hashCode`, or
+  unordered-to-seq in committed bytes. Canonical hashing is RFC-8785/JCS (sorted keys).
+
+## Tests
+- **weaver** (`weaver.framework.CatsEffect`). Suites named `*Suite`. GOTCHA: a suite-level
+  `private val name` shadows weaver's `name: String` → a baffling type error. Give test values
+  non-colliding names. Law suites need a `Cogen[T]` (weaver-discipline + cats-laws).
+- **Shared generators** live in `modules/shared-test` (`Generators.scala`, `TestFixture.scala`,
+  `Mock.scala`, `KeyHelpers.scala`, `FiberExtractors.scala`, `FiberBuilder.scala`) — reuse them, do not
+  re-roll a generator per suite. Keep pure-lattice law suites separate from combiner-level law suites.
+- **Golden / KAT patterns:** signing-canonical suites build with all Options=None, apply `dropNulls`,
+  assert `dropNulls(decode(payload).asJson) == payload`. Wire-size bands double as codec-bloat tripwires.
+  A golden test must NOT regenerate its own fixture in the same run (that asserts a tautology).
+
+## Naming
+- **"script", never "oracle"** in new code/routes/namespaces/docs. The two fiber kinds are state
+  machines and scripts. "oracle" survives only as a real-world domain noun. Consensus-visible names are
+  near-immutable.
+- **Reserved directive keys are `_`-prefixed** (`_scriptCall`, `_transferAsset`, `_spawn`, `_triggers`)
+  in `ReservedKeys.scala`.
+
+## Commits (commitlint-enforced in CI — `.commitlintrc.json`)
+- Conventional: `type(scope): subject`. Types: `feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert`.
+- **Lowercase subject start**, no trailing period, **header ≤ 72 chars**. `disallowScopes: release`
+  (`feat(openapi)` is fine). PR titles obey the same rules.
+- **MEASURE the subject before every commit** (eyeballing 73-vs-72 fails, repeatedly, in CI):
+  ```
+  s="feat(fiber): your subject here"; printf '%d %s\n' "${#s}" "$s"
+  ```
+  `bin/preflight` runs the same check over `origin/main..HEAD`. `.githooks/pre-push` is an opt-in mirror
+  (`git config core.hooksPath .githooks`) — hooks are kept opt-in by preference; **preflight is the contract.**
+- Trailers on every commit:
+  ```
+  Co-Authored-By: <model> <noreply@anthropic.com>
+  Claude-Session: <url>
+  Worksheet: docs/worksheets/<file>
+  ```

--- a/docs/agents/feedback.md
+++ b/docs/agents/feedback.md
@@ -1,0 +1,43 @@
+# Agent feedback log
+
+Append-only. Every session ends with an entry. This compounds: recurring entries become new `bin/`
+scripts, new lint rules, or new items in `process-observations.md`. Newest at the bottom.
+
+**Entry format**
+```
+### YYYY-MM-DD — <short title>
+- Worksheet: docs/worksheets/<file>   (or session ref)
+- What slowed me down: <the friction, with evidence — a PR#, a command, a log line>
+- Proposed fix: <concrete: a bin/ script, a lint rule, a doc, a process change>
+- Status: proposed | done | wont-fix
+```
+
+---
+
+### 2026-07-11 — a PR shipped red and nobody was watching
+- Worksheet: docs/worksheets/2026-07-11-onchain-v2.md
+- What slowed me down: PR #210 merged the OnChain-v2 work with all five e2e lanes red for ~30 min. The
+  agent moved on after opening the PR; James caught the failure, not the agent. "PR opened" was treated
+  as "done."
+- Proposed fix: `bin/pr-watch <pr#>` — poll checks to a terminal state, dump failing logs, exit code
+  mirrors outcome. Make "watched to green" part of the definition of done; encode it as a night-shift
+  stop condition.
+- Status: done (bin/pr-watch added; see process-observations #2)
+
+### 2026-07-11 — commitlint subject-case failure found in CI, not locally
+- Worksheet: docs/worksheets/2026-07-11-onchain-v2.md
+- What slowed me down: commitlint rejects uppercase-start subjects and headers > 72 chars. The pre-push
+  mirror is opt-in, so violations surfaced only in CI (as they did for #162 at 87 chars and #207 at 73).
+  Eyeballing 73-vs-72 does not work.
+- Proposed fix: `bin/preflight` runs the commitlint range check over `origin/main..HEAD` unconditionally,
+  reading `header-max-length` live from `.commitlintrc.json`. Conventions doc mandates measuring every
+  subject with `s="…"; printf '%d %s\n' "${#s}" "$s"`.
+- Status: done (bin/preflight step 4; conventions.md)
+
+### 2026-07-11 — sbt thin-client died under concurrent worktree use
+- Worksheet: docs/worksheets/2026-07-11-agent-infra-scaffold.md
+- What slowed me down: a parallel session in a second worktree shared the sbt thin client → "server was
+  not detected / failed to connect", killing a test run mid-flight.
+- Proposed fix: `bin/test` runs batch mode (no `--client`) and, on detecting the connect-failure string,
+  prints the recovery steps (`pkill -f 'sbt.*server'; rm -f project/target/active.json`).
+- Status: done (bin/test)

--- a/docs/agents/process-observations.md
+++ b/docs/agents/process-observations.md
@@ -1,0 +1,70 @@
+# Process observations
+
+Candid, evidence-based. James asked to be pushed on this. Each item is a recurring inefficiency with
+its evidence and a concrete fix. No hedging — these are calls, not musings.
+
+## 1. Opt-in local gates guarantee repeat CI failures
+The commit-subject length rule (`header-max-length:72`) has failed CI more than once — #162 (87 chars),
+#207 (73, one over) — each an amend + force-push + a red run. The prettier gate in the SDK (#238) shipped
+*after* style had drifted to 288 single-quote / 169 double-quote, forcing a big-bang reformat of ~70% of
+the diff. The fix that would end the recurrence — `.githooks/pre-push` — is deliberately kept opt-in
+because James dislikes hook bloat.
+**Call:** `bin/preflight` is now the contract, and it runs the commit-subject check unconditionally.
+Agents should treat `.githooks` as default-on for themselves — the AGENTS.md workflow mandates preflight
+before every push — even though it stays opt-in for humans. A gate that isn't run isn't a gate.
+
+## 2. "PR opened" is not "done"
+PR #210 shipped with all five e2e lanes red for ~30 minutes before James noticed — not the agent.
+**Call:** a PR is done when checks are green AND watched. `bin/pr-watch <pr#>` closes this; it must exit 0
+before a session ends. Encoded in the `night-shift` skill's stop condition.
+
+## 3. Gitignored session logs died with the machine
+`.workspace/` was gitignored scratch. Context — plans, running state, why-decisions — evaporated when the
+machine was lost, and later sessions re-derived it (see #4, #6).
+**Call:** worksheets are now committed under `docs/worksheets/`, resumable by another agent. `.workspace/`
+stays for private scratch only. Worksheet FIRST, updated at every stopping point.
+
+## 4. 70% coverage that never fails is a dashboard, not a gate
+`coverageFailOnMinimum := false` — the number is advisory. Tests can rot under it silently, and coverage %
+is a weak signal anyway (a test can execute a line and assert nothing).
+**Call:** either enforce a ratchet (fail if coverage drops vs main) or invest the signal budget in mutation
+testing. Recommend a **stryker4s spike**: a mutation score is a real "do the tests catch bugs" gate, which
+is what `test-audit` verifies by hand today. Deterministic, CI-friendly.
+
+## 5. Prefer deterministic proxies over wall-clock CI benchmarks
+On shared CI runners wall-clock timings are noisy and flaky. The wire-size suite pins byte marginals in
+tight bands (deterministic serialization) and doubles as a codec-bloat tripwire.
+**Call:** measure bytes, gas units, and counts in CI — all deterministic by consensus requirement. Reserve
+wall-clock benchmarks for nightly. A **gas-regression suite** is the correct "perf test" for this codebase.
+
+## 6. The publishing saga burned four release attempts
+metakit-sdk rc.1→rc.4 partially failed on a different registry each time (npm `--tag`, empty cargo token,
+crates TP-only 403, expired NPM_TOKEN, CDN cache lie). Each burned a version number (you can't re-publish),
+forcing rc churn — and every step blocked on James doing per-package config the pull-only agent can't.
+**Call:** add a `publish-dry-run` gate to CI *before* the tag (`npm pack` / `cargo publish --dry-run` /
+`python -m build`). metakit-sdk already has this pattern — port it. A dry-run that passes on the PR turns a
+release into a formality instead of a saga.
+
+## 7. The dependency-bump omnibus has been done by hand 4+ times
+sdk #207 / #237 / #252 and services #296 all repeated the same ritual: isolated worktree off `origin/main`,
+combine N dependabot PRs onto one branch + one fresh lockfile, bump caret floors so the bot stops
+re-proposing, verify all gates, close superseded PRs with a note. Pure toil, identical each time.
+**Call:** this is a scheduled **night-shift task** candidate — a standing "combine dependabot into one
+branch, verify, open one PR, close the rest with a note" routine. The existing `sdk-bump.yml` auto-merge
+silently fails on breaking SDK changes, so the routine must run preflight, not blind-merge.
+
+## 8. Single-reviewer bottleneck creates self-blocking states
+The SDK format gate (#238) was appended to main's required checks while the PR that *defines* the
+formatting was still unmerged and waiting on the only code-owner (James, `enforce_admins:true` + 1 required
+review). The gate was live before its definition landed.
+**Call:** flag single-reviewer bottlenecks explicitly. Consider **auto-merge-on-green for T0–1 docs/deps
+PRs** (the `prs` script and `close-stale-prs.sh` exist because these pile up). Never add a required status
+check before the PR that satisfies it is merged.
+
+## 9. A commit message claimed work it didn't do
+#162 renamed a chain message and the commit message CLAIMED it updated the e2e harness — it didn't. Every
+lifecycle step broke with HTTP 500, diagnosed only via `gh run download` container logs.
+**Call:** every claim in a commit message must be verifiable by a command listed in the worksheet. "Updated
+the e2e harness" means the worksheet shows the grep that found the consumers and the `tsc --noEmit` that
+passed. If you can't cite the command that proves the claim, don't make the claim. The `test-audit` and
+`commit-sweep` skills exist to catch exactly this class of unverified assertion.

--- a/docs/agents/review-personas/ai-smells-test-integrity.md
+++ b/docs/agents/review-personas/ai-smells-test-integrity.md
@@ -1,0 +1,57 @@
+# Persona: ai-smells-test-integrity
+
+MISSION: Catch AI-authored code smells and, above all, tests that don't actually test. A green suite that
+asserts nothing is worse than no suite — it manufactures false confidence. Verify claims; don't trust them.
+
+## Owned docs (keep current)
+- `../conventions.md` — the discipline residue; if you find a convention violated that a linter COULD
+  enforce, the fix is to move it into scalafix/scalafmt and delete it from the doc.
+- the `test-audit` skill (`../../../.claude/skills/test-audit/SKILL.md`).
+
+## Checklist (yes/no)
+1. **Tautological assertions:** does a test assert something that is true by construction (`x == x`,
+   re-deriving the expected with the same code under test, asserting a mock returns what it was told to)?
+2. **Self-regenerating golden fixtures:** does a golden/KAT test WRITE its fixture and then assert against
+   what it just wrote in the same run? A golden must compare against a committed, independently-produced
+   expected value — never regenerate-then-compare.
+3. **Would the test fail if its subject were wrong?** For a changed suite, mentally (or actually — see the
+   test-audit skill) mutate the subject: flip a `>` to `>=`, return a constant. If the test still passes,
+   it's decorative. Flag it.
+4. **Vacuous property generators:** does a scalacheck/weaver property generate a range so narrow (or a
+   generator that always produces the same value) that the property is trivially satisfied?
+5. **Error-message drift:** does an assertion match on exception text / a log string that the code no longer
+   produces (or that a stable `reasonCode` should replace)? String-matched tests rot silently.
+6. **weaver name-shadowing:** a suite-level `private val name` shadows weaver's `name: String` → a baffling
+   type error, or worse a subtly wrong test. Test values must have non-colliding names.
+7. **Shared-generator reuse:** is a new bespoke generator duplicating one in `modules/shared-test`
+   (`Generators.scala`, `TestFixture.scala`, `Mock.scala`)? Prefer the shared one.
+8. **Dead / over-general abstractions:** a helper/typeclass/trait with exactly one caller, a parameter that
+   is always passed the same value, a generic signature used monomorphically. AI over-generalizes — flag it.
+9. **Comments narrating the obvious:** `// increment i` over `i += 1`. Delete-worthy. (Consensus WHY-scaladoc
+   is the opposite and is REQUIRED — do not confuse the two.)
+10. **Hallucinated-API patterns:** a call to a method/opcode that doesn't exist or is misused (e.g. array ops
+    decoding as literal Maps — the SDK A2 class). Does it compile AND do what the name says?
+11. **The claim-vs-reality check (the big one):** does the commit message / PR / worksheet CLAIM something the
+    diff does not do? "Updated the e2e harness" with no harness change; "added a test" that is `ignore`-d;
+    "fixed X" with no regression test. Verify every claim against the diff and a runnable command.
+
+## Defect classes / real incidents
+- **"Claimed but didn't" (#162):** the commit message said the e2e harness was updated for a message rename;
+  it wasn't. Every lifecycle step 500'd, found only in container logs. THE archetype: a claim no command
+  backs. Rule: every claim in a commit message must be verifiable by a command listed in the worksheet.
+- **Golden regenerating its own fixture:** the fixture and the "expected" come from the same run → the test
+  can never fail. Signing-canonical suites do it right: build payload, `dropNulls`, compare to the payload.
+- **weaver `name` shadow:** documented gotcha; a `private val name` in a suite breaks compilation cryptically.
+- **Coverage theater:** a line is executed (counts toward 70%) but nothing about its output is asserted.
+  Coverage % is not test quality — this is why a stryker4s mutation-testing spike is the proposed backbone.
+
+## How to verify a claim (don't just read — run)
+- "test added" → find the test, confirm it's not `ignore`-d, run it (`bin/test <module> "*Suite*"`).
+- "harness updated" → `grep` the changed identifier in `e2e-test/`, run `cd e2e-test && npx tsc --noEmit`.
+- "no drift" → `bin/regen-openapi` and check the diff is empty.
+- "it fails when broken" → mutate the subject locally, run the test, confirm RED, then revert.
+
+## OUT OF SCOPE (do not flag)
+- Consensus correctness, wire compat, state growth, asset economics — those are the other four personas.
+  Your lane is: does the code smell AI-authored, and do the tests actually test?
+- Required WHY-scaladoc on consensus code (that is a convention, not a smell). Formatting (scalafmt/scalafix).

--- a/docs/agents/review-personas/asset-economics.md
+++ b/docs/agents/review-personas/asset-economics.md
@@ -1,0 +1,54 @@
+# Persona: asset-economics
+
+MISSION: Guarantee value safety in the asset system — no inflation, no cross-holder theft, no consent
+bypass. The asset combiner runs on every validator; a conservation break mints or steals value
+deterministically across the whole network.
+
+## Owned docs (keep current)
+- `../../proposals/asset-model.md` — Asset Model RFC v2 (TokenBehavior lattice, morphisms, R1 custody).
+- `../../proposals/asset-model-review-and-interop.md` — the 26-agent review (P0/P1/P2 findings).
+
+## Where the logic lives
+`shared-data/…/lifecycle/combine/AssetCombiner.scala` (Σ-conservation, R1, consent, nonce, Decompose
+witness); `models/…/schema/asset/*` (`MorphismSpec`, TokenBehavior lattice); asset validators under
+`validate/AssetValidator.scala`. C2 (the worst asset defect class) lived in the combiner.
+
+## Checklist (yes/no, with file references)
+1. **Supply conservation:** does every morphism (Compose / Decompose / Pool / Burn / Transfer) preserve
+   total Σ-amount? Sum in == sum out (± an explicit, authorized Burn/Mint)? Walk the arithmetic.
+2. **Counterparty dedup:** is the id-set of an aggregation op DISTINCT? `Compose(assetId=S, otherAssetIds=[S])`
+   double-counts S once-removed = inflation. Is `S ∉ otherAssetIds` enforced (self-exclusion)?
+3. **Consent is MANDATORY, not opt-in:** is the compose/pool consent gate a no-op when `nonce=None`? A gate
+   that only checks consent *if a nonce is present* is opt-in consent = bypass. Consent must be required.
+4. **Same-holder verification:** where an op assumes inputs share a holder, is that verified, not assumed?
+5. **R1 custody:** can only the current holder move/consume an asset? Is holder-ownership checked in the
+   combiner (not just structurally at the gate)? Single-owner / single-policy rules intact?
+6. **Nonce linearity (commit-reveal):** is each nonce single-use and strictly linear — no replay, no reuse,
+   no skip that leaves a hole an attacker fills? Is the reveal bound to the exact prior commit?
+7. **Decompose faithfulness:** does Decompose emit a witness/commitment that actually corresponds to the
+   composed inputs (not an unverifiable claim)? Is the commitment checked, not trusted?
+8. **Policy resolution:** is `resolveAssetPolicy` reading the intended version deterministically? (The direct
+   `versions.get` is INTENTIONAL — read the scaladoc before "fixing" it.)
+9. **Apply order:** are asset transfers applied in `sortBy(_._1)` emitter order (deterministic), not
+   insertion/hash order?
+10. **Mutation bound:** is `maxAssetMutations=32` per transition respected?
+11. **Σ-gated guards:** if a guard uses sigma verification as an authz layer, is the message chain-computed,
+    domain-separated, and single-use-nonce-bound (else replay)? (`../../design/sigma-message-binding-spec.md`.)
+12. **Sequence/atomicity:** does `FiberCombiner` bump the sequence exactly once, atomically, with the asset
+    application — no partial apply on a later failure?
+
+## Defect classes (C2 family + review findings)
+- **Inflation via missing dedup/self-exclusion:** `Compose` counting an id twice.
+- **Consent bypass via optional gate:** consent enforced only when `nonce` present.
+- **Cross-holder theft:** an op that moves another holder's asset because same-holder wasn't verified.
+- **Unfaithful Decompose witness:** a commitment recorded as fact but not verifiable.
+- **Nonce replay / non-linearity:** reusing or skipping a nonce.
+- **Unverifiable claims recorded as fact** (`commuteObligation`, shallow `ConformanceChecker`) — INFO-level,
+  note it but don't block unless it gates value.
+
+## OUT OF SCOPE (do not flag)
+- Non-asset consensus layering (consensus-safety persona), except the shared TOCTOU/CombineRejected rules,
+  which DO apply here — an asset stateful check belongs in the combiner as `CombineRejected`, never as an
+  `Invalid` at the gate.
+- State-growth / wire-size of asset maps (state-growth persona). SDK asset types (wire-compat persona).
+- New crypto primitives — sigma-gated guards are an AUTHZ layer over existing crypto, not new crypto.

--- a/docs/agents/review-personas/consensus-safety.md
+++ b/docs/agents/review-personas/consensus-safety.md
@@ -1,0 +1,72 @@
+# Persona: consensus-safety
+
+MISSION: Catch anything that could halt the chain, fork committed state, or produce an
+`InvalidSignature`. This is the highest-stakes review — a block is all-or-nothing and the combiner runs
+the VM on every validator, so one determinism or layering bug is a network event, not a bug ticket.
+
+## Owned docs (keep current — a drift you find here, you fix here)
+- `../../../CLAUDE.md` — the 3 data-application invariants.
+- `../../signing-canonical-and-validation.md` — full rationale + guard-suite table.
+- `../../audit/fiber-engine-permissionless-safety-audit-2026-07-07.md` — the defect catalog below.
+If the diff reveals one of these docs is stale (a new suite, a moved limit, a changed mechanism), update
+the doc in the same review.
+
+## Checklist (yes/no, with file references)
+1. New/changed signed-message field (`models/…/schema/Updates.scala`)? → Is it `Option[T]` or
+   required-no-default (NOT a defaulted `Boolean`/`SortedMap`)? Is there a `*SigningCanonicalSuite` case?
+2. Any hand-rolled codec (`Json.obj`/`downField`) added? → Rejected unless derivation is genuinely
+   ambiguous AND a golden field-name + round-trip KAT pins it.
+3. Any field/ADT rename on a schema type? → field names are signed JSON keys; is every golden test updated
+   and intentional (not "the test drifted so I updated the fixture")?
+4. New/changed `validateSignedUpdate` logic (`shared-data/…/lifecycle/Validator.scala`)? → STRUCTURAL only?
+   Does it read `CalculatedState.registry` lineage (`lineageOf`/`refResolvesAndMatches`/`versionAppendable`/
+   `scriptRefResolvesAndMatches`)? That is forbidden (TOCTOU block-poison).
+5. New `L0Validator` method taking a `SchemaRef`/`SchemaBinding` param? → review it specifically for
+   invariant 3; the script path was missed once (audit C3).
+6. Stateful rejection added at the gate that should be a combiner `CombineRejected`? (mutable status/seq/
+   balance/lineage reads belong in the combiner.)
+7. Combiner change (`Combiner.scala`)? → Does any path throw something OTHER than `CombineRejected` on a
+   business-rule failure? Only `CombineRejected` may escape the fold; anything else aborts the snapshot = halt.
+8. Committed receipt / rejection text hashed into state? → Must be a stable `reasonCode`/`ValueKind`, never
+   `getClass.getSimpleName`/`ex.getMessage` (L1 mixed-version fork). `FailureReasonCanonicalSuite` guards it.
+9. Any `CommitKey` derivation added to `CalculatedState.entries`? → Is it TOTAL (no throw on any input;
+   check the long-name/hash-fallback branch)? A non-total key throws inside combine = halt.
+10. Determinism: any wall-clock, `Random`, float, `hashCode`, or unordered `.toSeq`/`Map`-iteration reaching
+    committed bytes? Committed collections `SortedMap`/`SortedSet`? Apply order an explicit `sortBy`?
+11. Any consensus-critical limit changed (`ExecutionLimits.scala`)? → That is a hard fork; is it announced/gated?
+12. Fail-open vs fail-closed: does a gate treat a MISSING key as pass-through? Is that intended and documented
+    (the seq gate fails open for unknown ids by design) or an accidental "missing ⇒ accept"?
+13. Genesis change? → Does it seed BOTH OnChain and CalculatedState commit maps consistently
+    (`GenesisBuilder.scala`)? Guards: `GenesisBuilderSuite`, `StdManifestContractSuite`.
+14. Spawn/owner logic (`SpawnValidator.scala`)? → Is the child-owners ⊆ parent fail-closed floor intact (H1)?
+
+## Defect classes (from the fiber-engine audit — hunt these)
+- **C1 metered-but-not-priced compute:** an op that pins state / burns `maxGas` and is free to repeat.
+- **C2 conservation break / cross-holder theft:** aggregation ops without counterparty dedup/self-exclusion
+  (`Compose(assetId=S, otherAssetIds=[S])` double-counts = inflation), or a consent gate that is a **no-op
+  when nonce=None** (opt-in instead of mandatory). Ask: is consent MANDATORY, the id-set DISTINCT, same-holder verified?
+- **C3 registry-lineage read in `validateSignedUpdate`:** TOCTOU block-poison (see checklist 4–5).
+- **H1 owner-forgery:** `_spawn` assigning arbitrary unsigned child `owners`; fix = child ⊆ parent floor.
+- **H2 un-metered O(chain-state) host work:** Scala loops folding over ALL assets/children per candidate
+  transition, outside the gas meter, over never-pruned state.
+- **M1 stateful own-record checks left at the gate:** mutable status/seq/transition reads in `validateSignedUpdate`.
+- **M2 cascade auth asymmetry:** direct path owner-gated but cascade (`_triggers`, `proofs=empty`) skips it.
+- **M3 front-run footgun:** creator-chosen `fiberId` lets an attacker create the exact allowlisted UUID.
+- **L1 version-dependent committed text** (see checklist 8). **L5 fail-silent effect extraction:** malformed
+  `_transferAsset`/`_triggers` silently dropped while the tx commits success.
+
+## Consensus-critical limits (must be identical across validators)
+`maxDepth=10`, `maxGas=10_000_000`, `maxStateSizeBytes=1_048_576`, `maxAssetMutations=32`,
+`maxActiveDependencies=64`, `maxDependencyLedger=256`, `maxSpawnsPerTransition=16`; metakit `DefaultMaxDepth=64`;
+snapshot binary cap 512,000 B.
+
+## Regression anchors (breaking one is a serious defect, flag loudly)
+RFC-8785/JCS canonical hashing; `SortedMap`/`SortedSet` for committed collections; asset transfers applied in
+`sortBy(_._1)` emitter order; tighten-only migration lattice; `$caller` non-spoofable; single shared `maxGas`
+threaded everywhere; R1 holder-defense.
+
+## OUT OF SCOPE (do not flag)
+- Style/formatting (scalafmt/scalafix own it). Unused imports (non-fatal by config).
+- Defaults on server-DERIVED state (`OnChain`, `RegistryShape`) — invariant 1 governs signed messages only.
+- Immutable reads in `validateSignedUpdate` (owner-signature presence is TOCTOU-safe).
+- Test-only code quality (that is the ai-smells persona). Wire-size/economics specifics (state-growth persona).

--- a/docs/agents/review-personas/state-growth-determinism.md
+++ b/docs/agents/review-personas/state-growth-determinism.md
@@ -1,0 +1,56 @@
+# Persona: state-growth-determinism
+
+MISSION: Keep on-chain state bounded and every committed byte deterministic. Cumulative state on the wire
+is a slow-motion permanent halt; a non-deterministic committed byte is a fork. Both are silent until the
+chain is large or two validators disagree.
+
+## Owned docs (keep current)
+- `../../proposals/onchain-incrementals.md` *(arrives with PR #210)* — the OnChain-v2 RFC (deltas, DL1 fold/heal, cap avoidance).
+- `../../proposals/economics-and-state-rent.md` — fee/rent design; the C1 gating hurdle.
+- the wire-size suite (`OnChainWireSizeSuite`) — the byte-budget guard.
+
+## The hard limits (memorize)
+- **Snapshot binary cap: 512,000 bytes** (`max-state-channel-snapshot-binary-size-in-bytes`). The WHOLE
+  snapshot binary, incl. `dataApplication.onChainState`. Exceed it → `UnableToReduceProposalByCutting` =
+  **permanent chain halt**. Cumulative maps on `OnChain` hit this at ~2,265 fibers — which is exactly why
+  OnChain-v2 moves cumulative maps to `CalculatedState` and keeps only per-batch `touched*` deltas on OnChain.
+- `maxStateSizeBytes=1_048_576` (per-fiber resulting state), `maxAssetMutations=32`, `maxActiveDependencies=64`,
+  `maxDependencyLedger=256`, `maxSpawnsPerTransition=16`, `maxGas=10_000_000`, `maxDepth=10`.
+
+## Checklist (yes/no, with file references)
+1. New map/set field on `OnChain` (`models/…/schema/OnChain.scala`)? → Is it a per-batch DELTA (O(churn),
+   cleared each snapshot) or does it accumulate? Cumulative on OnChain is banned — it hits the 512KB cap.
+2. New map on `CalculatedState`? → Who PRUNES it? Is growth bounded, or does it grow unbounded with usage
+   forever? An unbounded never-pruned map is a latent problem even off the wire (H2 host-work substrate).
+3. Wire size: did `bin/wire-size` / `OnChainWireSizeSuite` stay within its band? A field that widens the
+   marginal per-fiber/per-batch bytes is a codec-bloat regression — flag it even if under the cap today.
+4. New `CommitKey` namespace / committed-MPT entry (`CalculatedState.entries`)? → Is the key derivation TOTAL
+   (never throws) and total-keyed (a stable, collision-safe key for every input, incl. over-long names)?
+5. Determinism in committed bytes: any wall-clock, `Random`, float arithmetic, `hashCode`, or unordered
+   iteration (`Map`/`Set` `.toSeq`, `.toList` of an unordered collection) reaching committed state?
+6. Committed collections `SortedMap`/`SortedSet`? Apply/emit order an explicit `sortBy` (not insertion or
+   hash order)? Asset transfers apply in `sortBy(_._1)` emitter order.
+7. Host-side loop added (Scala, outside the JLVM gas meter) that folds over an unbounded collection — all
+   assets, all children, all dependencies — per candidate transition? That is the **H2** class: charge it
+   gas or bound it. Building context by folding over ALL of anything per transition is the smell.
+8. `CommitIndex.fold` (OnChain-v2)? → Is it applied ONLY at `index.ordinal+1`? Folding across a gap loses
+   `touched*` writes and the gate fails open. DL1 heal must verify subtree completeness, never fold a gap.
+9. Gas: is every new metered operation actually priced (not metered-but-free, the C1 pattern)? Is the single
+   shared `maxGas` threaded through, not a fresh unlimited budget?
+10. `DataStateOps` (`syntax/DataStateOps.scala`): are the OnChain delta, CalculatedState cumulative, and record
+    all written from ONE computed hash in one focus chain? If they diverge, delta ≠ cumulative → DL1 heal
+    returns wrong state.
+
+## Defect classes
+- **Cumulative-on-the-wire → halt:** the OnChain-v2 motivating bug. Any map that grows with total usage on OnChain.
+- **Unbounded never-pruned state:** grows forever; also the substrate for un-metered O(state) host work.
+- **H2 un-metered host loop:** O(chain-state) Scala work outside the gas meter, charged a flat gas.
+- **Non-deterministic committed byte:** unordered iteration / wall-clock / float / hashCode → fork.
+- **Fold-across-a-gap fail-open:** `CommitIndex.fold` off by an ordinal silently drops writes.
+- **Codec bloat:** a field that widens the wire marginal without a wire-size band update.
+
+## OUT OF SCOPE (do not flag)
+- Signature-canonical / validation-layering correctness (consensus-safety persona) — except where it touches
+  committed-byte determinism, which is shared ground: flag it and tag both personas.
+- Asset economic semantics (asset-economics persona). Endpoint/SDK wire shape (wire-compat persona).
+- Test quality (ai-smells persona). Formatting (scalafmt/scalafix).

--- a/docs/agents/review-personas/wire-compat.md
+++ b/docs/agents/review-personas/wire-compat.md
@@ -1,0 +1,52 @@
+# Persona: wire-compat
+
+MISSION: Keep the wire contract consistent across the chain, the OpenAPI docs, the TS SDK, and the e2e
+harness. A silent wire drift surfaces as an opaque HTTP 400, a 404, or a green-but-lying e2e — never as a
+clean compile error.
+
+## Owned docs (keep current)
+- `../../openapi-ml0.{json,yaml}`, `../../openapi-dl1.{json,yaml}` — the generated contracts.
+- `../../proposals/typed-network-interface.md` — named DTOs → one OpenAPI contract → generated SDK.
+- `../../API-REFERENCE.md` — the human endpoint/port reference.
+
+## Checklist (yes/no, with file references)
+1. Any route added/changed/removed (`l0/…/ML0Routes.scala`, DL1 routes)? → Was `bin/regen-openapi` run and
+   the regenerated `docs/openapi-*` committed IN THIS PR? (CI auto-commits on same-repo PRs, but review it.)
+2. Endpoint COUNT changed? → Is `OpenApiDocSuite` updated to the new count (ML0/DL1)? It pins counts.
+3. New DL1 route? → Does the client path include the **`/data-application`** prefix? A missing prefix 404s
+   (the #210 heal-client bug). Custom DL1 routes mount under `/data-application`.
+4. Any change to a signed wire shape or a field the SDK sends/reads? → Grep `e2e-test/` for consumers
+   (`runner.ts` sync helpers, `terminal.ts` queries) and update them in the SAME PR. The harness is coupled
+   to wire shapes; a shape change with a stale harness = every lifecycle step 500s (the #162 incident).
+5. Does the SDK round-trip EVERY field the chain signs? → A field the SDK silently strips before signing
+   (the `transitionPolicy` dial incident) downgrades behavior invisibly. New signed field ⇒ SDK must send it.
+6. Route added? → Is it a typed tapir endpoint (named DTO), not an ad-hoc string handler?
+7. Version lockstep: does this change require a matching bump in `@ottochain/sdk` and/or the metakit rc pin
+   (`project/Dependencies.scala`)? A metagraph JAR only runs against its exact tessellation-SDK; JAR↔SDK↔
+   metakit-rc move together. Note the required companion PRs.
+8. Breaking wire change? → Does it ride the announced release train (e.g. 0.8.0), not a silent minor?
+9. Genesis/manifest wire shape touched? → Do the SDK's `genesis-manifest.ts` and chain `GenesisManifest`
+   still agree field-for-field?
+10. Webhook payloads (`architecture/ml0-snapshot-webhooks.md`)? → Still match the SDK's `webhook-notifications.ts`?
+    (Note: the `transaction.rejected` webhook is DEAD — graceful rejects show as "not included", not a webhook.)
+11. Did an e2e lane stay green only because it doesn't exercise the changed path? → Confirm the change is
+    actually covered, not merely un-broken.
+
+## Defect classes / real incidents
+- **Silent field-strip (transitionPolicy):** SDK dropped a hand-set dial before signing → fiber silently
+  downgraded to Open. Guard question: does `signing-parity`/`SdkCompatibilitySuite` assert the field verbatim?
+- **Path-prefix 404 (#210):** heal client omitted `/data-application` → silent heal failure, only e2e caught it.
+- **Harness-not-updated (#162):** a chain message rename that CLAIMED the harness was updated but wasn't →
+  HTTP 500 on every step, diagnosed only from container logs.
+- **Endpoint-count drift:** adding a route without updating `OpenApiDocSuite` → red CI on the count assertion.
+- **Version skew:** JAR built against a different tessellation-SDK than the running cluster → silent boot /
+  `InvalidSignatureForHash` on DL1.
+- **SDK alignment classes (from the SDK-side audit, if the diff touches SDK types):** S1 authz bound to
+  attacker `event.*` (only `proofs[].address` is verified identity); A1 `$timestamp` is not a reserved key;
+  A3 SDK directives the chain silently drops (object-form `dependencies`, transition-level `emits/spawns`);
+  A4 wire-type drift (`schemaShape→machineShape`, `PublishVersion` split).
+
+## OUT OF SCOPE (do not flag)
+- The internal consensus correctness of a validator/combiner (consensus-safety persona).
+- Unbounded-state / gas / byte-budget concerns (state-growth persona).
+- Test tautologies / naming (ai-smells persona). Formatting (scalafmt/scalafix).

--- a/docs/agents/tools.md
+++ b/docs/agents/tools.md
@@ -1,0 +1,60 @@
+# Tools — the toolbelt and how to grow it
+
+**Standing instruction: any non-obvious incantation you type twice, script it into `bin/`.** The
+toolbelt is meant to grow. A script you write once saves every future cheap-model session the cost of
+rediscovering the incantation — and encodes the recovery steps for when it goes wrong.
+
+## How to write a bin/ script
+- **bash, `set -euo pipefail`.** Absolute or repo-root-relative paths (`ROOT="$(git rev-parse --show-toplevel)"; cd "$ROOT"`).
+- **Every script has `--help`** as its first behavior. The pattern used across `bin/`:
+  `case "${1:-}" in -h|--help) sed -n '2,15p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;; esac` — the header
+  comment IS the help text.
+- **Self-contained, no new deps.** Only tools already in the repo/user environment (git, sbt, gh, node,
+  just). If a script needs sbt, guard the toolchain: `command -v sbt` first, source SDKMAN only as a
+  fallback (and wrap the `source` in `set +e … set -e` — SDKMAN's init trips `errexit`).
+- **Delegate to `just` where a recipe exists** — don't duplicate `just test` / `just build` / `just e2e-up`.
+  Wrap them (add module mapping, drift checks, recovery hints) rather than reimplement.
+- **Fail loudly with the fix.** On a detectable failure, print the exact recovery commands (see
+  `bin/test`'s stale-server hint, `bin/preflight`'s OpenAPI-drift instructions).
+- `chmod +x`, then verify: `bash -n bin/<script>` and `bin/<script> --help`.
+
+## bin/ (this repo)
+| script | what |
+|---|---|
+| `bin/preflight [--fast]` | every CI gate locally, in CI's order. Must exit 0 before you push. |
+| `bin/test <module\|all> [glob]` | module tests by friendly name (l0/l1/dl1/shared/models), batch mode. |
+| `bin/regen-openapi` | regenerate the OpenAPI contracts + report drift. |
+| `bin/pr-watch <pr#>` | poll a PR's checks to a terminal state; dump failing logs. A PR isn't done until this exits 0. |
+| `bin/tasks [label]` | list open issues by label (agent-ready, cheap-model-ok, needs-senior, blast-radius). |
+| `bin/agent-review <persona> [range]` | run one review persona over a diff (`--dry-run` prints the prompt). |
+| `bin/wire-size` | run the OnChain wire-size suite + print byte probes. |
+| `bin/worksheet <slug>` | start a dated worksheet from the template; print trailer + tag reminders. |
+
+## just recipes (delegate to these)
+`just test` · `just test-only <suite>` · `just build` (currencyL0/currencyL1/dataL1 assembly) ·
+`just e2e-up` / `just e2e` / `just e2e-down` / `just e2e-health` · `just up`/`down`/`health`/`logs`
+(docker-compose local) · `just resolve-tess-version` · `just keygen` / `just show-address`.
+Run `just` (or `just --list`) to see them all.
+
+## ~/bin ecosystem (the user's cross-repo scripts worth knowing)
+- `git-start-branch.sh <repo> <branch>` — ALWAYS starts from fresh `origin/main` (fetch → reset →
+  new branch). The never-work-on-stale-state rule, scripted. Prefer it (or its manual equivalent).
+- `prs` — open PRs across all ottochain repos, split into Upstream (need James to merge) / Fork-reviewed
+  / Fork-needs-review. Use it to see what is waiting on a human.
+- `ecosystem-state.sh` — cron snapshot of every remote + open PR into `~/repos/.state/`; also polls the
+  live cluster status endpoint. Read its output instead of re-fetching by hand.
+
+## sbt gotchas (these cost cycles)
+- **Project keys are not the directory names:** `modules/l0 → currencyL0`, `modules/l1 → currencyL1`,
+  `modules/data_l1 → dataL1`, plus `models`, `sharedData`, `sharedTest`. `sbt "l0/compile"` is a silent
+  no-op → scalafix runs on a stale SemanticDB → CI `--check` fails though local looked clean. `bin/test`
+  maps the friendly names for you.
+- **Thin-client death under concurrent worktrees:** "server was not detected / failed to connect". Recover:
+  `pkill -f 'sbt.*server'; rm -f project/target/active.json`; use batch `sbt "cmd"` (what `bin/test` does).
+- **Unused imports are NOT fatal** (`-Wconf:cat=unused:info`, no `-Xfatal-warnings`). Don't chase them as
+  errors — but run `scalafixAll scalafmtAll` before commit; `scalafmtOnCompile`/`scalafixOnCompile` are on
+  locally, and CI re-checks in check-mode (which does not lie about a stale cache).
+- **sbt-dynver throws in a linked `git worktree`** (NoWorkTreeException) — for version-sensitive tasks build
+  from a normal checkout.
+- **`assembly / mainClass` is pinned on currencyL0** because `GenerateOpenApi` also defines a `main`; without
+  the pin sbt-assembly writes no Main-Class and `ml0.jar` won't boot.

--- a/docs/signing-canonical-and-validation.md
+++ b/docs/signing-canonical-and-validation.md
@@ -1,0 +1,126 @@
+# Signing-canonical & validation-layering invariants
+
+The full rationale behind the three data-application invariants in `CLAUDE.md`. Read this before
+touching any signed message, codec, validator, or combiner. Owned by the **consensus-safety** review
+persona (`agents/review-personas/consensus-safety.md`).
+
+These rules exist because a Constellation data block is accepted **all-or-nothing**: one `Invalid`
+verdict on one transaction drops the *entire* snapshot's block for *every* transaction in it. And the
+combiner runs the full VM synchronously on *every* ML0 validator — any divergence in committed bytes
+forks the chain. So the cost of getting these wrong is a halt or a fork, not a failed request.
+
+---
+
+## Invariant 1 — signed-message fields are `Option[T]` or REQUIRED, never defaulted
+
+On-chain signature verification is over `JCS(dropNulls(payload))` — RFC-8785 canonical JSON of the
+payload after null object-fields are recursively stripped. `dropNulls` strips `null`; it does **not**
+strip `false` or `{}` or `[]`.
+
+The trap: a signed-message field declared `Boolean = false` or `SortedMap = empty`.
+- The client (SDK) omits it → it is absent from the signed canonical.
+- The chain's derived decoder re-fills the default → it is *present* in the verified canonical.
+- Signed bytes ≠ verified bytes → **`InvalidSignature`**, surfaced as an opaque empty-body HTTP 400.
+
+Rule: every field on an `OttochainMessage` variant is either `Option[T]` (omit-safe: `None` → `null`
+→ dropped) or REQUIRED with no default. Never a non-`Option` field with a default. Server-*derived*
+state (`OnChain`, `RegistryShape`) MAY carry defaults — this invariant governs **signed messages only**.
+
+Field names are signature-load-bearing (they are the JSON keys hashed). A rename or reorder re-hashes
+everything. Therefore: **derive codecs** (`@derive(customizableEncoder, customizableDecoder)`), never
+hand-roll `Json.obj("field" -> …)`/`downField`. Where derivation is genuinely ambiguous
+(`RegistryShape`/`RegistryTarget` field-name discrimination, `ScriptShape` ADT) the hand-rolled codec
+is pinned by a golden field-name KAT + round-trip test.
+
+Do NOT write lenient decoders that "fix" shapes (e.g. accepting `{"value":"x"}` for a bare string).
+Standardize on the canonical form and make fixtures canonical; auto-correcting a shape is a signing hazard.
+
+**Guard:** add a case to `PublishVersionSigningCanonicalSuite` / `AssetOpSigningCanonicalSuite` for any
+new signed message. The suite builds the payload with every Option = `None`, applies `dropNulls`, and
+asserts `dropNulls(decode(payload).asJson) == payload`. `SdkCompatibilitySuite` /
+`E2eSignedPayloadCompatSuite` pin cross-repo wire agreement with the SDK.
+
+---
+
+## Invariant 2 — two-tier validation: structural at the gate, stateful in the combiner
+
+There are two places a transaction can be rejected, and they are NOT interchangeable:
+
+- **`validateUpdate` / `validateSignedUpdate`** (the block-acceptance gate) — STRUCTURAL checks only:
+  field presence, expression depth, owner-signature presence, sequence number against `OnChain`.
+  A verdict of `Invalid` here drops the whole all-or-nothing block.
+- **The combiner** (`Combiner.scala` + `combine/*`) — the authoritative deterministic stateful gate. It
+  runs the VM and may reject *gracefully* via `CombineRejected(reason)` → a `RejectionReceipt`, leaving
+  `previous` state unmutated and the rest of the block intact.
+
+So: any rejection that needs to read `CalculatedState` (balances, lineage, status, prior seq) belongs in
+the combiner as `CombineRejected`, never as an `Invalid` at the gate. Registry stateful checks are
+combine-only (L1 cannot see version lineage). Fiber stateful checks stay at L1 only where the datum is
+immutable and locally available (`OnChain.fiberCommits` has the seqNum).
+
+**The one escape hatch:** in `Combiner.scala` only `CombineRejected` may escape the fold (via
+`recoverWith`). ANY other throwable aborts the whole snapshot combine by design — that is a consensus
+halt. A stateful condition that should have been a graceful `CombineRejected` but is thrown as something
+else, or asserted as `Invalid` at the gate, is a halt/block-poison waiting to happen.
+
+Committed rejection receipts must use a **stable `reasonCode` / `ValueKind`**, never version-dependent
+text (`getClass.getSimpleName`, `ex.getMessage`). Hashing prose into committed state means a reword
+forks the state hash of a *rejected* tx across mixed validator versions. Prose goes to logs only.
+**Guard:** `FailureReasonCanonicalSuite` asserts byte-identical committed receipts across differing
+exception messages.
+
+---
+
+## Invariant 3 — `validateSignedUpdate` must NEVER read `CalculatedState.registry` lineage
+
+This is the TOCTOU block-poisoning rule and the sharpest of the three.
+
+`validateSignedUpdate` runs at block acceptance. If it reads *mutable* registry lineage — any call to
+`lineageOf` / `refResolvesAndMatches` / `versionAppendable` / `scriptRefResolvesAndMatches` on a
+`SchemaRef` / `SchemaBinding` — then a concurrent third-party publish or yank can flip the answer
+`Valid → Invalid` between two validators or two moments (time-of-check vs time-of-use). One `Invalid`
+drops the entire block for every transaction in the snapshot. That is a griefing vector: an attacker
+publishing/yanking a version can poison unrelated transactions' blocks.
+
+Rule: registry/script lineage checks belong **ONLY** in the combiner as graceful `CombineRejected`
+(`resolveScriptBinding` / `RegistryCombiner` re-verify there, gracefully). `validateSignedUpdate` for
+fiber/registry/script create/upgrade ops does structural checks only. Immutable reads (owner-signature
+presence) are TOCTOU-safe and allowed. The fiber path was hardened first; the script path was missed
+in the first pass (audit C3) — so **review every new `L0Validator` method that takes a `SchemaRef` or
+`SchemaBinding` parameter.** `RegistryValidator.CombinedValidator` is documented "MUST NOT be used from
+validateSignedUpdate."
+
+---
+
+## Consensus-critical limits (must be byte-identical across all validators)
+From `modules/models/.../schema/fiber/ExecutionLimits.scala` — changing any of these is a hard fork:
+`maxDepth=10`, `maxGas=10_000_000`, `maxStateSizeBytes=1_048_576`, `maxAssetMutations=32`,
+`maxActiveDependencies=64`, `maxDependencyLedger=256`, `maxSpawnsPerTransition=16`; metakit codec
+`DefaultMaxDepth=64`. The snapshot binary is separately hard-capped at **512,000 bytes**
+(`max-state-channel-snapshot-binary-size-in-bytes`, tessellation node-shared config).
+
+## Determinism discipline (committed bytes only)
+Committed collections are `SortedMap` / `SortedSet`; apply order is an explicit `sortBy`. No wall-clock,
+`Random`, floats, `hashCode`, or unordered-to-seq conversions may reach committed bytes. Canonical
+hashing is RFC-8785/JCS with sorted keys — no map-order forks.
+
+## Guard-suite table (invariant → suite that fails when you break it)
+| Invariant / property | Guard suite |
+|---|---|
+| Signed-field Option-or-required + dropNulls round-trip | `PublishVersionSigningCanonicalSuite`, `AssetOpSigningCanonicalSuite` |
+| Cross-repo wire agreement with SDK | `SdkCompatibilitySuite`, `E2eSignedPayloadCompatSuite` |
+| Hand-rolled codec field-names / ADT discriminators | golden field-name + round-trip KATs |
+| Committed receipt stable across exception text (Inv. 2) | `FailureReasonCanonicalSuite` |
+| Committed-state projection totality | `CommittedViewSuite` |
+| Genesis seeds OnChain + CalculatedState together | `GenesisBuilderSuite`, `GenesisManifestLoaderSuite`, `StdManifestContractSuite` |
+| Wire-size budget / codec bloat | `OnChainWireSizeSuite` (ships with OnChain-v2, PR #210) |
+
+## Note: the OnChain-v2 / CommitIndex world (PR #210) changes some wording
+On the current `main`, `OnChain` holds **cumulative** `fiberCommits`/`registryCommits`/`assetCommits`
+maps. PR #210 (`onchain-incrementals` RFC) moves the cumulative maps into `CalculatedState`, leaves
+per-batch `touched*` **deltas** + `burnedAssets` on `OnChain`, and adds `CommitIndex` (contiguous
+`fold` valid ONLY at `index.ordinal+1`; folding across a gap loses writes and the gate **fails open**)
+plus a DL1 `GET /commit-index` heal route. After #210 lands: "structural checks against `OnChain`" for
+fiber ops read the relocated commit-index triple (allowed) — but registry *lineage* reads stay barred
+by Invariant 3, and the 512KB cap becomes the reason cumulative maps had to leave `OnChain` at all.
+Update this section when #210 merges.

--- a/docs/worksheets/2026-07-11-agent-infra-scaffold.md
+++ b/docs/worksheets/2026-07-11-agent-infra-scaffold.md
@@ -66,3 +66,6 @@ relays SHAs + verification; James reviews and merges.
 
 ## Feedback entry (appended to docs/agents/feedback.md)
 - sbt thin-client death under concurrent worktree use (logged).
+
+
+**PRs:** scasplte2/ottochain#212, ottobot-ai/ottochain-sdk#253

--- a/docs/worksheets/2026-07-11-agent-infra-scaffold.md
+++ b/docs/worksheets/2026-07-11-agent-infra-scaffold.md
@@ -1,0 +1,68 @@
+# 2026-07-11 — agent-infra-scaffold
+
+<!-- metadata.type: project -->
+
+## Goal
+Make less-capable models productive and safe in ottochain by externalizing context into docs, executable
+`bin/` scripts, review personas, worksheets, and skills. Fix the dangling `docs/signing-canonical-and-
+validation.md` reference in CLAUDE.md. Do NOT touch `modules/` or `.github/` — scaffold only.
+
+## Context links
+- Branch: chore/agent-infra (off fresh origin/main @ #209)
+- Seeds: scratchpad seed-pack.md + three mining reports (ottochain, workflow, sdk)
+- Related worksheets: [[2026-07-11-onchain-v2]] (the source of several session-hot lessons)
+- Tier: T0-1 (docs/bin/worksheets/skills only — no consensus code touched)
+
+## Plan
+- [x] branch off origin/main; read the 4 ground-truth files
+- [x] AGENTS.md router + minimal CLAUDE.md edit (invariants byte-identical)
+- [x] docs/signing-canonical-and-validation.md (fixes the dangling ref)
+- [x] docs/INDEX.md
+- [x] docs/agents/{README, blast-radius, conventions, tools, process-observations, feedback}.md
+- [x] docs/agents/review-personas/{consensus-safety, wire-compat, state-growth-determinism, asset-economics, ai-smells-test-integrity}.md
+- [x] docs/worksheets/{README, TEMPLATE} + this + the onchain-v2 retro
+- [x] bin/ (8 scripts, chmod +x, --help each)
+- [x] .claude/skills/{night-shift, commit-sweep, test-audit}/SKILL.md
+- [x] verification: bash -n, --help, regen-openapi no-op, CommittedViewSuite, preflight --fast
+
+## The mining phase
+Three parallel research agents produced the seed pack + three reports (repo mining: gotchas, defect
+classes, blast-radius, CI inventory, doc inventory; workflow mining: preferences, tier vocabulary, ~/bin
+idioms, inefficiency evidence; SDK mining: cross-repo references). This scaffold is the synthesis; the
+personas and process-observations cite those reports' evidence directly.
+
+## State of play (running log)
+- Confirmed the ground truth against the repo: origin/main HEAD is #209. **OnChain-v2 / CommitIndex
+  (#210/#211) is NOT merged yet** — `OnChain` still holds cumulative `fiberCommits`/`registryCommits`/
+  `assetCommits`; `CommitIndex.scala` and `OnChainWireSizeSuite` do not exist on this branch (only
+  `CommittedViewSuite`). Docs reflect the current state and mark the v2 world as incoming (PR #210).
+- Verified `ExecutionLimits.scala` constants for the limits table (maxDepth=10 … maxSpawnsPerTransition=16).
+- bin/ scripts: the SDKMAN source under `set -euo pipefail` exited the shell (errexit inside the sourced
+  init). Fixed: only source SDKMAN as a fallback when `sbt` is absent, wrapped in `set +e … set -e`. The
+  `~/bin/sbt` wrapper is self-sufficient, so the fallback is rarely hit.
+
+## Open items (deliberately not done here — follow-ups)
+- The SDK-repo agent-infra scaffold runs in a PARALLEL session (ottochain-sdk is greenfield: no
+  CLAUDE.md/AGENTS.md yet; needs the S1/S2/A1–A4 personas, a pnpm preflight, `node scripts/lint-apps.mjs`).
+- Propagation to `-services` / `-explorer` later (their own bin/ + personas).
+- stryker4s mutation-testing spike (process-observations #4) — proposed, not built.
+- gas-regression suite (process-observations #5) — proposed, not built.
+- night-shift dry-run / publish-dry-run CI gate (process-observations #6) — proposed, not built.
+- Re-word the signing doc's "OnChain-v2 note" and blast-radius `CommitIndex` entries once #210 merges.
+
+## Decisions needing a human or senior model
+- None — pure T0-1 scaffold. But: the process-observations doc makes several proposals (default-on hooks
+  for agents, auto-merge-on-green for T0-1 PRs, scheduled dep-bump night-shift) that are James's calls.
+
+## Pre-commit checklist
+- [x] every commit subject measured ≤ 72, lowercase, no trailing period
+- [x] bin/preflight --fast run end-to-end
+- [x] no changes under modules/ or .github/
+- [x] trailers present
+
+## Outcome
+Scaffold complete on branch chore/agent-infra. Not pushed (per instructions). Handoff: parent agent
+relays SHAs + verification; James reviews and merges.
+
+## Feedback entry (appended to docs/agents/feedback.md)
+- sbt thin-client death under concurrent worktree use (logged).

--- a/docs/worksheets/2026-07-11-onchain-v2.md
+++ b/docs/worksheets/2026-07-11-onchain-v2.md
@@ -1,0 +1,65 @@
+# 2026-07-11 — onchain-v2
+
+<!-- metadata.type: project -->
+<!-- RETRO-WRITTEN: reconstructed from .workspace/work-log.md + memory after the fact, to seed the
+     worksheet convention with a real trace. Timestamps are approximate/ordinal. -->
+
+## Goal
+Stop cumulative commit maps on `OnChain` from growing the snapshot binary toward the 512KB cap (a
+permanent-halt risk at ~2,265 fibers). Move cumulative state to `CalculatedState`; keep only per-batch
+`touched*` deltas + `burnedAssets` on `OnChain`; give DL1 a fold/heal path so it can reconstruct
+cumulative state from deltas.
+
+## Context links
+- RFC: docs/proposals/onchain-incrementals.md
+- PRs: #210 (OnChain-v2 impl + DL1 commit-index route), #211 (`refactor/nested-match-cleanup`, pure refactor, −67 lines)
+- Related: docs/signing-canonical-and-validation.md (the cap + fold-open mechanics), docs/agents/blast-radius.md
+- Tier: T3 (touches OnChain, CalculatedState, Validator, DL1 routes, genesis, e2e harness) — senior session
+
+## Plan
+- [x] phase-0 probe: wire-size measurement of cumulative vs delta OnChain
+- [x] RFC in docs/proposals/onchain-incrementals.md
+- [x] impl: OnChain deltas + CalculatedState cumulative + CommitIndex fold
+- [x] DL1 fold/heal + GET /commit-index route
+- [x] regenerate pre-v2 genesis JSONs
+- [x] green all e2e lanes
+
+## State of play (running log)
+- t0 — phase-0 wire-size probe (commit 152eb67): confirmed cumulative maps blow the 512KB budget at
+  scale; deltas are O(churn). This became `OnChainWireSizeSuite`, which now guards the budget permanently.
+- t1 — RFC written (10ab705): deltas on OnChain, cumulative maps relocated to CalculatedState, DL1
+  reconstructs via a contiguous `CommitIndex.fold` (valid ONLY at `index.ordinal+1`; a gap fails open).
+- t2 — impl (f1ccbbd): `OnChain` now carries `touched*` deltas + `burnedAssets`; `CalculatedState` holds
+  the cumulative `fiberCommits`/`registryCommits`/`assetCommits`; `CommitKey` derivation kept TOTAL.
+- t3 — **CI round 1: RED.** All five e2e lanes timed out. Root cause: the e2e harness polled DL1
+  `/v1/onchain` for cumulative `fiberCommits`/`assetCommits` — which v2 turned into vanishing per-batch
+  deltas → every DL1-sync gate timed out. The harness was coupled to the old wire shape (blast-radius item).
+- t4 — fix (cc2c4c4): extracted the fold/heal into a shared `CommitIndexService`; DL1 wires ONE instance
+  into BOTH `validateUpdate` and a NEW `GET /v1/commit-index` route; harness now polls
+  `/data-application/v1/commit-index`. NOTE the `/data-application` prefix — the first heal-client URL
+  omitted it and 404'd silently.
+- t5 — regenerated pre-v2 genesis JSONs: without regen, DL1 heal returned empty `fiberCommits` for seeded
+  fibers (genesis must seed BOTH OnChain and CalculatedState commit maps consistently).
+- t6 — #211 landed in parallel as a pure nested-match→chaining refactor (ran in a separate worktree off
+  MAIN HEAD, zero conflicts with the feature work).
+- t7 — all lanes green.
+
+## Decisions needing a human or senior model (recorded)
+- Relocating cumulative maps OnChain→CalculatedState is a committed-state shape change → genesis redeploy
+  at 0.8.0, coordinated validator upgrade (not a rolling deploy). Signed off as part of the 0.8.0 train.
+- `CommitIndex.fold` fails OPEN across a gap by design (DL1 heals rather than rejects) — accepted, documented.
+
+## Outcome
+Shipped via #210 (+#211 refactor). OnChain is now O(churn) on the wire; cumulative state is provable via
+CalculatedState + CommitIndex; DL1 heals from ML0. `OnChainWireSizeSuite` guards the byte budget going forward.
+
+## The two CI lessons (fed into the scaffold)
+1. **PR opened ≠ done.** #210 sat with all 5 e2e lanes red for ~30 min before James noticed, not the
+   agent. → `bin/pr-watch`; a PR is done only when checks are green AND watched.
+2. **The e2e harness is coupled to wire shapes.** A wire-format change MUST grep `e2e-test/` for consumers
+   in the same PR. → wire-compat persona checklist item; blast-radius lists `runner.ts`.
+Plus: commitlint subject-case/length failures surfaced only in CI (opt-in pre-push mirror) → `bin/preflight`
+runs the check unconditionally.
+
+## Feedback entry (appended to docs/agents/feedback.md)
+- The PR-monitoring miss and the commitlint-in-CI miss are both logged there.

--- a/docs/worksheets/README.md
+++ b/docs/worksheets/README.md
@@ -29,6 +29,9 @@ Milestone tags are namespaced `ws/<slug>`:
 ```
 git tag ws/onchain-v2
 ```
+**Tag on `main` after the squash-merge, not on branch commits** — this repo squash-merges,
+so branch SHAs vanish; a tag applied pre-merge dangles.
+
 The `ws/` namespace is deliberate: `release.yml` fires ONLY on `v*` tags (verified), so a `ws/*` tag
 never triggers a release.
 

--- a/docs/worksheets/README.md
+++ b/docs/worksheets/README.md
@@ -1,0 +1,42 @@
+# docs/worksheets — committed, resumable session traces
+
+A worksheet is the running record of one unit of work. It is **committed** (not gitignored `.workspace/`
+scratch, which died with the machine and cost re-work) so any agent — or you next week — can resume
+exactly where the last session stopped.
+
+## The rule
+**Open a worksheet FIRST**, before writing code. Update it at every stopping point: after a decision,
+before a break, when blocked, when a CI run is in flight. A worksheet that is only filled in at the end
+is a report, not a trace — the point is that a fresh session can pick it up mid-flight.
+
+## Start one
+```
+bin/worksheet <slug>      # copies TEMPLATE.md → docs/worksheets/YYYY-MM-DD-<slug>.md, prints reminders
+```
+
+## Naming
+`docs/worksheets/YYYY-MM-DD-<slug>.md`. Slug is short and kebab-case: `onchain-v2`, `agent-infra-scaffold`.
+
+## Commit trailer convention
+Every commit that belongs to a worksheet's work carries:
+```
+Worksheet: docs/worksheets/YYYY-MM-DD-<slug>.md
+```
+This lets `git log` reconstruct which commits belong to which session trace.
+
+## Tag convention
+Milestone tags are namespaced `ws/<slug>`:
+```
+git tag ws/onchain-v2
+```
+The `ws/` namespace is deliberate: `release.yml` fires ONLY on `v*` tags (verified), so a `ws/*` tag
+never triggers a release.
+
+## Frontmatter taxonomy (reuse, don't fork)
+Match the user's existing memory taxonomy: `metadata.type: feedback|reference|project|user`. Worksheets
+are `type: project`. `[[wikilinks]]` to other worksheets/docs are fine.
+
+## What goes in one
+See `TEMPLATE.md`. In short: goal, context links (PRs/issues/RFCs), plan, a running state-of-play log,
+blockers, decisions that need a human or senior model, a pre-commit checklist, handoff notes, outcome,
+and the feedback entry you'll append to `../agents/feedback.md`.

--- a/docs/worksheets/TEMPLATE.md
+++ b/docs/worksheets/TEMPLATE.md
@@ -1,0 +1,49 @@
+# YYYY-MM-DD — <slug>
+
+<!-- metadata.type: project -->
+<!-- Started from bin/worksheet. Update at EVERY stopping point, not just at the end. -->
+
+## Goal
+One or two sentences. What "done" looks like, concretely.
+
+## Context links
+- PRs: #___
+- Issues: #___
+- RFCs / docs: docs/proposals/___.md
+- Related worksheets: [[YYYY-MM-DD-___]]
+- Branch: <type>/<slug>  (branched off fresh origin/main)
+- Tier: T0-1 | T2 | T3   (see docs/agents/blast-radius.md — if T3, a human/senior signs off below)
+
+## Plan
+- [ ] step 1
+- [ ] step 2
+- [ ] step 3
+
+## State of play (running log — newest at the bottom, timestamped)
+- HH:MM — what I did / found / decided. Cite the command or file, not a vibe.
+
+## Blockers
+- <what is blocking, and what would unblock it>
+
+## Decisions needing a human or senior model
+- <decision> — why it exceeds this tier (e.g. touches a blast-radius file). Recorded sign-off: <who/when>.
+
+## Pre-commit checklist (every commit)
+- [ ] subject measured: `s="..."; printf '%d %s\n' "${#s}" "$s"` ≤ 72, lowercase start, no trailing period
+- [ ] `bin/preflight` (or `--fast`) green
+- [ ] blast-radius files touched named in the PR body with a safety rationale (if any)
+- [ ] trailers present (Co-Authored-By, Claude-Session, Worksheet)
+
+## PR / watch
+- [ ] PR opened: #___
+- [ ] `bin/pr-watch <pr#>` exited 0  ← a PR is NOT done until this passes
+- Agents never merge — merge is James's.
+
+## Handoff notes (so a fresh session can resume)
+- Where things stand, what's next, what to avoid re-doing, any local state (branches, stashes, running clusters).
+
+## Outcome
+- What shipped, PR#, final state.
+
+## Feedback entry (copy into docs/agents/feedback.md)
+- What slowed me down + the proposed workflow fix.


### PR DESCRIPTION
## What

Repo-native infrastructure for making AI coding agents — especially cheaper models — productive here without hand-holding: externalized context (docs), executable verification (bin/), and bounded judgment (tiers). Docs/scripts only; **zero changes under `modules/` or `.github/`**.

- **`AGENTS.md`** — the router: read-first invariants, tier model (T0–1 free / T2 review-first / T3 propose-only, using the `agent-swarm-architecture` vocabulary), standard workflow (fetch → branch off origin/main → worksheet → preflight → PR → watch to green; merges stay with @scasplte2)
- **`docs/signing-canonical-and-validation.md`** — NEW; fixes the dangling CLAUDE.md reference. Full rationale behind the 3 invariants + guard-suite table. CLAUDE.md edit is minimal (invariant text byte-identical — no conflict with #210)
- **`docs/agents/review-personas/`** — 5 personas seeded from the real audits (consensus-safety, wire-compat, state-growth-determinism, asset-economics, ai-smells-test-integrity); each owns docs and carries a concrete checklist + defect classes with in-repo examples
- **`docs/agents/blast-radius.md`** — the consensus-critical file map with per-file WHY + escalation protocol
- **`docs/agents/{conventions,tools,process-observations,feedback}.md`** — the linter-unenforceable residue; bin-script authoring guide; candid evidence-cited process calls (opt-in gates, PR-watching, coverage-as-dashboard, deterministic proxies, publishing dry-runs, dep-bump automation); append-only session feedback log
- **`docs/worksheets/`** — committed, resumable session traces (template + two real worksheets: the OnChain-v2 session retro and this scaffold); `Worksheet:` commit trailer + `ws/<slug>` tag convention
- **`bin/`** — 8 scripts: `preflight` (format+lint+tests+OpenAPI-drift+commitlint+e2e-tsc — would have caught both of #210's CI failures locally), `test` (friendly module names + sbt batch fallback), `regen-openapi`, `pr-watch`, `tasks`, `agent-review`, `wire-size`, `worksheet`
- **`.claude/skills/{night-shift,commit-sweep,test-audit}`** — prescriptive autonomous-work procedures
- **`docs/INDEX.md`** — one-line summary of every doc in the repo

## Verified

- All 8 scripts: `bash -n` + `--help` clean; `bin/regen-openapi` no-op on main; `bin/test shared` maps + runs (4/4)
- `bin/preflight --fast` end-to-end: format/lint PASS, sharedData 641/641, openapi-drift PASS, commitlint PASS
- CLAUDE.md invariants byte-identical; markdown links resolved (5 fixed)
- Written against current main (#209); OnChain-v2 references explicitly flagged "arrives with #210"

Sibling PR scaffolds the same system in ottochain-sdk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R5TUSJPD8FCtJagf7siXgt