### PR TITLE
feat(nullifier): protocol nullifier set — state, effect token, surface

### DIFF
--- a/docs/openapi-ml0.json
+++ b/docs/openapi-ml0.json
@@ -993,7 +993,8 @@
           "usedNonces",
           "fiberCommits",
           "assetCommits",
-          "registryCommits"
+          "registryCommits",
+          "nullifiers"
         ],
         "properties" : {
           "stateMachines" : {
@@ -1021,6 +1022,9 @@
             "$ref" : "#/components/schemas/Map_V"
           },
           "registryCommits" : {
+            "$ref" : "#/components/schemas/Map_V"
+          },
+          "nullifiers" : {
             "$ref" : "#/components/schemas/Map_V"
           }
         }

--- a/docs/openapi-ml0.yaml
+++ b/docs/openapi-ml0.yaml
@@ -648,6 +648,7 @@ components:
       - fiberCommits
       - assetCommits
       - registryCommits
+      - nullifiers
       properties:
         stateMachines:
           $ref: '#/components/schemas/Map_V'
@@ -666,6 +667,8 @@ components:
         assetCommits:
           $ref: '#/components/schemas/Map_V'
         registryCommits:
+          $ref: '#/components/schemas/Map_V'
+        nullifiers:
           $ref: '#/components/schemas/Map_V'
     Checkpoint_CalculatedState:
       title: Checkpoint_CalculatedState

--- a/docs/proposals/asset-shielded-mode.md
+++ b/docs/proposals/asset-shielded-mode.md
@@ -10,14 +10,17 @@ integration**: a shielded representation on `AssetRecord`, a `ShieldedSpend` mor
 set as a TOTAL committed-view key** with a bounded-growth design, and selective-disclosure viewing
 keys. No new cryptography is proposed.
 
-> **This is a future, gated RFC — NOT low-hanging.** Per
-> `docs/proposals/asset-model-zk-extension.md`, the near-term zk wins are the **ZkVerify-gated
-> morphism** (already *shipped* — PR #166, `5267cc1`) and the **`Pool` morphism** (the lossy compose,
-> *in progress / recommended next*). This RFC is the *large* item: a subsystem gated on (1) a public
-> security audit of metakit's verifier — a **hard prerequisite** before it guards real value — and
-> (2) a nullifier-set state-rent / bounded-growth design. It is deliberately scoped *after* those two
-> wins. It does not change the public-by-default posture of `CalculatedState`; shielded is an opt-in
-> `AssetPolicy` flavor, never the base ledger.
+> **STATUS UPDATE (2026-07-16, maintainer decision):** the **nullifier-set portion of this RFC
+> (§3.3) is superseded by `docs/proposals/protocol-nullifier-set.md`** and is in active
+> implementation. The two former gates were re-scoped: (1) the external audit of metakit's
+> verifiers is a **pre-mainnet-value** gate, not a pre-implementation gate (we are pre-launch);
+> (2) **unbounded growth is ACCEPTED** for v1 — post-rc.7 incremental MPT + post-#210 per-batch
+> OnChain deltas make per-snapshot cost scale with touched keys, not set size; the working-copy
+> and checkpoint-serialization costs are managed (checkpoint exclusion), and the
+> `nullifier/<domain>/<nf>` key layout leaves epoch-windowing retrofittable (revisit trigger:
+> heap pressure / ~10M entries). The `ShieldedSpend` morphism, shielded `AssetPolicy` mode, and
+> viewing keys below REMAIN future work and will consume the protocol nullifier subsystem.
+> Shielded stays an opt-in `AssetPolicy` flavor, never the base ledger.
 
 **Companions:** `docs/proposals/asset-model-zk-extension.md` (the reconciled findings of record —
 this RFC is its §4 + roadmap items #4/#5 written up), `docs/proposals/zk-coin-audit.md` (the external

--- a/docs/proposals/protocol-nullifier-set.md
+++ b/docs/proposals/protocol-nullifier-set.md
@@ -1,0 +1,116 @@
+# Protocol Nullifier Set — design of record
+
+Status: **ACTIVE — in implementation** (2026-07-16). Supersedes the nullifier-set portion of
+`asset-shielded-mode.md` §3.3 (that RFC's `ShieldedSpend`/viewing-keys remain future work and
+will consume this subsystem). Maintainer decisions herein are final for v1; pre-launch, so no
+state-migration constraints apply.
+
+## 1. Decisions (and the reasoning that settled them)
+
+1. **Unbounded is accepted.** The classic "nullifier sets grow forever" objection targets the
+   wrong layer here: post-rc.7 the committed MPT updates incrementally (per-touched-key cost),
+   and post-#210 only per-batch `OnChain` deltas ride the wire. Disk is ~100 B/entry. The two
+   real unbounded costs are managed instead of designed around:
+   - the JVM working copy (`CalculatedState` is in-memory): mitigated by **excluding the set
+     from `/v1/checkpoint`** (dedicated routes instead) — the only whole-state JSON
+     serialization path;
+   - monotonic growth (a nullifier can never be pruned — pruning re-enables a double-spend):
+     the `nullifier/<domain>/<nf>` key layout leaves room to retrofit epoch partitioning
+     later without changing the light-client story. **Revisit trigger:** sustained heap
+     pressure from the map or ≳10M entries.
+2. **No audit gate on building.** External audit of the verifier stack is a *pre-mainnet-value*
+   gate, not a pre-implementation gate. (`asset-shielded-mode.md` updated accordingly.)
+3. **Domain = the consuming fiber's own id, always (v1).** `nullifier/<fiberId>/<nf>`. This
+   eliminates the cross-app griefing vector (nobody can insert into another app's namespace)
+   without needing an authorization design. Cross-fiber shared domains are follow-on work.
+4. **Consumption is an effect token, not a message or opcode.** `_consumeNullifier` joins
+   `_spawn/_transferAsset/_emit/_addDependency/...` in the existing `FiberDirective`/
+   `EffectKind` architecture: the transition's *effect* emits it (array form), the extractor
+   scrapes it from the AUTHORED AST only (injection-immune for free), and the combiner
+   enforces it. Zero VM/JLVM changes; any app (mixer, shieldApp, riverdale-health) opts in by
+   emitting the token.
+5. **Combiner-only enforcement (CLAUDE.md rule #2/#3).** All nullifiers in a transition are
+   checked absent and inserted atomically; any hit ⇒ graceful `CombineRejected("nullifier
+   already consumed …")` ⇒ `RejectionReceipt`. The check must NEVER appear in
+   `validateSignedUpdate` (stateful read at block validity = TOCTOU block poisoning).
+   Sequential combine gives intra-batch double-spend protection for free.
+6. **No `OnChain` / `CommitIndex` changes.** DL1 never reads nullifiers (stateful checks are
+   combiner-only), so the #210 delta shape and the L1 fast-path are untouched. The set lives
+   ONLY in `CalculatedState` + the committed projection.
+7. **Value = spend ordinal.** `nullifiers: SortedMap[UUID, SortedMap[Hash, SnapshotOrdinal]]`
+   — a spent-at receipt for near-zero cost; the committed leaf value is the ordinal JSON.
+8. **Light-client surface, two phases.**
+   - Phase A (this repo only): `GET /v1/nullifiers/{domain}/{nf}` (spent? + ordinal) and
+     **presence** proofs via the existing state-proof machinery (`CommitKey`
+     `nullifier/<domain>/<nf>` fits: 111 chars, 3 segments, charset-valid).
+   - Phase B (one metakit change): **MPT absence proofs**. Verified finding: the MPT layer is
+     inclusion-only today (`MerklePatriciaProver.attestPath` errors `PathNotFound` on a
+     missing key; the verifier fold must terminate in a Leaf; `mpt_prefix_verify` can prove
+     absence only by O(domain) complete enumeration and cannot represent an empty domain).
+     Fix mirrors the SMT package, which already models absence first-class
+     (`SparseMerkleProof.{Inclusion,Absence}`, `AbsenceWitness.{Default,OtherLeaf}`): add an
+     `Absence` MPT proof variant whose witness chain terminates in branch-missing-nibble /
+     divergent-extension / other-leaf, a prover arm where `PathNotFound` is raised today, a
+     verifier arm reusing the existing fold, and `Committed.proveKey` returning it. Then
+     ottochain serves it and `@ottochain/sdk verifyStateProof` gains the absence arm. This is
+     the one piece that needs a metakit release (1.8.0-rc.8).
+
+## 2. What this buys the flagship demo (riverdale-health)
+
+- "One script, one fill" moves from app-authored guard clause to **protocol-enforced
+  uniqueness** — a definition that forgets the check is still protected.
+- Fiber records stop accumulating nullifier maps in `stateData`: records and every state-proof
+  over them become **constant-size**.
+- The PDMP query: prove "this prescription is spent/unspent" with a **single
+  `nullifier/<domain>/<nf>` key against the consensus-signed root** — no fiber read, no
+  patient data. (Unspent needs Phase B absence proofs.)
+- No proof fixture regeneration: the M5 `exprHash` binds the in-guest effect, not the
+  on-chain definition, so migrating defs to `_consumeNullifier` is fixture-neutral.
+
+## 3. Implementation map (seams verified at file:line on main, post-#210)
+
+The `_transferAsset` trail is the model; `_addDependency` (self-fiber, emitter-keyed) is the
+closer analogue for domain-keying. Chain work (PR-1):
+
+- **models**: `ReservedKeys.CONSUME_NULLIFIER` (+ directive-field keys); `FiberDirective.
+  ConsumeNullifier` (total-match ⇒ forgetting a handler is a compile error);
+  `EffectKind.Nullifier` (UPPERCASE wire name; joins the `allowedEffects` dial);
+  `FiberEffect.NullifierConsumed(nullifier: Hash)`; `FiberResult.Success.
+  nullifierConsumptions = List.empty`; `TransactionResult.Committed.nullifierConsumptions:
+  Map[UUID, List[NullifierConsumed]] = Map.empty`; `ExecutionLimits.maxNullifierConsumptions`
+  (cap 32, mirroring `maxAssetMutations`); `CalculatedState.nullifiers` (trailing default —
+  test blast radius ≈ zero) + `committedView.entries` projection (TOTAL key derivation).
+- **shared-data**: `EffectExtractor` handler arm + `extractNullifierConsumptions` (clone
+  `extractAssetTransfers`: array directive, `evalOrReject` gas-charged, malformed = loud
+  `rejectDirective`, absent = no-op); `FiberEvaluator.buildSuccessOutcome` collect + the
+  fail-closed `allowedEffects` row; `FiberEngine` threading through
+  `processStateMachineSuccess → commitStateMachineSuccess → completeStateMachineTransaction`
+  with the emitter-keyed map (`Map(originalFiber.fiberId -> …)` — this IS the domain) +
+  cascade merge (clone `mergeAssetTransfers`; thread `TriggerHandler`/`TriggerDispatcher`);
+  `FiberCombiner.handleCommittedOutcome` applies via a new `NullifierCombiner`
+  (deterministic emitter sort, cap check, absent-check → insert at current ordinal, hit ⇒
+  `CombineRejected`); `DefinitionLinter` shape rule for the nf expression + auto-recognition
+  via `ReservedKeys.directiveKeys`.
+- **l0**: checkpoint slimming at the handler (`MetaHandler.checkpoint` returns
+  `state.copy(nullifiers = empty)` — canonical encoder untouched); `GET
+  /v1/nullifiers/{domain}/{nf}` route + `StateProofHandler.nullifier` (presence proof via
+  `proofFor(s"nullifier/$domain/$nf")`).
+- **Free wins confirmed**: `StateMerger` already strips `_`-prefixed keys from stateData;
+  directive injection from data-computed keys is dead by construction (authored-AST walk);
+  `RejectionReceipt.reason` is a free string (no enum change); genesis needs no seeding;
+  signing-canonical suites are unaffected (nullifiers is not a signed message);
+  `CommittedViewSuite` pins keys/sizes, not root hashes, so existing cases stay green.
+- **Tests**: extractor unit suite (clone `AssetTransferRecipientObjectFormSuite`); combiner
+  suite (clone `AssetFiberTransferSuite`): consume-ok, double-spend ⇒ receipt, cross-fiber
+  isolation (same nf, two domains, both succeed), cap exceeded, malformed directive,
+  `allowedEffects` denial; committed-view projection test (`nullifier/<uuid>/<hex>` keys).
+
+SDK work (PR-3, after PR-1 shape settles): `_consumeNullifier` in the fiber-app types +
+linter mirror, nullifier route client, checkpoint type note, Phase-B absence arm in
+`verifyStateProof`.
+
+## 4. Rollout
+
+PR-1 ottochain subsystem → PR-2 metakit MPT absence (+ rc.8) → PR-3 sdk surface →
+PR-4 riverdale-health migration (after PR-1 and the health lane PR both land) + README/design
+doc guarantee-table updates + privacy-handoff P0.1 status flip.

--- a/modules/l0/src/main/scala/xyz/kd5ujc/metagraph_l0/ML0Routes.scala
+++ b/modules/l0/src/main/scala/xyz/kd5ujc/metagraph_l0/ML0Routes.scala
@@ -74,6 +74,12 @@ class ML0Routes[F[_]: Async](
     case GET -> Root / "assets" / UUIDVar(id) / "state-proof" :? FieldQueryParam(field) =>
       stateProof.asset(id, field)
 
+    // --- nullifiers ---
+    // Spent-nullifier presence proof (protocol-nullifier-set.md): 200 + state proof when spent (record =
+    // spend ordinal), 404 when unspent/unknown. The nullifier set is excluded from /v1/checkpoint, so this
+    // (plus the committed key) is the ONLY read surface for it.
+    case GET -> Root / "nullifiers" / UUIDVar(domain) / nf => stateProof.nullifier(domain, nf)
+
     // --- registry ---
     case GET -> Root / "registry"                           => registry.all.toResponse
     case GET -> Root / "registry" / "reverse" / UUIDVar(id) => registry.reverse(id).toResponse

--- a/modules/l0/src/main/scala/xyz/kd5ujc/metagraph_l0/handlers/MetaHandler.scala
+++ b/modules/l0/src/main/scala/xyz/kd5ujc/metagraph_l0/handlers/MetaHandler.scala
@@ -3,6 +3,8 @@ package xyz.kd5ujc.metagraph_l0.handlers
 import cats.effect.Async
 import cats.syntax.all._
 
+import scala.collection.immutable.SortedMap
+
 import io.constellationnetwork.currency.dataApplication.{DataApplicationValidationError, L0NodeContext}
 import io.constellationnetwork.metagraph_sdk.lifecycle.CheckpointService
 import io.constellationnetwork.metagraph_sdk.std.Checkpoint
@@ -40,7 +42,13 @@ class MetaHandler[F[_]: Async](
     context.getOnChainState[OnChain]
 
   def checkpoint: F[Either[DataApplicationValidationError, Checkpoint[CalculatedState]]] =
-    checkpointService.get.map(_.asRight[DataApplicationValidationError])
+    checkpointService.get.map { cp =>
+      // The protocol nullifier set is UNBOUNDED (monotonic, never pruned — protocol-nullifier-set.md), and
+      // /v1/checkpoint is the only whole-state JSON serialization surface, so the set is EXCLUDED here — a
+      // handler-level slim ONLY (the canonical encoder / committed hashing paths are untouched). Nullifier
+      // reads are served by the dedicated GET /v1/nullifiers/{domain}/{nf} route + committed state proofs.
+      cp.copy(state = cp.state.copy(nullifiers = SortedMap.empty)).asRight[DataApplicationValidationError]
+    }
 
   /**
    * The full recreated commit maps at the last committed ordinal (onchain-incrementals RFC §3.4):

--- a/modules/l0/src/main/scala/xyz/kd5ujc/metagraph_l0/handlers/StateProofHandler.scala
+++ b/modules/l0/src/main/scala/xyz/kd5ujc/metagraph_l0/handlers/StateProofHandler.scala
@@ -6,9 +6,11 @@ import cats.effect.Async
 import cats.syntax.all._
 
 import io.constellationnetwork.metagraph_sdk.lifecycle.committed.{CommitKey, CommittedReader}
+import io.constellationnetwork.security.hash.Hash
 
 import xyz.kd5ujc.schema.CalculatedState
 import xyz.kd5ujc.schema.api.{ErrorResponse, StateProofResponse}
+import xyz.kd5ujc.schema.fiber.NullifierHex
 
 import io.circe.Json
 import io.circe.syntax.EncoderOps
@@ -36,6 +38,23 @@ class StateProofHandler[F[_]: Async](reader: CommittedReader[F, CalculatedState]
   /** Custody proof for an asset instance — mirrors `stateMachine`/`script` against the `asset/<id>` key. */
   def asset(id: UUID, field: Option[String]): F[Response[F]] =
     proofFor(s"asset/$id", field)(_.assets.get(id).map(_.asJson))
+
+  /**
+   * Spent-nullifier presence proof (protocol-nullifier-set.md Phase A) against the
+   * `nullifier/<domain>/<nf>` committed key; the proven record is the spend ordinal. `nf` is normalized
+   * through [[NullifierHex]] (the same normalizer the combiner-side extractor enforces) so the queried key is
+   * byte-identical to the committed one; a value that cannot normalize is a BadRequest. An UNSPENT nullifier
+   * is a 404 like the other handlers (MPT absence proofs are Phase B — metakit rc.8).
+   */
+  def nullifier(domain: UUID, nf: String): F[Response[F]] =
+    NullifierHex.normalize(nf) match {
+      case None =>
+        Response[F](Status.BadRequest)
+          .withEntity(ErrorResponse(s"nullifier must be 64 hex chars (optionally 0x-prefixed), got '$nf'"))
+          .pure[F]
+      case Some(hex) =>
+        proofFor(s"nullifier/$domain/$hex", None)(_.nullifiers.get(domain).flatMap(_.get(Hash(hex))).map(_.asJson))
+    }
 
   private def proofFor(keyStr: String, field: Option[String])(
     recordOf: CalculatedState => Option[Json]

--- a/modules/models/src/main/scala/xyz/kd5ujc/schema/CalculatedState.scala
+++ b/modules/models/src/main/scala/xyz/kd5ujc/schema/CalculatedState.scala
@@ -8,6 +8,7 @@ import scala.collection.immutable.{SortedMap, SortedSet}
 
 import io.constellationnetwork.currency.dataApplication.DataCalculatedState
 import io.constellationnetwork.metagraph_sdk.lifecycle.committed.{CommitKey, CommittedView}
+import io.constellationnetwork.schema.SnapshotOrdinal
 import io.constellationnetwork.security.hash.Hash
 
 import xyz.kd5ujc.schema.CodecConfiguration._
@@ -35,7 +36,13 @@ case class CalculatedState(
   // deltas — the two cannot diverge. Projected as commit/f|a|r/<id> leaves for provable DL1 healing.
   fiberCommits:    SortedMap[UUID, FiberCommit] = SortedMap.empty,
   assetCommits:    SortedMap[UUID, AssetCommit] = SortedMap.empty,
-  registryCommits: SortedMap[RegistryName, Hash] = SortedMap.empty
+  registryCommits: SortedMap[RegistryName, Hash] = SortedMap.empty,
+  // Protocol nullifier set (protocol-nullifier-set.md): domain (= consuming fiber id) -> nf (normalized
+  // 64-hex Hash) -> the ordinal it was spent at. MONOTONIC — never pruned (pruning re-enables a
+  // double-spend); unbounded growth is accepted here (CalculatedState is rooted, never wire-shipped) and the
+  // set is EXCLUDED from /v1/checkpoint (the only whole-state JSON path — see MetaHandler). Sole writer:
+  // NullifierCombiner (combiner-only enforcement, CLAUDE.md rules #2/#3).
+  nullifiers: SortedMap[UUID, SortedMap[Hash, SnapshotOrdinal]] = SortedMap.empty
 ) extends DataCalculatedState
 
 object CalculatedState {
@@ -68,6 +75,10 @@ object CalculatedState {
    *   - `commit/a/<uuid>` from `assetCommits`     these small leaves are what a DL1 heals its CommitIndex
    *   - `commit/r/<name>` from `registryCommits`  from, batch-proof-verified against the breadcrumb mptRoot
    *                        (over-long names fall back to `commit/r/h/<sha256>` like `registry/`)
+   *   - `nullifier/<uuid>/<nf>` from `nullifiers`; the leaf value is the spend-ordinal JSON. TOTAL: the
+   *                        domain is a UUID and the nf is exactly 64 lowercase hex chars (NullifierHex
+   *                        normalization is enforced before any insert), so the key always fits
+   *                        (9 + 36 + 1 + 64 = 110 chars, 3 segments each <= 64, charset-valid)
    *
    * Asset POLICIES need no projection of their own — they live in `registry` as `RegistryEntry`s
    * (`AssetPolicyPackage`) and are already covered by the `registry/<name>` key.
@@ -94,9 +105,12 @@ object CalculatedState {
         val fiberCommits = s.fiberCommits.toList.map { case (id, c) => CommitKey.unsafe(s"commit/f/$id") -> c.asJson }
         val assetCommits = s.assetCommits.toList.map { case (id, c) => CommitKey.unsafe(s"commit/a/$id") -> c.asJson }
         val registryCommits = s.registryCommits.toList.map { case (n, h) => commitRegistryKey(n) -> h.asJson }
+        val nullifiers = s.nullifiers.toList.flatMap { case (dom, nfs) =>
+          nfs.toList.map { case (nf, ord) => CommitKey.unsafe(s"nullifier/$dom/${nf.value}") -> ord.asJson }
+        }
         SortedMap.from(
           fibers ::: scripts ::: registry ::: reverse ::: assets ::: nonces :::
-          fiberCommits ::: assetCommits ::: registryCommits
+          fiberCommits ::: assetCommits ::: registryCommits ::: nullifiers
         )
       }
     }

--- a/modules/models/src/main/scala/xyz/kd5ujc/schema/CodecConfiguration.scala
+++ b/modules/models/src/main/scala/xyz/kd5ujc/schema/CodecConfiguration.scala
@@ -1,6 +1,9 @@
 package xyz.kd5ujc.schema
 
+import io.constellationnetwork.security.hash.Hash
+
 import io.circe.magnolia.configured.Configuration
+import io.circe.{KeyDecoder, KeyEncoder}
 
 /**
  * Shared codec configuration for all OttoChain schema types.
@@ -18,4 +21,11 @@ object CodecConfiguration {
 
   implicit val magnoliaConfiguration: Configuration =
     Configuration.default.withDefaults
+
+  // Hash as a JSON-object map KEY (tessellation derives only the value-position Encoder/Decoder). Renders as
+  // its plain string value — the same bytes as the value-position codec — so `SortedMap[Hash, *]` fields
+  // (e.g. `CalculatedState.nullifiers` inner maps) round-trip byte-stably. No validation on decode, matching
+  // the value-position decoder (Hash is a plain string wrapper).
+  implicit val hashKeyEncoder: KeyEncoder[Hash] = KeyEncoder.encodeKeyString.contramap(_.value)
+  implicit val hashKeyDecoder: KeyDecoder[Hash] = KeyDecoder.decodeKeyString.map(Hash(_))
 }

--- a/modules/models/src/main/scala/xyz/kd5ujc/schema/fiber/ExecutionLimits.scala
+++ b/modules/models/src/main/scala/xyz/kd5ujc/schema/fiber/ExecutionLimits.scala
@@ -31,13 +31,19 @@ package xyz.kd5ujc.schema.fiber
  *                          (the same source-of-truth pattern `maxAssetMutations` etc. use), NOT per-operator
  *                          config. Value chosen: 16 (greenfield — no live pinned-constitution fibers to brick;
  *                          ordered between maxAssetMutations=32 and maxActiveDependencies=64).
+ * @param maxNullifierConsumptions Maximum number of `_consumeNullifier` items applied per emitting fiber per
+ *                          transition (protocol-nullifier-set.md). Bounds nullifier-set growth per transaction
+ *                          independently of gas, mirroring `maxAssetMutations` (same value, same
+ *                          consensus-constant discipline: enforced in `NullifierCombiner` as a graceful
+ *                          CombineRejected, never at block acceptance).
  */
 final case class ExecutionLimits(
-  maxDepth:               Int = 10,
-  maxGas:                 Long = 10_000_000L,
-  maxStateSizeBytes:      Int = 1_048_576, // 1MB
-  maxAssetMutations:      Int = 32,
-  maxActiveDependencies:  Int = 64,
-  maxDependencyLedger:    Int = 256,
-  maxSpawnsPerTransition: Int = 16
+  maxDepth:                 Int = 10,
+  maxGas:                   Long = 10_000_000L,
+  maxStateSizeBytes:        Int = 1_048_576, // 1MB
+  maxAssetMutations:        Int = 32,
+  maxActiveDependencies:    Int = 64,
+  maxDependencyLedger:      Int = 256,
+  maxSpawnsPerTransition:   Int = 16,
+  maxNullifierConsumptions: Int = 32
 )

--- a/modules/models/src/main/scala/xyz/kd5ujc/schema/fiber/FiberDirective.scala
+++ b/modules/models/src/main/scala/xyz/kd5ujc/schema/fiber/FiberDirective.scala
@@ -34,6 +34,12 @@ object FiberDirective extends Enum[FiberDirective] {
         EffectKind.Dependency
       )
 
+  // Protocol nullifier consumption (protocol-nullifier-set.md): the effect's `_consumeNullifier` array items
+  // are bare nf VALUES (strings / evaluated sub-expressions), not objects — the domain is ALWAYS the emitting
+  // fiber's own id, stamped by the engine, never authored. Appended last, so nullifier effects emit after the
+  // pre-existing families (emission order = declaration order, see the scaladoc above).
+  case object ConsumeNullifier extends FiberDirective(Set(ReservedKeys.CONSUME_NULLIFIER), EffectKind.Nullifier)
+
   /**
    * Reserved keys honoured from the post-evaluation RESULT position — i.e. every directive EXCEPT `_spawn`,
    * which is sourced from the authored effect EXPRESSION (and so was already injection-immune). The

--- a/modules/models/src/main/scala/xyz/kd5ujc/schema/fiber/FiberEffect.scala
+++ b/modules/models/src/main/scala/xyz/kd5ujc/schema/fiber/FiberEffect.scala
@@ -2,6 +2,8 @@ package xyz.kd5ujc.schema.fiber
 
 import java.util.UUID
 
+import io.constellationnetwork.security.hash.Hash
+
 import xyz.kd5ujc.schema.CodecConfiguration._
 import xyz.kd5ujc.schema.asset.AssetHolder
 
@@ -56,4 +58,15 @@ object FiberEffect {
    */
   @derive(customizableEncoder, customizableDecoder)
   final case class DependencyMutated(fiberId: UUID, active: Boolean) extends FiberEffect
+
+  /**
+   * A protocol nullifier consumption (`_consumeNullifier`, protocol-nullifier-set.md). Carries the RESOLVED,
+   * NORMALIZED nf value (64 lowercase hex chars, `0x` stripped — enforced at extraction, [[xyz.kd5ujc.shared_data.fiber.evaluation.EffectExtractor]]).
+   * The DOMAIN is NOT carried here: it is ALWAYS the emitting fiber's own id, stamped by the engine when it
+   * keys the per-transaction map (`Map(emitterFiberId -> consumptions)`) — an effect can never consume into
+   * another app's namespace. Enforcement (absent-check → insert at the current ordinal, double-spend ⇒
+   * graceful `CombineRejected`) lives ONLY in the combiner (`NullifierCombiner`), never at block acceptance.
+   */
+  @derive(customizableEncoder, customizableDecoder)
+  final case class NullifierConsumed(nullifier: Hash) extends FiberEffect
 }

--- a/modules/models/src/main/scala/xyz/kd5ujc/schema/fiber/FiberPolicy.scala
+++ b/modules/models/src/main/scala/xyz/kd5ujc/schema/fiber/FiberPolicy.scala
@@ -14,7 +14,7 @@ import enumeratum.{CirceEnum, Enum, EnumEntry}
 import io.circe.{Decoder, DecodingFailure, Encoder, Json}
 
 /**
- * The 5 directive families [[xyz.kd5ujc.shared_data.fiber.evaluation.EffectExtractor]] scrapes from a
+ * The 6 directive families [[xyz.kd5ujc.shared_data.fiber.evaluation.EffectExtractor]] scrapes from a
  * transition's effect result. A fiber's [[FiberPolicy.Constrained.allowedEffects]] (when set) restricts which of
  * these its transitions may produce. Entry names are UPPERCASE on the wire (`"TRIGGER"`, `"SPAWN"`, …) — the
  * cross-language string contract with the SDK builder.
@@ -29,6 +29,7 @@ object EffectKind extends Enum[EffectKind] with CirceEnum[EffectKind] {
   case object Emit extends EffectKind // _emit
   case object Transfer extends EffectKind // _transferAsset
   case object Dependency extends EffectKind // _addDependency / _setDependencyActive
+  case object Nullifier extends EffectKind // _consumeNullifier (protocol-nullifier-set.md)
 }
 
 /**

--- a/modules/models/src/main/scala/xyz/kd5ujc/schema/fiber/FiberResult.scala
+++ b/modules/models/src/main/scala/xyz/kd5ujc/schema/fiber/FiberResult.scala
@@ -37,7 +37,10 @@ object FiberResult {
     returnValue:         Option[JsonLogicValue],
     emittedEvents:       List[EmittedEvent] = List.empty,
     assetTransfers:      List[FiberEffect.AssetTransferred] = List.empty,
-    dependencyMutations: List[FiberEffect.DependencyMutated] = List.empty
+    dependencyMutations: List[FiberEffect.DependencyMutated] = List.empty,
+    // `_consumeNullifier` consumptions (protocol-nullifier-set.md). Same in-process-only default rationale
+    // as assetTransfers; the combiner (NullifierCombiner) is the sole enforcement site.
+    nullifierConsumptions: List[FiberEffect.NullifierConsumed] = List.empty
   ) extends FiberResult
 
   /**

--- a/modules/models/src/main/scala/xyz/kd5ujc/schema/fiber/NullifierHex.scala
+++ b/modules/models/src/main/scala/xyz/kd5ujc/schema/fiber/NullifierHex.scala
@@ -1,0 +1,26 @@
+package xyz.kd5ujc.schema.fiber
+
+/**
+ * THE canonical nullifier-value normalizer (protocol-nullifier-set.md). A nullifier is the 64-char lowercase
+ * hex rendering of a Hash; clients may author it with or without a `0x` prefix and in any case. Every surface
+ * that accepts an nf value (the `_consumeNullifier` extractor, the offline linter, the `/v1/nullifiers` route)
+ * MUST normalize through here so the committed `nullifier/<domain>/<nf>` key is byte-identical everywhere.
+ *
+ * Normalization: strip one optional leading `0x`/`0X`, lowercase, then require EXACTLY 64 chars of
+ * `[0-9a-f]`. Anything else is `None` — the caller decides its loud-rejection mode (graceful
+ * `CombineRejected` in the extractor, BadRequest on the route, advisory diagnostic in the linter).
+ *
+ * The 64-hex guarantee is also what keeps the committed-key derivation TOTAL: the `<nf>` segment is exactly
+ * 64 chars of the CommitKey charset, so `CommitKey.unsafe(s"nullifier/$domain/$nf")` can never throw.
+ */
+object NullifierHex {
+
+  private val HexPattern = "^[0-9a-f]{64}$".r
+
+  /** `Some(normalized 64-hex)` or `None` when the value cannot be a nullifier. */
+  def normalize(raw: String): Option[String] = {
+    val stripped = if (raw.length >= 2 && (raw.startsWith("0x") || raw.startsWith("0X"))) raw.drop(2) else raw
+    val lowered = stripped.toLowerCase
+    if (HexPattern.matches(lowered)) Some(lowered) else None
+  }
+}

--- a/modules/models/src/main/scala/xyz/kd5ujc/schema/fiber/ReservedKeys.scala
+++ b/modules/models/src/main/scala/xyz/kd5ujc/schema/fiber/ReservedKeys.scala
@@ -21,6 +21,9 @@ object ReservedKeys {
   val ADD_DEPENDENCY = "_addDependency" // Runtime-add/re-activate a dynamic cross-fiber dependency (append-only ledger)
   val SET_DEPENDENCY_ACTIVE = "_setDependencyActive" // Toggle a dynamic dependency's active flag (never removed)
 
+  val CONSUME_NULLIFIER =
+    "_consumeNullifier" // Protocol nullifier consumption (protocol-nullifier-set.md); items are bare nf values
+
   /** Every reserved directive key — derived from [[FiberDirective]] so a new directive updates all consumers. */
   val directiveKeys: Set[String] = FiberDirective.values.flatMap(_.keys).toSet
 

--- a/modules/models/src/main/scala/xyz/kd5ujc/schema/fiber/TransactionResult.scala
+++ b/modules/models/src/main/scala/xyz/kd5ujc/schema/fiber/TransactionResult.scala
@@ -35,7 +35,12 @@ object TransactionResult {
     totalGasUsed:         Long,
     maxDepth:             Int = 0,
     operationCount:       Long = 0L,
-    assetTransfers:       Map[UUID, List[FiberEffect.AssetTransferred]] = Map.empty
+    assetTransfers:       Map[UUID, List[FiberEffect.AssetTransferred]] = Map.empty,
+    // `_consumeNullifier` consumptions keyed by the EMITTING fiber id — which IS the nullifier DOMAIN
+    // (protocol-nullifier-set.md decision #3: domain = the consuming fiber's own id, always). The combiner
+    // (NullifierCombiner) enforces absent-check → insert at the current ordinal; a hit is a graceful
+    // CombineRejected. Same in-process default rationale as assetTransfers.
+    nullifierConsumptions: Map[UUID, List[FiberEffect.NullifierConsumed]] = Map.empty
   ) extends TransactionResult
 
   /**

--- a/modules/models/src/main/scala/xyz/kd5ujc/schema/fiber/TriggerHandlerResult.scala
+++ b/modules/models/src/main/scala/xyz/kd5ujc/schema/fiber/TriggerHandlerResult.scala
@@ -21,7 +21,10 @@ object TriggerHandlerResult {
   final case class Success(
     updatedState:    CalculatedState,
     cascadeTriggers: List[FiberTrigger],
-    assetTransfers:  List[FiberEffect.AssetTransferred] = List.empty
+    assetTransfers:  List[FiberEffect.AssetTransferred] = List.empty,
+    // `_consumeNullifier` consumptions emitted by THIS triggered transition; the dispatcher keys them by the
+    // triggered (emitting) fiber id — which IS the nullifier domain (protocol-nullifier-set.md).
+    nullifierConsumptions: List[FiberEffect.NullifierConsumed] = List.empty
   ) extends TriggerHandlerResult
 
   /**

--- a/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/fiber/DefinitionLinter.scala
+++ b/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/fiber/DefinitionLinter.scala
@@ -5,7 +5,14 @@ import cats.Id
 import io.constellationnetwork.metagraph_sdk.json_logic._
 
 import xyz.kd5ujc.schema.asset.AssetHolder
-import xyz.kd5ujc.schema.fiber.{FiberContextRoot, ReservedKeys, StateId, StateMachineDefinition, Transition}
+import xyz.kd5ujc.schema.fiber.{
+  FiberContextRoot,
+  NullifierHex,
+  ReservedKeys,
+  StateId,
+  StateMachineDefinition,
+  Transition
+}
 import xyz.kd5ujc.schema.registry.MachineShape
 import xyz.kd5ujc.shared_data.lifecycle.validate.rules.{CommonRules, FiberRules}
 
@@ -100,6 +107,7 @@ object DefinitionLinter {
       checkVarPaths(t, idx, writtenFields, declaredStateFields, shape) ++
       checkDirectives(t, idx) ++
       checkTransferRecipients(t, idx) ++
+      checkNullifierValues(t, idx) ++
       checkInjectionHazard(t, idx) ++
       checkWrites(t, idx, shape)
     }
@@ -337,6 +345,73 @@ object DefinitionLinter {
       case ConstExpression(MapValue(m)) => m.contains(key)
       case _                            => false
     }
+
+  // ==========================================================================
+  // (b2b) `_consumeNullifier` value shape (bare 64-hex nf values)
+  // ==========================================================================
+
+  /**
+   * A `_consumeNullifier` array item is a bare nf VALUE: a string literal that normalizes to 64 hex chars
+   * (optional `0x` prefix — [[NullifierHex]], the same normalizer the chain enforces at extraction), OR a
+   * dynamic expression (`var`/`cat`/`substr`/…) whose resolved value the combiner checks. This is the offline
+   * shift-left for the extractor's loud `CombineRejected`: an obviously-wrong LITERAL (a string that can never
+   * normalize, or a non-string constant) is flagged here, before the definition is signed. Advisory Warnings —
+   * the chain gate is the extractor.
+   */
+  private def checkNullifierValues(t: Transition, idx: Int): List[Diagnostic] =
+    nullifierItemExprs(t.effect).flatMap(nullifierDiagnostic(_, idx))
+
+  /** Pull each `_consumeNullifier` item sub-expression out of an effect (descends if/merge nesting). */
+  private def nullifierItemExprs(expr: JsonLogicExpression): List[JsonLogicExpression] =
+    expr match {
+      case MapExpression(map) =>
+        map.get(ReservedKeys.CONSUME_NULLIFIER).toList.flatMap(nullifierItemsOfArray) ++
+        map.values.toList.collect { case a: ApplyExpression => a }.flatMap(nullifierItemExprs)
+      case ConstExpression(MapValue(map)) =>
+        map.get(ReservedKeys.CONSUME_NULLIFIER).toList.flatMap {
+          case ArrayValue(items) => items.map(ConstExpression(_): JsonLogicExpression)
+          case _                 => Nil
+        }
+      case ApplyExpression(_, args) => args.flatMap(nullifierItemExprs)
+      case _                        => Nil
+    }
+
+  private def nullifierItemsOfArray(arr: JsonLogicExpression): List[JsonLogicExpression] =
+    arr match {
+      case ArrayExpression(items)             => items
+      case ConstExpression(ArrayValue(items)) => items.map(ConstExpression(_): JsonLogicExpression)
+      case _                                  => Nil
+    }
+
+  /** Classify one item's STATIC shape (None == plausibly-valid literal, or dynamic / not statically checkable). */
+  private def nullifierDiagnostic(item: JsonLogicExpression, idx: Int): Option[Diagnostic] = {
+    val loc = Location(Some(idx), "effect", Some(ReservedKeys.CONSUME_NULLIFIER))
+    item match {
+      case ConstExpression(StrValue(s)) if NullifierHex.normalize(s).isDefined => None
+      case ConstExpression(StrValue(s)) =>
+        Some(
+          Diagnostic(
+            Severity.Warning,
+            "nullifier-literal-malformed",
+            s"""_consumeNullifier literal "$s" does not normalize to 64 hex chars """ +
+            s"(optionally 0x-prefixed); the chain rejects it at combine",
+            loc
+          )
+        )
+      case ConstExpression(_) =>
+        Some(
+          Diagnostic(
+            Severity.Warning,
+            "nullifier-literal-malformed",
+            "_consumeNullifier item must be a 64-hex string (or a dynamic expression); " +
+            "this non-string literal can never normalize and the chain rejects it at combine",
+            loc
+          )
+        )
+      // dynamic ({"var":..} / computed) — the resolved value is checked at combine (loud reject)
+      case _ => None
+    }
+  }
 
   // ==========================================================================
   // (b3) directive-injection hazard — dynamically-computed TOP-LEVEL effect keys

--- a/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/fiber/FiberEngine.scala
+++ b/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/fiber/FiberEngine.scala
@@ -398,7 +398,8 @@ object FiberEngine {
                   returnValue,
                   emittedEvents,
                   assetTransfers,
-                  dependencyMutations
+                  dependencyMutations,
+                  nullifierConsumptions
                 ) =>
               fiber match {
                 case sm: Records.StateMachineFiberRecord =>
@@ -411,7 +412,8 @@ object FiberEngine {
                     spawns,
                     emittedEvents,
                     assetTransfers,
-                    dependencyMutations
+                    dependencyMutations,
+                    nullifierConsumptions
                   )
 
                 case script: Records.ScriptFiberRecord =>
@@ -452,15 +454,16 @@ object FiberEngine {
         }
 
       private def processStateMachineSuccess(
-        sm:                  Records.StateMachineFiberRecord,
-        input:               FiberInput,
-        newStateData:        JsonLogicValue,
-        newStateId:          Option[StateId],
-        triggers:            List[FiberTrigger],
-        spawns:              List[SpawnDirective],
-        emittedEvents:       List[EmittedEvent],
-        assetTransfers:      List[FiberEffect.AssetTransferred],
-        dependencyMutations: List[FiberEffect.DependencyMutated]
+        sm:                    Records.StateMachineFiberRecord,
+        input:                 FiberInput,
+        newStateData:          JsonLogicValue,
+        newStateId:            Option[StateId],
+        triggers:              List[FiberTrigger],
+        spawns:                List[SpawnDirective],
+        emittedEvents:         List[EmittedEvent],
+        assetTransfers:        List[FiberEffect.AssetTransferred],
+        dependencyMutations:   List[FiberEffect.DependencyMutated],
+        nullifierConsumptions: List[FiberEffect.NullifierConsumed]
       ): FiberT[F, TransactionResult] =
         // #33 runtime conformance gate: a strict-bound fiber's produced state must conform, else abort.
         ConformanceChecker.violationsFor(sm.schemaBinding, calculatedState, newStateData) match {
@@ -476,20 +479,22 @@ object FiberEngine {
               spawns,
               emittedEvents,
               assetTransfers,
-              dependencyMutations
+              dependencyMutations,
+              nullifierConsumptions
             )
         }
 
       private def commitStateMachineSuccess(
-        sm:                  Records.StateMachineFiberRecord,
-        input:               FiberInput,
-        newStateData:        JsonLogicValue,
-        newStateId:          Option[StateId],
-        triggers:            List[FiberTrigger],
-        spawns:              List[SpawnDirective],
-        emittedEvents:       List[EmittedEvent],
-        assetTransfers:      List[FiberEffect.AssetTransferred],
-        dependencyMutations: List[FiberEffect.DependencyMutated]
+        sm:                    Records.StateMachineFiberRecord,
+        input:                 FiberInput,
+        newStateData:          JsonLogicValue,
+        newStateId:            Option[StateId],
+        triggers:              List[FiberTrigger],
+        spawns:                List[SpawnDirective],
+        emittedEvents:         List[EmittedEvent],
+        assetTransfers:        List[FiberEffect.AssetTransferred],
+        dependencyMutations:   List[FiberEffect.DependencyMutated],
+        nullifierConsumptions: List[FiberEffect.NullifierConsumed]
       ): FiberT[F, TransactionResult] =
         for {
           limits <- ExecutionOps.askLimits[FiberT[F, *]]
@@ -534,7 +539,7 @@ object FiberEngine {
 
                 r <- spawnResult.fold(
                   errors => aborted(errors.head),
-                  completeStateMachineTransaction(sm, updatedFiber, _, triggers, assetTransfers)
+                  completeStateMachineTransaction(sm, updatedFiber, _, triggers, assetTransfers, nullifierConsumptions)
                 )
               } yield r
           )
@@ -676,11 +681,12 @@ object FiberEngine {
       }
 
       private def completeStateMachineTransaction(
-        originalFiber:  Records.StateMachineFiberRecord,
-        updatedFiber:   Records.StateMachineFiberRecord,
-        spawnedFibers:  List[Records.StateMachineFiberRecord],
-        triggers:       List[FiberTrigger],
-        assetTransfers: List[FiberEffect.AssetTransferred]
+        originalFiber:         Records.StateMachineFiberRecord,
+        updatedFiber:          Records.StateMachineFiberRecord,
+        spawnedFibers:         List[Records.StateMachineFiberRecord],
+        triggers:              List[FiberTrigger],
+        assetTransfers:        List[FiberEffect.AssetTransferred],
+        nullifierConsumptions: List[FiberEffect.NullifierConsumed]
       ): FiberT[F, TransactionResult] = {
         val parentWithChildren = updatedFiber.copy(
           childFiberIds = updatedFiber.childFiberIds ++ spawnedFibers.map(_.fiberId)
@@ -698,26 +704,40 @@ object FiberEngine {
           if (assetTransfers.isEmpty) Map.empty
           else Map(originalFiber.fiberId -> assetTransfers)
 
+        // The primary fiber's _consumeNullifier effects, keyed by the EMITTING fiber id — this stamp IS the
+        // nullifier DOMAIN (protocol-nullifier-set.md decision #3): an effect can never name another app's
+        // namespace because the key is engine-supplied, never authored.
+        val primaryNullifierConsumptions: Map[UUID, List[FiberEffect.NullifierConsumed]] =
+          if (nullifierConsumptions.isEmpty) Map.empty
+          else Map(originalFiber.fiberId -> nullifierConsumptions)
+
         triggers.isEmpty
           .pure[FiberT[F, *]]
           .ifM(
-            ifTrue =
-              commitWithoutTriggers(originalFiber.fiberId, parentWithChildren, spawnedFibers, primaryAssetTransfers),
+            ifTrue = commitWithoutTriggers(
+              originalFiber.fiberId,
+              parentWithChildren,
+              spawnedFibers,
+              primaryAssetTransfers,
+              primaryNullifierConsumptions
+            ),
             ifFalse = dispatchTriggers(
               originalFiber.fiberId,
               spawnedFibers,
               triggers,
               stateWithSpawns,
-              primaryAssetTransfers
+              primaryAssetTransfers,
+              primaryNullifierConsumptions
             )
           )
       }
 
       private def commitWithoutTriggers(
-        primaryFiberId: UUID,
-        updatedFiber:   Records.StateMachineFiberRecord,
-        spawnedFibers:  List[Records.StateMachineFiberRecord],
-        assetTransfers: Map[UUID, List[FiberEffect.AssetTransferred]]
+        primaryFiberId:        UUID,
+        updatedFiber:          Records.StateMachineFiberRecord,
+        spawnedFibers:         List[Records.StateMachineFiberRecord],
+        assetTransfers:        Map[UUID, List[FiberEffect.AssetTransferred]],
+        nullifierConsumptions: Map[UUID, List[FiberEffect.NullifierConsumed]]
       ): FiberT[F, TransactionResult] =
         for {
           gasUsed    <- ExecutionOps.getGasUsed[FiberT[F, *]]
@@ -731,29 +751,42 @@ object FiberEngine {
             logEntries = logEntries.toList,
             totalGasUsed = gasUsed,
             maxDepth = depth,
-            assetTransfers = assetTransfers
+            assetTransfers = assetTransfers,
+            nullifierConsumptions = nullifierConsumptions
           ): TransactionResult
         }
 
       private def dispatchTriggers(
-        primaryFiberId:        UUID,
-        spawnedFibers:         List[Records.StateMachineFiberRecord],
-        triggers:              List[FiberTrigger],
-        stateWithSpawns:       CalculatedState,
-        primaryAssetTransfers: Map[UUID, List[FiberEffect.AssetTransferred]]
+        primaryFiberId:               UUID,
+        spawnedFibers:                List[Records.StateMachineFiberRecord],
+        triggers:                     List[FiberTrigger],
+        stateWithSpawns:              CalculatedState,
+        primaryAssetTransfers:        Map[UUID, List[FiberEffect.AssetTransferred]],
+        primaryNullifierConsumptions: Map[UUID, List[FiberEffect.NullifierConsumed]]
       ): FiberT[F, TransactionResult] = {
         val _ = primaryFiberId
         TriggerDispatcher
           .make[F, FiberT[F, *]]
           .dispatch(triggers, stateWithSpawns)
           .flatMap {
-            case TransactionResult.Committed(machines, scripts, _, totalGas, maxDepth, opCount, cascadeTransfers) =>
+            case TransactionResult.Committed(
+                  machines,
+                  scripts,
+                  _,
+                  totalGas,
+                  maxDepth,
+                  opCount,
+                  cascadeTransfers,
+                  cascadeNullifiers
+                ) =>
               ExecutionOps.getLogs[FiberT[F, *]].map { logs =>
                 val allMachines = spawnedFibers.map(f => f.fiberId -> f).toMap ++ machines
                 // Merge the primary fiber's transfers with the cascade's per-fiber maps. The keys are the
                 // EMITTING fiber ids; a fiber that emits in both its own transition and a re-entered cascade
                 // gets its lists concatenated (single combiner pass still applies them once each — R20).
                 val mergedTransfers = mergeAssetTransfers(primaryAssetTransfers, cascadeTransfers)
+                // Same merge for nullifier consumptions: emitter-keyed (= domain-keyed) lists concatenate.
+                val mergedNullifiers = mergeNullifierConsumptions(primaryNullifierConsumptions, cascadeNullifiers)
                 TransactionResult.Committed(
                   updatedStateMachines = allMachines,
                   updatedScripts = scripts,
@@ -761,7 +794,8 @@ object FiberEngine {
                   totalGasUsed = totalGas,
                   maxDepth = maxDepth,
                   operationCount = opCount,
-                  assetTransfers = mergedTransfers
+                  assetTransfers = mergedTransfers,
+                  nullifierConsumptions = mergedNullifiers
                 ): TransactionResult
               }
 
@@ -777,6 +811,15 @@ object FiberEngine {
       ): Map[UUID, List[FiberEffect.AssetTransferred]] =
         b.foldLeft(a) { case (acc, (fid, ts)) =>
           acc.updated(fid, acc.getOrElse(fid, List.empty) ++ ts)
+        }
+
+      /** Merge two emitter-keyed (= domain-keyed) nullifier-consumption maps by concatenating per-fiber lists. */
+      private def mergeNullifierConsumptions(
+        a: Map[UUID, List[FiberEffect.NullifierConsumed]],
+        b: Map[UUID, List[FiberEffect.NullifierConsumed]]
+      ): Map[UUID, List[FiberEffect.NullifierConsumed]] =
+        b.foldLeft(a) { case (acc, (fid, ns)) =>
+          acc.updated(fid, acc.getOrElse(fid, List.empty) ++ ns)
         }
 
       private def processScriptSuccess(

--- a/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/fiber/evaluation/EffectExtractor.scala
+++ b/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/fiber/evaluation/EffectExtractor.scala
@@ -9,6 +9,7 @@ import cats.{Monad, ~>}
 
 import io.constellationnetwork.metagraph_sdk.json_logic._
 import io.constellationnetwork.metagraph_sdk.json_logic.core.{BoolValue, MapValue, StrValue}
+import io.constellationnetwork.security.hash.Hash
 
 import xyz.kd5ujc.schema.asset.AssetHolder
 import xyz.kd5ujc.schema.fiber._
@@ -148,6 +149,9 @@ object EffectExtractor {
 
       case FiberDirective.Dependency =>
         ctx => extractDependencyMutations[F, G](ctx.authored, ctx.contextData).map(_.map(x => x: FiberEffect))
+
+      case FiberDirective.ConsumeNullifier =>
+        ctx => extractNullifierConsumptions[F, G](ctx.authored, ctx.contextData).map(_.map(x => x: FiberEffect))
     }
 
   /**
@@ -494,6 +498,57 @@ object EffectExtractor {
         rejectDirective[F, G, FiberEffect.AssetTransferred](
           "_transferAsset",
           s"malformed item (expected an object), got $other"
+        )
+    }
+
+  /**
+   * Extract protocol nullifier consumptions (`_consumeNullifier`, protocol-nullifier-set.md) with gas
+   * metering. Mirrors [[extractAssetTransfers]], but each array ITEM is a bare nf VALUE (a string literal or
+   * a sub-expression that evaluates to one) — no object wrapper, no domain field: the domain is ALWAYS the
+   * emitting fiber's own id, stamped later by the engine. Each item is RESOLVED here against the transition
+   * context (gas charged under [[GasExhaustionPhase.Effect]]), then NORMALIZED through [[NullifierHex]]
+   * (strip optional `0x`, lowercase, require exactly 64 hex chars). A malformed item (non-string, bad hex, or
+   * a gas/eval failure) raises a graceful [[CombineRejected]] — LOUD, never a silent drop (L5 discipline); an
+   * ABSENT directive is a no-op (empty list).
+   *
+   * SECURITY: this extractor carries NO enforcement. The combiner
+   * ([[xyz.kd5ujc.shared_data.lifecycle.combine.NullifierCombiner]]) does the absent-check → insert (and the
+   * double-spend / cap rejection) against the authoritative `CalculatedState.nullifiers`.
+   */
+  def extractNullifierConsumptions[F[_]: Async, G[_]: Monad](
+    effectResult: JsonLogicValue,
+    contextData:  JsonLogicValue
+  )(implicit
+    S:    Stateful[G, ExecutionState],
+    A:    Ask[G, FiberContext],
+    lift: F ~> G
+  ): G[List[FiberEffect.NullifierConsumed]] =
+    extractArrayByKey(effectResult, ReservedKeys.CONSUME_NULLIFIER)
+      .traverse(item => parseNullifierConsumption[F, G](item, contextData))
+
+  /** Parse ONE `_consumeNullifier` item: evaluate (metered), require a string, normalize to 64-hex or reject. */
+  private def parseNullifierConsumption[F[_]: Async, G[_]: Monad](
+    value:       JsonLogicValue,
+    contextData: JsonLogicValue
+  )(implicit
+    S:    Stateful[G, ExecutionState],
+    A:    Ask[G, FiberContext],
+    lift: F ~> G
+  ): G[FiberEffect.NullifierConsumed] =
+    evalOrReject[F, G](value, contextData, GasExhaustionPhase.Effect, "_consumeNullifier", "nullifier").flatMap {
+      case StrValue(raw) =>
+        NullifierHex
+          .normalize(raw)
+          .fold(
+            rejectDirective[F, G, FiberEffect.NullifierConsumed](
+              "_consumeNullifier",
+              s"nullifier must be 64 hex chars (optionally 0x-prefixed), got '$raw'"
+            )
+          )(hex => FiberEffect.NullifierConsumed(Hash(hex)).pure[G])
+      case other =>
+        rejectDirective[F, G, FiberEffect.NullifierConsumed](
+          "_consumeNullifier",
+          s"nullifier must be a hex string, got $other"
         )
     }
 

--- a/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/fiber/evaluation/FiberEvaluator.scala
+++ b/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/fiber/evaluation/FiberEvaluator.scala
@@ -338,6 +338,7 @@ object FiberEvaluator {
           emittedEvents = effects.collect { case FiberEffect.Emitted(ev) => ev }
           assetTransfers = effects.collect { case t: FiberEffect.AssetTransferred => t }
           depMutations = effects.collect { case d: FiberEffect.DependencyMutated => d }
+          nullifierConsumptions = effects.collect { case n: FiberEffect.NullifierConsumed => n }
 
           // FiberPolicy dial `allowedEffects`: FAIL-CLOSED gate on which directive families this transition may
           // produce. A non-empty family NOT in the allowlist aborts the WHOLE transition (total discard) — it
@@ -352,7 +353,8 @@ object FiberEvaluator {
               EffectKind.Spawn      -> spawnMachines.nonEmpty,
               EffectKind.Emit       -> emittedEvents.nonEmpty,
               EffectKind.Transfer   -> assetTransfers.nonEmpty,
-              EffectKind.Dependency -> depMutations.nonEmpty
+              EffectKind.Dependency -> depMutations.nonEmpty,
+              EffectKind.Nullifier  -> nullifierConsumptions.nonEmpty
             )
             present.collectFirst { case (k, true) if !allowed.contains(k) => k }
           }
@@ -395,7 +397,8 @@ object FiberEvaluator {
                             returnValue = None,
                             emittedEvents = emittedEvents,
                             assetTransfers = assetTransfers,
-                            dependencyMutations = depMutations
+                            dependencyMutations = depMutations,
+                            nullifierConsumptions = nullifierConsumptions
                           )
                       )
                     )

--- a/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/fiber/triggers/TriggerDispatcher.scala
+++ b/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/fiber/triggers/TriggerDispatcher.scala
@@ -50,9 +50,10 @@ object TriggerDispatcher {
    * Pending uses List for O(1) prepend (depth-first processing).
    */
   final private case class QueueState(
-    pending:        List[FiberTrigger],
-    txnState:       CalculatedState,
-    assetTransfers: Map[UUID, List[FiberEffect.AssetTransferred]]
+    pending:               List[FiberTrigger],
+    txnState:              CalculatedState,
+    assetTransfers:        Map[UUID, List[FiberEffect.AssetTransferred]],
+    nullifierConsumptions: Map[UUID, List[FiberEffect.NullifierConsumed]]
   )
 
   def make[F[_]: Async: SecurityProvider, G[_]: Monad](implicit
@@ -72,7 +73,7 @@ object TriggerDispatcher {
         triggers:  List[FiberTrigger],
         baseState: CalculatedState
       ): G[TransactionResult] = {
-        val initialQueue = QueueState(triggers, baseState, Map.empty)
+        val initialQueue = QueueState(triggers, baseState, Map.empty, Map.empty)
 
         Monad[G].tailRecM(initialQueue)(processNext)
       }
@@ -101,12 +102,13 @@ object TriggerDispatcher {
                   logEntries = logEntries.toList,
                   totalGasUsed = gasUsed,
                   maxDepth = depth,
-                  assetTransfers = qs.assetTransfers
+                  assetTransfers = qs.assetTransfers,
+                  nullifierConsumptions = qs.nullifierConsumptions
                 ): TransactionResult).asRight[QueueState]
 
               case trigger :: rest =>
                 processSingleTrigger(trigger, qs.txnState).flatMap {
-                  case Right((nextState, moreTriggers, transfers)) =>
+                  case Right((nextState, moreTriggers, transfers, consumptions)) =>
                     // Accumulate the triggered fiber's _transferAsset effects keyed by the EMITTING (triggered)
                     // fiber id — the holder-defense key the combiner uses (R1).
                     val nextTransfers =
@@ -116,10 +118,20 @@ object TriggerDispatcher {
                           trigger.targetFiberId,
                           qs.assetTransfers.getOrElse(trigger.targetFiberId, List.empty) ++ transfers
                         )
+                    // Same accumulation for _consumeNullifier: keyed by the EMITTING (triggered) fiber id,
+                    // which IS the nullifier domain (protocol-nullifier-set.md).
+                    val nextConsumptions =
+                      if (consumptions.isEmpty) qs.nullifierConsumptions
+                      else
+                        qs.nullifierConsumptions.updated(
+                          trigger.targetFiberId,
+                          qs.nullifierConsumptions.getOrElse(trigger.targetFiberId, List.empty) ++ consumptions
+                        )
                     QueueState(
                       pending = moreTriggers ++ rest,
                       txnState = nextState,
-                      assetTransfers = nextTransfers
+                      assetTransfers = nextTransfers,
+                      nullifierConsumptions = nextConsumptions
                     ).asLeft[TransactionResult].pure[G]
 
                   case Left(reason) =>
@@ -132,7 +144,12 @@ object TriggerDispatcher {
         }
 
       private type TriggerResult =
-        (CalculatedState, List[FiberTrigger], List[FiberEffect.AssetTransferred])
+        (
+          CalculatedState,
+          List[FiberTrigger],
+          List[FiberEffect.AssetTransferred],
+          List[FiberEffect.NullifierConsumed]
+        )
 
       private def processSingleTrigger(
         trigger: FiberTrigger,
@@ -182,10 +199,10 @@ object TriggerDispatcher {
           _             <- ExecutionOps.markProcessed[G](fiber.fiberId, trigger.input.key)
           handlerResult <- handler.handle(trigger, fiber, state)
           result <- handlerResult match {
-            case TriggerHandlerResult.Success(updatedState, cascadeTriggers, assetTransfers) =>
+            case TriggerHandlerResult.Success(updatedState, cascadeTriggers, assetTransfers, nullifierConsumptions) =>
               ExecutionOps
                 .incrementDepth[G]
-                .as((updatedState, cascadeTriggers, assetTransfers).asRight[FailureReason])
+                .as((updatedState, cascadeTriggers, assetTransfers, nullifierConsumptions).asRight[FailureReason])
 
             case TriggerHandlerResult.Failed(reason) =>
               reason.asLeft[TriggerResult].pure[G]

--- a/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/fiber/triggers/TriggerHandler.scala
+++ b/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/fiber/triggers/TriggerHandler.scala
@@ -115,8 +115,20 @@ class StateMachineTriggerHandler[F[_]: Async: SecurityProvider, G[_]: Monad](
       result <- outcome match {
         // Cascaded (triggered) transitions do not spawn or mutate dynamic dependencies — those directives
         // (`spawns`, `dependencyMutations`) are honoured only on the PRIMARY transition (see FiberEngine),
-        // so both are ignored here, as `spawns` already is.
-        case FiberResult.Success(newStateData, newStateId, triggers, _, _, emittedEvents, assetTransfers, _) =>
+        // so both are ignored here, as `spawns` already is. `_consumeNullifier` IS honoured on the cascade
+        // (like Transfer/Emit): the domain is the triggered fiber's OWN id, so a cascade can only ever
+        // consume into its own namespace.
+        case FiberResult.Success(
+              newStateData,
+              newStateId,
+              triggers,
+              _,
+              _,
+              emittedEvents,
+              assetTransfers,
+              _,
+              nullifierConsumptions
+            ) =>
           val receipt = EventReceipt.success(
             sm = sm,
             eventName = trigger.input.key,
@@ -144,7 +156,8 @@ class StateMachineTriggerHandler[F[_]: Async: SecurityProvider, G[_]: Monad](
               TriggerHandlerResult.Success(
                 updatedState = updatedState,
                 cascadeTriggers = triggers,
-                assetTransfers = assetTransfers
+                assetTransfers = assetTransfers,
+                nullifierConsumptions = nullifierConsumptions
               ): TriggerHandlerResult
             )
 

--- a/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/combine/FiberCombiner.scala
+++ b/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/combine/FiberCombiner.scala
@@ -174,8 +174,8 @@ class FiberCombiner[F[_]: Async: SecurityProvider](
     outcome <- orchestrator.process(update.fiberId, input, proofsList)
 
     newState <- outcome match {
-      case TransactionResult.Committed(updatedFibers, updatedScripts, logEntries, _, _, _, assetTransfers) =>
-        handleCommittedOutcome(updatedFibers, updatedScripts, logEntries, assetTransfers)
+      case TransactionResult.Committed(updatedFibers, updatedScripts, logEntries, _, _, _, transfers, nullifiers) =>
+        handleCommittedOutcome(updatedFibers, updatedScripts, logEntries, transfers, nullifiers)
 
       case TransactionResult.Aborted(reason, gasUsed, _) =>
         handleAbortedOutcome(update.fiberId, update.eventName, reason, gasUsed, currentOrdinal)
@@ -302,9 +302,10 @@ class FiberCombiner[F[_]: Async: SecurityProvider](
     newState <- outcome match {
       // A migration pass MUST NOT fabricate `_transferAsset` of held assets (asset-model.md §10, R34); the
       // engine's migration path never produces asset transfers, but the same holder-checked entry point is
-      // used here defensively so any future migration-emitted transfer is still gated by R1.
-      case TransactionResult.Committed(updatedFibers, updatedScripts, logEntries, _, _, _, assetTransfers) =>
-        handleCommittedOutcome(updatedFibers, updatedScripts, logEntries, assetTransfers)
+      // used here defensively so any future migration-emitted transfer is still gated by R1. The same
+      // defensive threading covers `_consumeNullifier` (the migration path never emits it either).
+      case TransactionResult.Committed(updatedFibers, updatedScripts, logEntries, _, _, _, transfers, nullifiers) =>
+        handleCommittedOutcome(updatedFibers, updatedScripts, logEntries, transfers, nullifiers)
 
       case TransactionResult.Aborted(reason, gasUsed, _) =>
         handleAbortedOutcome(update.fiberId, "__upgrade__", reason, gasUsed, currentOrdinal)
@@ -366,23 +367,29 @@ class FiberCombiner[F[_]: Async: SecurityProvider](
    * Applies fiber/script record updates, appends log entries to OnChain.latestLogs, then — within the SAME
    * combiner pass — applies any `_transferAsset` effects the transition emitted (the §9/§10 return channel,
    * R2) through [[AssetCombiner.applyFiberTransfers]], which enforces the holder-ownership defense (R1) and
-   * the no-reentrancy / mutation bound (R20). A rejected transfer raises `CombineRejected`, which
-   * `Combiner.insert` turns into a graceful `RejectionReceipt` for the whole update (#154) — the fiber's state
-   * mutation is discarded along with it (all-or-nothing; never a partial apply).
+   * the no-reentrancy / mutation bound (R20), and then any `_consumeNullifier` effects through
+   * [[NullifierCombiner.applyConsumptions]] (absent-check → insert at the current ordinal; double-spend /
+   * cap breach reject — protocol-nullifier-set.md). A rejected transfer or consumption raises
+   * `CombineRejected`, which `Combiner.insert` turns into a graceful `RejectionReceipt` for the whole update
+   * (#154) — the fiber's state mutation is discarded along with it (all-or-nothing; never a partial apply).
    */
   private def handleCommittedOutcome(
-    updatedFibers:  Map[UUID, Records.StateMachineFiberRecord],
-    updatedScripts: Map[UUID, Records.ScriptFiberRecord],
-    logEntries:     List[FiberLogEntry],
-    assetTransfers: Map[UUID, List[FiberEffect.AssetTransferred]]
+    updatedFibers:         Map[UUID, Records.StateMachineFiberRecord],
+    updatedScripts:        Map[UUID, Records.ScriptFiberRecord],
+    logEntries:            List[FiberLogEntry],
+    assetTransfers:        Map[UUID, List[FiberEffect.AssetTransferred]],
+    nullifierConsumptions: Map[UUID, List[FiberEffect.NullifierConsumed]]
   ): F[DataState[OnChain, CalculatedState]] =
     for {
       withFibers <- current.withFibersAndScripts[F](updatedFibers, updatedScripts).map(_.appendLogs(logEntries))
-      result <-
+      withTransfers <-
         if (assetTransfers.isEmpty) withFibers.pure[F]
         else
           AssetCombiner[F](withFibers, ctx, Limits.MaxRegistryBundleBytes)
             .applyFiberTransfers(withFibers, assetTransfers)
+      result <-
+        if (nullifierConsumptions.isEmpty) withTransfers.pure[F]
+        else NullifierCombiner[F](ctx).applyConsumptions(withTransfers, nullifierConsumptions)
     } yield result
 
   /**

--- a/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/combine/NullifierCombiner.scala
+++ b/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/combine/NullifierCombiner.scala
@@ -1,0 +1,102 @@
+package xyz.kd5ujc.shared_data.lifecycle.combine
+
+import java.util.UUID
+
+import cats.effect.Async
+import cats.syntax.all._
+
+import scala.collection.immutable.SortedMap
+
+import io.constellationnetwork.currency.dataApplication.{DataState, L0NodeContext}
+import io.constellationnetwork.schema.SnapshotOrdinal
+import io.constellationnetwork.security.SecurityProvider
+import io.constellationnetwork.security.hash.Hash
+
+import xyz.kd5ujc.schema.fiber.{ExecutionLimits, FiberEffect}
+import xyz.kd5ujc.schema.{CalculatedState, OnChain}
+import xyz.kd5ujc.shared_data.syntax.all._
+
+import monocle.Monocle.toAppliedFocusOps
+import org.typelevel.log4cats.slf4j.Slf4jLogger
+
+/**
+ * Combiner for the protocol nullifier set (docs/proposals/protocol-nullifier-set.md) — the AUTHORITATIVE,
+ * deterministic enforcement site and the SOLE writer of `CalculatedState.nullifiers`. Applied from
+ * [[FiberCombiner.handleCommittedOutcome]] within the SAME combiner pass as the fiber-state mutation, after
+ * the asset transfers, mirroring [[AssetCombiner.applyFiberTransfers]].
+ *
+ * ALL-OR-NOTHING per transition: any hit — an already-present nf (double-spend), a per-emitter cap breach —
+ * raises a graceful [[CombineRejected]], which `Combiner.insert` turns into a single `RejectionReceipt` for
+ * the whole update and discards the partial mutation (rule #2; the #154 lesson — never a snapshot abort).
+ * The check must NEVER appear in `validateSignedUpdate` (a stateful read at block validity is the rule-#3
+ * TOCTOU block-poisoning hazard); sequential combine gives intra-batch double-spend protection for free.
+ *
+ * DOMAIN ISOLATION: the map is keyed by the EMITTING fiber id (stamped by the engine, never authored), so a
+ * fiber can only ever consume into its OWN `nullifier/<domain>/<nf>` namespace — the cross-app griefing
+ * vector is closed by construction. Writes touch ONLY `calculated.nullifiers` — never `onChain` (decision
+ * #6: no OnChain / CommitIndex change; DL1 never reads nullifiers).
+ */
+class NullifierCombiner[F[_]: Async: SecurityProvider](ctx: L0NodeContext[F]) {
+
+  /**
+   * Apply the `_consumeNullifier` effects a committed fiber transition produced. `consumptionsByEmitter` keys
+   * the per-fiber nf lists by the EMITTING fiber id — the nullifier DOMAIN. Deterministic order: by emitter
+   * UUID, preserving each list's emission order. The per-emitter cap
+   * (`ExecutionLimits.maxNullifierConsumptions`) is checked up front; every nf is then absent-checked and
+   * inserted with the CURRENT snapshot ordinal (the spent-at receipt, decision #7) in a single sequential
+   * fold, so an intra-transition duplicate hits its own earlier insert and rejects.
+   */
+  def applyConsumptions(
+    st:                    DataState[OnChain, CalculatedState],
+    consumptionsByEmitter: Map[UUID, List[FiberEffect.NullifierConsumed]]
+  ): F[DataState[OnChain, CalculatedState]] = {
+    val ordered: List[(UUID, List[FiberEffect.NullifierConsumed])] =
+      consumptionsByEmitter.toList.sortBy(_._1)
+
+    val maxConsumptions = ExecutionLimits().maxNullifierConsumptions
+    for {
+      _ <- ordered.traverse_ { case (domain, ns) =>
+        raiseRejected(
+          ns.size <= maxConsumptions,
+          s"fiber $domain emitted ${ns.size} nullifier consumptions, exceeding maxNullifierConsumptions $maxConsumptions"
+        )
+      }
+      currentOrdinal <- ctx.getCurrentOrdinal
+      result <- ordered.flatMap { case (domain, ns) => ns.map(domain -> _) }.foldLeftM(st) {
+        case (acc, (domain, consumption)) => applyConsumption(acc, domain, consumption, currentOrdinal)
+      }
+    } yield result
+  }
+
+  /**
+   * Apply ONE nullifier consumption: reject if `nf` is already present under `domain` (the double-spend
+   * gate), else insert `nf -> ordinal`. The nf value is guaranteed normalized 64-hex by the extractor
+   * (`NullifierHex`), which is what keeps the committed `nullifier/<domain>/<nf>` key derivation total.
+   */
+  private def applyConsumption(
+    st:          DataState[OnChain, CalculatedState],
+    domain:      UUID,
+    consumption: FiberEffect.NullifierConsumed,
+    ordinal:     SnapshotOrdinal
+  ): F[DataState[OnChain, CalculatedState]] = {
+    val nf = consumption.nullifier
+    val domainSet = st.calculated.nullifiers.getOrElse(domain, SortedMap.empty[Hash, SnapshotOrdinal])
+    if (domainSet.contains(nf))
+      Async[F].raiseError(CombineRejected(s"nullifier already consumed (double-spend): $domain/${nf.value}"))
+    else
+      Slf4jLogger
+        .getLogger[F]
+        .info(s"[nullifier-consume] $domain/${nf.value} at ordinal ${ordinal.value.value}")
+        .as(st.focus(_.calculated.nullifiers).modify(_.updated(domain, domainSet.updated(nf, ordinal))))
+  }
+
+  /** Raise a graceful `CombineRejected(reason)` unless `cond` holds. */
+  private def raiseRejected(cond: Boolean, reason: => String): F[Unit] =
+    Async[F].raiseError(CombineRejected(reason)).unlessA(cond)
+}
+
+object NullifierCombiner {
+
+  def apply[F[_]: Async: SecurityProvider](ctx: L0NodeContext[F]): NullifierCombiner[F] =
+    new NullifierCombiner[F](ctx)
+}

--- a/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/combine/ScriptCombiner.scala
+++ b/modules/shared-data/src/main/scala/xyz/kd5ujc/shared_data/lifecycle/combine/ScriptCombiner.scala
@@ -108,7 +108,7 @@ class ScriptCombiner[F[_]: Async: SecurityProvider](
     outcome <- orchestrator.process(update.fiberId, input, update.proofs.toList)
 
     newState <- outcome match {
-      case TransactionResult.Committed(_, updatedScripts, logEntries, _, _, _, _) =>
+      case TransactionResult.Committed(_, updatedScripts, logEntries, _, _, _, _, _) =>
         updatedScripts.get(update.fiberId) match {
           case Some(updatedScript) =>
             current.withRecord[F](update.fiberId, updatedScript).map(_.appendLogs(logEntries))
@@ -207,7 +207,7 @@ class ScriptCombiner[F[_]: Async: SecurityProvider](
     outcome <- orchestrator.migrateScript(update.fiberId, update.newProgram, newBinding, update.migration)
 
     newState <- outcome match {
-      case TransactionResult.Committed(_, updatedScripts, logEntries, _, _, _, _) =>
+      case TransactionResult.Committed(_, updatedScripts, logEntries, _, _, _, _, _) =>
         updatedScripts.get(update.fiberId) match {
           case Some(updated) => current.withRecord[F](update.fiberId, updated).map(_.appendLogs(logEntries))
           case None =>

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/CommittedViewSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/CommittedViewSuite.scala
@@ -96,6 +96,39 @@ object CommittedViewSuite extends SimpleIOSuite {
 
   // ── commit/ projections (onchain-incrementals RFC §3.1) — the provable DL1 heal namespace ──
 
+  // ── nullifier/ projections (protocol-nullifier-set.md) — one TOTAL leaf per spent nullifier ──
+
+  test("entries projects nullifier/<uuid>/<hex> keys with ordinal values; empty projects nothing") {
+    import io.circe.syntax.EncoderOps
+    import io.constellationnetwork.security.hash.Hash
+
+    val domA = UUID.fromString("00000000-0000-0000-0000-0000000000d1")
+    val domB = UUID.fromString("00000000-0000-0000-0000-0000000000d2")
+    val nf1 = Hash("a" * 64)
+    val nf2 = Hash("b" * 64)
+    val ord = SnapshotOrdinal.unsafeApply(7L)
+
+    val s = CalculatedState.genesis.copy(
+      nullifiers = SortedMap(
+        domA -> SortedMap(nf1 -> ord, nf2 -> SnapshotOrdinal.MinValue),
+        domB -> SortedMap(nf1 -> ord) // same nf under a second domain: distinct leaf (domain isolation)
+      )
+    )
+    val entries = CalculatedState.committedView.entries(s)
+    val keys = entries.keySet.map(_.value)
+    IO.pure(
+      expect(keys.contains(s"nullifier/$domA/${nf1.value}")) and
+      expect(keys.contains(s"nullifier/$domA/${nf2.value}")) and
+      expect(keys.contains(s"nullifier/$domB/${nf1.value}")) and
+      // the leaf value is the spend-ordinal JSON (the spent-at receipt)
+      expect(entries.find(_._1.value == s"nullifier/$domA/${nf1.value}").map(_._2).contains(ord.asJson)) and
+      // one leaf per spent nf, nothing else projected
+      expect(entries.size == 3) and
+      // an empty nullifier map projects nothing
+      expect(CalculatedState.committedView.entries(CalculatedState.genesis).isEmpty)
+    )
+  }
+
   test("entries projects commit/f|a|r keys; over-long registry names take the hashed fallback") {
     import xyz.kd5ujc.schema.{AssetCommit, FiberCommit}
     import xyz.kd5ujc.schema.fiber.FiberOrdinal

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/DefinitionLinterSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/DefinitionLinterSuite.scala
@@ -283,6 +283,50 @@ object DefinitionLinterSuite extends SimpleIOSuite {
   }
 
   // ---------------------------------------------------------------------------
+  // (b2b) _consumeNullifier value shape (bare 64-hex values)
+  // ---------------------------------------------------------------------------
+
+  private def nullifierDef(itemsJson: String): String =
+    s"""
+    {
+      "states": { "s0": { "id": "s0", "isFinal": false }, "s1": { "id": "s1", "isFinal": true } },
+      "initialState": "s0",
+      "transitions": [
+        {
+          "from": "s0", "to": "s1", "eventName": "fill", "guard": true,
+          "effect": { "_consumeNullifier": [ $itemsJson ], "filled": true },
+          "dependencies": []
+        }
+      ]
+    }
+    """
+
+  test("a well-formed 64-hex _consumeNullifier literal produces no nullifier diagnostic (0x form too)") {
+    val plain = DefinitionLinter.validate(parseDef(nullifierDef(s""""${"a" * 64}"""")))
+    val prefixed = DefinitionLinter.validate(parseDef(nullifierDef(s""""0x${"B" * 64}"""")))
+    IO.pure(
+      expect(plain.forall(_.code != "nullifier-literal-malformed")) and
+      expect(prefixed.forall(_.code != "nullifier-literal-malformed"))
+    )
+  }
+
+  test("an obviously-wrong _consumeNullifier literal is a nullifier-literal-malformed Warning") {
+    val badHex = DefinitionLinter.validate(parseDef(nullifierDef(""""definitely-not-hex"""")))
+    val tooShort = DefinitionLinter.validate(parseDef(nullifierDef(s""""${"a" * 32}"""")))
+    val nonString = DefinitionLinter.validate(parseDef(nullifierDef("42")))
+    IO.pure(
+      expect(warningsOf(badHex).exists(_.code == "nullifier-literal-malformed")) and
+      expect(warningsOf(tooShort).exists(_.code == "nullifier-literal-malformed")) and
+      expect(warningsOf(nonString).exists(_.code == "nullifier-literal-malformed"))
+    )
+  }
+
+  test("a dynamic _consumeNullifier item (var/cat) produces no nullifier diagnostic (checked at combine)") {
+    val dynamic = DefinitionLinter.validate(parseDef(nullifierDef("""{ "var": "event.nf" }""")))
+    IO.pure(expect(dynamic.forall(_.code != "nullifier-literal-malformed")))
+  }
+
+  // ---------------------------------------------------------------------------
   // (b3) directive-injection hazard: dynamic TOP-LEVEL effect keys
   // ---------------------------------------------------------------------------
 

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/DepthAndHashSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/DepthAndHashSuite.scala
@@ -118,7 +118,7 @@ object DepthAndHashSuite extends SimpleIOSuite {
         result <- orchestrator.process(parentId, input, List.empty)
 
       } yield result match {
-        case TransactionResult.Committed(machines, _, _, _, _, _, _) =>
+        case TransactionResult.Committed(machines, _, _, _, _, _, _, _) =>
           // Spawns don't increment depth - only triggers do
           // With maxDepth=1, parent transition at depth 0 succeeds, child is spawned
           expect(
@@ -188,7 +188,7 @@ object DepthAndHashSuite extends SimpleIOSuite {
           expect(originalFiber.exists(_.stateDataHash == initialHash)) and
           expect(originalFiber.exists(_.stateData == initialData)) and
           expect(originalFiber.exists(_.sequenceNumber == FiberOrdinal.unsafeApply(10L)))
-        case TransactionResult.Committed(_, _, _, _, _, _, _) =>
+        case TransactionResult.Committed(_, _, _, _, _, _, _, _) =>
           failure("Expected Aborted for missing transition")
       }
     }
@@ -381,7 +381,7 @@ object DepthAndHashSuite extends SimpleIOSuite {
       } yield result match {
         case TransactionResult.Aborted(reason, _, _) =>
           expect(reason.isInstanceOf[FailureReason.DepthExceeded])
-        case TransactionResult.Committed(_, _, _, _, _, _, _) =>
+        case TransactionResult.Committed(_, _, _, _, _, _, _, _) =>
           failure("Expected to exceed depth")
       }
     }

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/DeterministicExecutionSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/DeterministicExecutionSuite.scala
@@ -99,7 +99,7 @@ object DeterministicExecutionSuite extends SimpleIOSuite with Checkers {
       expect(result1.isInstanceOf[TransactionResult.Committed]) and
       expect(
         result1 match {
-          case TransactionResult.Committed(updatedSMs, _, _, _, _, _, _) =>
+          case TransactionResult.Committed(updatedSMs, _, _, _, _, _, _, _) =>
             updatedSMs.get(fiberId).exists(_.currentState == StateId("ACTIVE"))
           case _ => false
         }
@@ -180,7 +180,7 @@ object DeterministicExecutionSuite extends SimpleIOSuite with Checkers {
         case TransactionResult.Aborted(reason, _, _) =>
           expect(reason.isInstanceOf[FailureReason.GasExhaustedFailure])
             .or(failure(s"Expected GasExhaustedFailure but got: ${reason.getClass.getSimpleName}"))
-        case TransactionResult.Committed(_, _, _, _, _, _, _) =>
+        case TransactionResult.Committed(_, _, _, _, _, _, _, _) =>
           failure("Expected Aborted with GasExhaustedFailure, but transaction was committed")
       }
     }
@@ -330,7 +330,7 @@ object DeterministicExecutionSuite extends SimpleIOSuite with Checkers {
         case TransactionResult.Aborted(reason, _, _) =>
           expect(reason.isInstanceOf[FailureReason.CycleDetected])
             .or(failure(s"Expected CycleDetected, got $reason"))
-        case TransactionResult.Committed(_, _, _, _, _, _, _) =>
+        case TransactionResult.Committed(_, _, _, _, _, _, _, _) =>
           failure(s"Expected Aborted, got Committed")
       }
     }
@@ -574,7 +574,7 @@ object DeterministicExecutionSuite extends SimpleIOSuite with Checkers {
           .runA(ExecutionState.initial)
 
       } yield result match {
-        case TransactionResult.Committed(updatedSMs, _, _, _, _, _, _) =>
+        case TransactionResult.Committed(updatedSMs, _, _, _, _, _, _, _) =>
           // Both fibers should be updated atomically
           expect(updatedSMs.size == 2, s"Expected 2 updated machines, got ${updatedSMs.size}") and
           expect(
@@ -738,7 +738,7 @@ object DeterministicExecutionSuite extends SimpleIOSuite with Checkers {
         result <- orchestrator.process(fiberId, input, List.empty)
 
       } yield result match {
-        case TransactionResult.Committed(machines, _, _, totalGasUsed, _, _, _) =>
+        case TransactionResult.Committed(machines, _, _, totalGasUsed, _, _, _, _) =>
           // Gas should include ALL guard evaluations (both failed ones + the successful one) + effect
           // First guard: == check (1) + add (1) + 2 consts (2) = 4
           // Second guard: == check (1) + add (1) + 2 consts (2) = 4
@@ -839,7 +839,7 @@ object DeterministicExecutionSuite extends SimpleIOSuite with Checkers {
             case other =>
               failure(s"Expected GasExhaustedFailure but got: ${other.getClass.getSimpleName}")
           }
-        case TransactionResult.Committed(_, _, _, _, _, _, _) =>
+        case TransactionResult.Committed(_, _, _, _, _, _, _, _) =>
           failure("Expected Aborted with GasExhaustedFailure, but transaction was committed")
       }
     }
@@ -1142,7 +1142,7 @@ object DeterministicExecutionSuite extends SimpleIOSuite with Checkers {
             reason.isInstanceOf[FailureReason.CycleDetected],
             s"Expected CycleDetected but got: ${reason.getClass.getSimpleName}: ${reason.toMessage}"
           )
-        case TransactionResult.Committed(_, _, _, _, _, _, _) =>
+        case TransactionResult.Committed(_, _, _, _, _, _, _, _) =>
           failure("Expected Aborted with CycleDetected, but transaction was committed")
       }
     }
@@ -1337,7 +1337,7 @@ object DeterministicExecutionSuite extends SimpleIOSuite with Checkers {
             reason.isInstanceOf[FailureReason.CycleDetected],
             s"Expected CycleDetected but got: ${reason.getClass.getSimpleName}: ${reason.toMessage}"
           )
-        case TransactionResult.Committed(_, _, _, _, _, _, _) =>
+        case TransactionResult.Committed(_, _, _, _, _, _, _, _) =>
           failure("Expected Aborted with CycleDetected, but transaction was committed")
       }
     }
@@ -1562,7 +1562,7 @@ object DeterministicExecutionSuite extends SimpleIOSuite with Checkers {
             reason.isInstanceOf[FailureReason.CycleDetected],
             s"Expected CycleDetected but got: ${reason.getClass.getSimpleName}: ${reason.toMessage}"
           )
-        case TransactionResult.Committed(_, _, _, _, _, _, _) =>
+        case TransactionResult.Committed(_, _, _, _, _, _, _, _) =>
           failure("Expected Aborted with CycleDetected, but transaction was committed")
       }
     }
@@ -1634,7 +1634,7 @@ object DeterministicExecutionSuite extends SimpleIOSuite with Checkers {
             reason.isInstanceOf[FailureReason.TriggerTargetNotFound],
             s"Expected TriggerTargetNotFound but got: ${reason.getClass.getSimpleName}"
           )
-        case TransactionResult.Committed(machines, _, _, _, _, _, _) =>
+        case TransactionResult.Committed(machines, _, _, _, _, _, _, _) =>
           // If missing dependencies are skipped, verify the main transition completed
           expect(
             machines.get(fiberId).exists(_.currentState == StateId("end")),

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/EventBatchBoundingSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/EventBatchBoundingSuite.scala
@@ -155,7 +155,7 @@ object EventBatchBoundingSuite extends SimpleIOSuite {
         result <- engine.process(fiberId, input, proofs)
 
         updatedFiber = result match {
-          case TransactionResult.Committed(machines, _, _, _, _, _, _) =>
+          case TransactionResult.Committed(machines, _, _, _, _, _, _, _) =>
             machines.get(fiberId)
           case _ => None
         }

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/FailureReasonSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/FailureReasonSuite.scala
@@ -98,7 +98,7 @@ object FailureReasonSuite extends SimpleIOSuite {
             case other =>
               failure(s"Expected NoTransitionFound but got: ${other.getClass.getSimpleName}")
           }
-        case TransactionResult.Committed(_, _, _, _, _, _, _) =>
+        case TransactionResult.Committed(_, _, _, _, _, _, _, _) =>
           failure("Expected Aborted with NoTransitionFound, but transaction was committed")
       }
     }
@@ -176,7 +176,7 @@ object FailureReasonSuite extends SimpleIOSuite {
             case other =>
               failure(s"Expected NoGuardMatched but got: ${other.getClass.getSimpleName}")
           }
-        case TransactionResult.Committed(_, _, _, _, _, _, _) =>
+        case TransactionResult.Committed(_, _, _, _, _, _, _, _) =>
           failure("Expected Aborted with NoGuardMatched, but transaction was committed")
       }
     }
@@ -265,7 +265,7 @@ object FailureReasonSuite extends SimpleIOSuite {
             case other =>
               failure(s"Expected TriggerTargetNotFound but got: ${other.getClass.getSimpleName}")
           }
-        case TransactionResult.Committed(_, _, _, _, _, _, _) =>
+        case TransactionResult.Committed(_, _, _, _, _, _, _, _) =>
           failure("Expected Aborted with TriggerTargetNotFound, but transaction was committed")
       }
     }
@@ -372,7 +372,7 @@ object FailureReasonSuite extends SimpleIOSuite {
       } yield result match {
         case TransactionResult.Aborted(reason, _, _) =>
           expect(reason.isInstanceOf[FailureReason.CycleDetected])
-        case TransactionResult.Committed(_, _, _, _, _, _, _) =>
+        case TransactionResult.Committed(_, _, _, _, _, _, _, _) =>
           failure("Expected Aborted with CycleDetected, got Committed")
       }
     }
@@ -457,7 +457,7 @@ object FailureReasonSuite extends SimpleIOSuite {
                 s"Expected GasExhaustedFailure in Guard phase but got: ${other.getClass.getSimpleName}: ${other.toMessage}"
               )
           }
-        case TransactionResult.Committed(_, _, _, _, _, _, _) =>
+        case TransactionResult.Committed(_, _, _, _, _, _, _, _) =>
           failure("Expected Aborted with GasExhaustedFailure, but transaction was committed")
       }
     }
@@ -531,7 +531,7 @@ object FailureReasonSuite extends SimpleIOSuite {
         result <- orchestrator.process(fiberId, input, List.empty)
 
       } yield result match {
-        case TransactionResult.Committed(_, _, _, _, _, _, _) =>
+        case TransactionResult.Committed(_, _, _, _, _, _, _, _) =>
           success
         case TransactionResult.Aborted(reason, _, _) =>
           failure(s"Expected Committed but got Aborted: ${reason}")
@@ -602,7 +602,7 @@ object FailureReasonSuite extends SimpleIOSuite {
             case other =>
               failure(s"Expected FiberInputMismatch but got: ${other.getClass.getSimpleName}")
           }
-        case TransactionResult.Committed(_, _, _, _, _, _, _) =>
+        case TransactionResult.Committed(_, _, _, _, _, _, _, _) =>
           failure("Expected Aborted with FiberInputMismatch, but transaction was committed")
       }
     }
@@ -663,7 +663,7 @@ object FailureReasonSuite extends SimpleIOSuite {
             case other =>
               failure(s"Expected FiberInputMismatch but got: ${other.getClass.getSimpleName}")
           }
-        case TransactionResult.Committed(_, _, _, _, _, _, _) =>
+        case TransactionResult.Committed(_, _, _, _, _, _, _, _) =>
           failure("Expected Aborted with FiberInputMismatch, but transaction was committed")
       }
     }

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/FiberPolicyEnforcementSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/FiberPolicyEnforcementSuite.scala
@@ -529,7 +529,7 @@ object FiberPolicyEnforcementSuite extends SimpleIOSuite {
 
   /** The commuteObligation flag of the single UpgradeReceipt in a committed migration (None if not committed). */
   private def commuteObligationOf(r: TransactionResult): Option[Boolean] = r match {
-    case TransactionResult.Committed(_, _, logs, _, _, _, _) =>
+    case TransactionResult.Committed(_, _, logs, _, _, _, _, _) =>
       logs.collectFirst { case u: FiberLogEntry.UpgradeReceipt => u.commuteObligation }
     case _ => None
   }

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/GasMeteringPhaseSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/GasMeteringPhaseSuite.scala
@@ -93,7 +93,7 @@ object GasMeteringPhaseSuite extends SimpleIOSuite {
         result <- orchestrator.process(fiberId, input, List.empty)
 
       } yield result match {
-        case TransactionResult.Committed(machines, _, _, _, _, _, _) =>
+        case TransactionResult.Committed(machines, _, _, _, _, _, _, _) =>
           expect(machines.get(fiberId).exists(_.currentState == StateId("end")))
         case TransactionResult.Aborted(reason, _, _) =>
           failure(s"Expected Committed but got Aborted: ${reason.toMessage}")
@@ -210,7 +210,7 @@ object GasMeteringPhaseSuite extends SimpleIOSuite {
         result <- orchestrator.process(machine1Id, input, List.empty)
 
       } yield result match {
-        case TransactionResult.Committed(machines, _, _, _, _, _, _) =>
+        case TransactionResult.Committed(machines, _, _, _, _, _, _, _) =>
           // Both machines should have transitioned
           expect(machines.get(machine1Id).exists(_.currentState == StateId("b"))) and
           expect(machines.get(machine2Id).exists(_.currentState == StateId("y")))
@@ -296,7 +296,7 @@ object GasMeteringPhaseSuite extends SimpleIOSuite {
         result <- orchestrator.process(fiberId, input, List.empty)
 
       } yield result match {
-        case TransactionResult.Committed(machines, _, _, _, _, _, _) =>
+        case TransactionResult.Committed(machines, _, _, _, _, _, _, _) =>
           val updated = machines.get(fiberId)
           expect(updated.isDefined) and
           expect(updated.exists(_.currentState == StateId("end"))) and
@@ -375,7 +375,7 @@ object GasMeteringPhaseSuite extends SimpleIOSuite {
             reason.isInstanceOf[FailureReason.GasExhaustedFailure],
             s"Expected GasExhaustedFailure but got: ${reason.getClass.getSimpleName}"
           )
-        case TransactionResult.Committed(_, _, _, _, _, _, _) =>
+        case TransactionResult.Committed(_, _, _, _, _, _, _, _) =>
           failure("Expected Aborted with GasExhaustedFailure for gas limit of 0")
       }
     }
@@ -454,7 +454,7 @@ object GasMeteringPhaseSuite extends SimpleIOSuite {
               // Any abort with an expensive effect under low gas is expected behavior
               success
           }
-        case TransactionResult.Committed(_, _, _, gasUsed, _, _, _) =>
+        case TransactionResult.Committed(_, _, _, gasUsed, _, _, _, _) =>
           // If it somehow completes with 100 gas, document that behavior
           expect(gasUsed <= 100L)
       }
@@ -557,7 +557,7 @@ object GasMeteringPhaseSuite extends SimpleIOSuite {
 
       } yield {
         val highSuccess = resultHigh match {
-          case TransactionResult.Committed(machines, _, _, _, _, _, _) =>
+          case TransactionResult.Committed(machines, _, _, _, _, _, _, _) =>
             machines.contains(childId) // Child was created
           case _ => false
         }
@@ -565,7 +565,7 @@ object GasMeteringPhaseSuite extends SimpleIOSuite {
         val lowFailed = resultLow match {
           case TransactionResult.Aborted(reason, _, _) =>
             reason.isInstanceOf[FailureReason.GasExhaustedFailure]
-          case TransactionResult.Committed(_, _, _, _, _, _, _) =>
+          case TransactionResult.Committed(_, _, _, _, _, _, _, _) =>
             false // Unexpectedly succeeded
         }
 
@@ -694,7 +694,7 @@ object GasMeteringPhaseSuite extends SimpleIOSuite {
         result <- orchestrator.process(machine1Id, input, List.empty)
 
       } yield result match {
-        case TransactionResult.Committed(machines, _, _, gasUsed, _, _, _) =>
+        case TransactionResult.Committed(machines, _, _, gasUsed, _, _, _, _) =>
           // Both machines transitioned
           // Gas includes: guard eval + effect eval + trigger overhead for both machines
           // Actual gas depends on FiberGasConfig and VM gas costs
@@ -836,9 +836,9 @@ object GasMeteringPhaseSuite extends SimpleIOSuite {
 
       } yield (resultDefault, resultMainnet, resultMinimal) match {
         case (
-              TransactionResult.Committed(_, _, _, defaultGas, _, _, _),
-              TransactionResult.Committed(_, _, _, mainnetGas, _, _, _),
-              TransactionResult.Committed(_, _, _, minimalGas, _, _, _)
+              TransactionResult.Committed(_, _, _, defaultGas, _, _, _, _),
+              TransactionResult.Committed(_, _, _, mainnetGas, _, _, _, _),
+              TransactionResult.Committed(_, _, _, minimalGas, _, _, _, _)
             ) =>
           // Verify gas was actually consumed (trigger chain has overhead)
           // Each config: trigger overhead + guard + effect for 2 machines

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/GuardEdgeCasesSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/GuardEdgeCasesSuite.scala
@@ -104,7 +104,7 @@ object GuardEdgeCasesSuite extends SimpleIOSuite {
         result <- orchestrator.process(fiberId, input, List.empty)
 
       } yield result match {
-        case TransactionResult.Committed(machines, _, _, _, _, _, _) =>
+        case TransactionResult.Committed(machines, _, _, _, _, _, _, _) =>
           // First guard should fail (missing field evaluates to null != true), fallback should succeed
           val updated = machines.get(fiberId)
           expect(updated.isDefined, "Updated fiber should exist") and
@@ -192,7 +192,7 @@ object GuardEdgeCasesSuite extends SimpleIOSuite {
         result <- orchestrator.process(fiberId, input, List.empty)
 
       } yield result match {
-        case TransactionResult.Committed(machines, _, _, gasUsed, _, _, _) =>
+        case TransactionResult.Committed(machines, _, _, gasUsed, _, _, _, _) =>
           // Deeply nested guard: 10 levels of nested conditionals
           // Each level has: if (1) = 2 gas ops, so ~20 gas minimum
           val expectedMinGas = 10L
@@ -380,7 +380,7 @@ object GuardEdgeCasesSuite extends SimpleIOSuite {
         result <- orchestrator.process(fiberId, input, List.empty)
 
       } yield result match {
-        case TransactionResult.Committed(machines, _, _, _, _, _, _) =>
+        case TransactionResult.Committed(machines, _, _, _, _, _, _, _) =>
           val updated = machines.get(fiberId)
           expect(updated.isDefined) and
           // Second transition should be taken (75 > 50 but 75 not > 100)
@@ -460,7 +460,7 @@ object GuardEdgeCasesSuite extends SimpleIOSuite {
             reason.isInstanceOf[FailureReason.EvaluationError],
             s"Expected EvaluationError but got: ${reason.getClass.getSimpleName}: ${reason.toMessage}"
           )
-        case TransactionResult.Committed(_, _, _, _, _, _, _) =>
+        case TransactionResult.Committed(_, _, _, _, _, _, _, _) =>
           failure("Expected Aborted with EvaluationError, but transaction was committed")
       }
     }
@@ -529,7 +529,7 @@ object GuardEdgeCasesSuite extends SimpleIOSuite {
             reason.isInstanceOf[FailureReason.EvaluationError],
             s"Expected EvaluationError but got: ${reason.getClass.getSimpleName}"
           )
-        case TransactionResult.Committed(_, _, _, _, _, _, _) =>
+        case TransactionResult.Committed(_, _, _, _, _, _, _, _) =>
           failure("Expected Aborted with EvaluationError for non-MapValue state data")
       }
     }

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/NullifierConsumeSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/NullifierConsumeSuite.scala
@@ -1,0 +1,278 @@
+package xyz.kd5ujc.shared_data
+
+import java.util.UUID
+
+import cats.effect.IO
+
+import scala.collection.immutable.SortedMap
+
+import io.constellationnetwork.currency.dataApplication.{DataState, L0NodeContext}
+import io.constellationnetwork.ext.cats.syntax.next._
+import io.constellationnetwork.metagraph_sdk.json_logic._
+import io.constellationnetwork.metagraph_sdk.std.JsonBinaryHasher.HasherOps
+import io.constellationnetwork.schema.SnapshotOrdinal
+import io.constellationnetwork.security.SecurityProvider
+import io.constellationnetwork.security.hash.Hash
+import io.constellationnetwork.security.signature.Signed
+
+import xyz.kd5ujc.schema.fiber._
+import xyz.kd5ujc.schema.{CalculatedState, OnChain, Records, Updates}
+import xyz.kd5ujc.shared_data.fiber.FiberEngine
+import xyz.kd5ujc.shared_data.lifecycle.Combiner
+import xyz.kd5ujc.shared_test.Participant._
+import xyz.kd5ujc.shared_test.TestFixture
+
+import io.circe.parser._
+import weaver.SimpleIOSuite
+
+/**
+ * The protocol nullifier set (docs/proposals/protocol-nullifier-set.md) wired END-TO-END through the
+ * combiner: a transition emitting `_consumeNullifier` inserts `nullifier/<emitter-domain>/<nf> -> ordinal`
+ * into `CalculatedState.nullifiers`, and the combiner (`NullifierCombiner`) is the SOLE, graceful
+ * enforcement site. Proves:
+ *   (1) HAPPY PATH — the nf lands under the EMITTING fiber's own domain with the batch ordinal;
+ *   (2) DOUBLE-SPEND — a second consumption of the same nf under the same domain is a RejectionReceipt and
+ *       the whole update (fiber mutation included) is discarded — protocol-enforced "one script, one fill";
+ *   (3) DOMAIN ISOLATION — a DIFFERENT fiber consuming the SAME nf value succeeds (the domain is the
+ *       emitter's own id, so apps can never collide with / grief each other's namespaces);
+ *   (4) CAP — more than `maxNullifierConsumptions` items in one transition is a graceful reject;
+ *   (5) MALFORMED — a non-hex nf value is a LOUD graceful reject (never a silent drop);
+ *   (6) POLICY — `allowedEffects` without the NULLIFIER family aborts the transition (fail-closed dial);
+ *   (7) SANITIZATION — `_consumeNullifier` never leaks into stateData (StateMerger strips `_`-keys).
+ */
+object NullifierConsumeSuite extends SimpleIOSuite {
+
+  private val nfA = "a" * 64
+  private val nfB = "b" * 64
+
+  // A one-state "prescription" machine: OPEN -> OPEN on "fill", whose effect consumes the given nf values.
+  // `nfJsonItems` is the raw JSON of the `_consumeNullifier` array items (strings / sub-expressions).
+  private def fillJson(nfJsonItems: String): String =
+    s"""
+    {
+      "states": {
+        "OPEN": { "id": "OPEN", "isFinal": false }
+      },
+      "initialState": "OPEN",
+      "transitions": [
+        {
+          "from": "OPEN",
+          "to": "OPEN",
+          "eventName": "fill",
+          "guard": true,
+          "effect": { "_consumeNullifier": [ $nfJsonItems ], "filled": true },
+          "dependencies": []
+        }
+      ]
+    }
+    """
+
+  private def buildFiber(id: UUID, json: String, ordinal: SnapshotOrdinal): IO[Records.StateMachineFiberRecord] =
+    for {
+      definition <- IO.fromEither(decode[StateMachineDefinition](json))
+      stateData = MapValue(Map("filled" -> BoolValue(false)))
+      hash <- (stateData: JsonLogicValue).computeDigest
+    } yield Records.StateMachineFiberRecord(
+      fiberId = id,
+      creationOrdinal = ordinal,
+      previousUpdateOrdinal = ordinal,
+      latestUpdateOrdinal = ordinal,
+      definition = definition,
+      currentState = StateId("OPEN"),
+      stateData = stateData,
+      stateDataHash = hash,
+      sequenceNumber = FiberOrdinal.MinValue,
+      owners = Set.empty,
+      status = FiberStatus.Active
+    )
+
+  private def rejectionReasons(state: DataState[OnChain, CalculatedState]): List[String] =
+    state.onChain.latestLogs.values.flatten.collect { case r: FiberLogEntry.RejectionReceipt => r.reason }.toList
+
+  private def fill(fiberId: UUID, seq: FiberOrdinal = FiberOrdinal.MinValue): Updates.TransitionStateMachine =
+    Updates.TransitionStateMachine(fiberId, "fill", MapValue(Map.empty), seq)
+
+  // ── (1) happy path: nf present under the emitter domain with the batch ordinal ──────────────────
+
+  test("happy path: the consumed nf lands under the EMITTING fiber's domain with the batch ordinal") {
+    TestFixture.resource(Set(Alice)).use { fixture =>
+      implicit val sp: SecurityProvider[IO] = fixture.securityProvider
+      implicit val l0: L0NodeContext[IO] = fixture.l0Context
+      val combiner = Combiner.make[IO]()
+
+      val fiberId = UUID.fromString("d0c70000-0000-4000-8000-000000000001")
+      for {
+        fiber <- buildFiber(fiberId, fillJson(s""""$nfA""""), fixture.ordinal)
+        genesis = DataState(OnChain.genesis, CalculatedState.genesis.copy(stateMachines = SortedMap(fiberId -> fiber)))
+        pr    <- fixture.registry.generateProofs(fill(fiberId), Set(Alice))
+        after <- combiner.insert(genesis, Signed(fill(fiberId), pr))
+        domain = after.calculated.nullifiers.get(fiberId)
+      } yield expect(rejectionReasons(after).isEmpty) and
+      expect(domain.flatMap(_.get(Hash(nfA))).contains(fixture.ordinal)) and
+      // the fiber's own transition committed alongside the insert
+      expect(after.calculated.stateMachines.get(fiberId).map(_.sequenceNumber).contains(FiberOrdinal.MinValue.next)) and
+      // nothing landed under any OTHER domain
+      expect(after.calculated.nullifiers.keySet == Set(fiberId))
+    }
+  }
+
+  // ── (2) double-spend: second insert of the same nf ⇒ RejectionReceipt, state unmutated ──────────
+
+  test("double-spend: a second fill consuming the same nf is a RejectionReceipt and mutates nothing") {
+    TestFixture.resource(Set(Alice)).use { fixture =>
+      implicit val sp: SecurityProvider[IO] = fixture.securityProvider
+      implicit val l0: L0NodeContext[IO] = fixture.l0Context
+      val combiner = Combiner.make[IO]()
+
+      val fiberId = UUID.fromString("d0c70000-0000-4000-8000-000000000002")
+      for {
+        fiber <- buildFiber(fiberId, fillJson(s""""$nfA""""), fixture.ordinal)
+        genesis = DataState(OnChain.genesis, CalculatedState.genesis.copy(stateMachines = SortedMap(fiberId -> fiber)))
+        pr1    <- fixture.registry.generateProofs(fill(fiberId), Set(Alice))
+        after1 <- combiner.insert(genesis, Signed(fill(fiberId), pr1))
+        second = fill(fiberId, FiberOrdinal.MinValue.next)
+        pr2    <- fixture.registry.generateProofs(second, Set(Alice))
+        after2 <- combiner.insert(after1, Signed(second, pr2))
+      } yield expect(rejectionReasons(after1).isEmpty) and
+      expect(rejectionReasons(after2).exists(_.contains("nullifier already consumed (double-spend)"))) and
+      // the nullifier map is UNMUTATED: still exactly the first spend at the first ordinal
+      expect(after2.calculated.nullifiers == after1.calculated.nullifiers) and
+      // the second update's fiber mutation was discarded along with it (all-or-nothing)
+      expect(after2.calculated.stateMachines.get(fiberId).map(_.sequenceNumber).contains(FiberOrdinal.MinValue.next))
+    }
+  }
+
+  // ── (3) domain isolation: a DIFFERENT fiber may consume the SAME nf value ───────────────────────
+
+  test("domain isolation: two different fibers consuming the same nf value both succeed") {
+    TestFixture.resource(Set(Alice)).use { fixture =>
+      implicit val sp: SecurityProvider[IO] = fixture.securityProvider
+      implicit val l0: L0NodeContext[IO] = fixture.l0Context
+      val combiner = Combiner.make[IO]()
+
+      val fiberA = UUID.fromString("d0c70000-0000-4000-8000-00000000000a")
+      val fiberB = UUID.fromString("d0c70000-0000-4000-8000-00000000000b")
+      for {
+        fa <- buildFiber(fiberA, fillJson(s""""$nfA""""), fixture.ordinal)
+        fb <- buildFiber(fiberB, fillJson(s""""$nfA""""), fixture.ordinal)
+        genesis = DataState(
+          OnChain.genesis,
+          CalculatedState.genesis.copy(stateMachines = SortedMap(fiberA -> fa, fiberB -> fb))
+        )
+        prA    <- fixture.registry.generateProofs(fill(fiberA), Set(Alice))
+        after1 <- combiner.insert(genesis, Signed(fill(fiberA), prA))
+        prB    <- fixture.registry.generateProofs(fill(fiberB), Set(Alice))
+        after2 <- combiner.insert(after1, Signed(fill(fiberB), prB))
+      } yield expect(rejectionReasons(after2).isEmpty) and
+      expect(after2.calculated.nullifiers.get(fiberA).flatMap(_.get(Hash(nfA))).contains(fixture.ordinal)) and
+      expect(after2.calculated.nullifiers.get(fiberB).flatMap(_.get(Hash(nfA))).contains(fixture.ordinal))
+    }
+  }
+
+  // ── (4) cap: more than maxNullifierConsumptions items in one transition ⇒ reject ────────────────
+
+  test("cap: a transition consuming 33 nullifiers (cap 32) is a graceful RejectionReceipt") {
+    TestFixture.resource(Set(Alice)).use { fixture =>
+      implicit val sp: SecurityProvider[IO] = fixture.securityProvider
+      implicit val l0: L0NodeContext[IO] = fixture.l0Context
+      val combiner = Combiner.make[IO]()
+
+      val fiberId = UUID.fromString("d0c70000-0000-4000-8000-000000000004")
+      val cap = ExecutionLimits().maxNullifierConsumptions
+      val items = (0 to cap).map(i => "\"%064x\"".format(i)).mkString(", ") // cap + 1 = 33 distinct nfs
+      for {
+        fiber <- buildFiber(fiberId, fillJson(items), fixture.ordinal)
+        genesis = DataState(OnChain.genesis, CalculatedState.genesis.copy(stateMachines = SortedMap(fiberId -> fiber)))
+        pr    <- fixture.registry.generateProofs(fill(fiberId), Set(Alice))
+        after <- combiner.insert(genesis, Signed(fill(fiberId), pr))
+      } yield expect(rejectionReasons(after).exists(_.contains("exceeding maxNullifierConsumptions"))) and
+      // nothing was inserted (all-or-nothing) and the fiber mutation was discarded
+      expect(after.calculated.nullifiers.isEmpty) and
+      expect(after.calculated.stateMachines.get(fiberId).map(_.sequenceNumber).contains(FiberOrdinal.MinValue))
+    }
+  }
+
+  // ── (5) malformed nf: bad hex is a LOUD graceful reject ─────────────────────────────────────────
+
+  test("malformed: a non-hex nf value is a graceful RejectionReceipt (never a silent drop)") {
+    TestFixture.resource(Set(Alice)).use { fixture =>
+      implicit val sp: SecurityProvider[IO] = fixture.securityProvider
+      implicit val l0: L0NodeContext[IO] = fixture.l0Context
+      val combiner = Combiner.make[IO]()
+
+      val fiberId = UUID.fromString("d0c70000-0000-4000-8000-000000000005")
+      for {
+        f <- buildFiber(fiberId, fillJson(""""not-a-nullifier""""), fixture.ordinal)
+        genesis = DataState(OnChain.genesis, CalculatedState.genesis.copy(stateMachines = SortedMap(fiberId -> f)))
+        pr    <- fixture.registry.generateProofs(fill(fiberId), Set(Alice))
+        after <- combiner.insert(genesis, Signed(fill(fiberId), pr))
+      } yield expect(rejectionReasons(after).exists(r => r.contains("_consumeNullifier") && r.contains("64 hex"))) and
+      expect(after.calculated.nullifiers.isEmpty)
+    }
+  }
+
+  // ── (6) allowedEffects: a policy without the NULLIFIER family aborts the transition ─────────────
+
+  test("allowedEffects: consuming a nullifier under a policy without NULLIFIER is a PolicyViolation abort") {
+    TestFixture.resource(Set(Alice)).use { fixture =>
+      implicit val sp: SecurityProvider[IO] = fixture.securityProvider
+      for {
+        base <- IO.fromEither(decode[StateMachineDefinition](fillJson(s""""$nfA"""")))
+        forbid = base.copy(policy = FiberPolicy.constrained(allowedEffects = Some(Set(EffectKind.Emit))))
+        permit = base.copy(policy = FiberPolicy.constrained(allowedEffects = Some(Set(EffectKind.Nullifier))))
+        fid = UUID.fromString("d0c70000-0000-4000-8000-000000000006")
+        data = MapValue(Map("filled" -> BoolValue(false)))
+        h <- (data: JsonLogicValue).computeDigest
+        record = (d: StateMachineDefinition) =>
+          Records.StateMachineFiberRecord(
+            fiberId = fid,
+            creationOrdinal = fixture.ordinal,
+            previousUpdateOrdinal = fixture.ordinal,
+            latestUpdateOrdinal = fixture.ordinal,
+            definition = d,
+            currentState = StateId("OPEN"),
+            stateData = data,
+            stateDataHash = h,
+            sequenceNumber = FiberOrdinal.MinValue,
+            owners = Set.empty,
+            status = FiberStatus.Active
+          )
+        input = FiberInput.Transition("fill", MapValue(Map.empty))
+        forbidState = CalculatedState(SortedMap(fid -> record(forbid)), SortedMap.empty)
+        permitState = CalculatedState(SortedMap(fid -> record(permit)), SortedMap.empty)
+        forbidRes <- FiberEngine.make[IO](forbidState, fixture.ordinal).process(fid, input, List.empty)
+        permitRes <- FiberEngine.make[IO](permitState, fixture.ordinal).process(fid, input, List.empty)
+      } yield expect(forbidRes match {
+        case TransactionResult.Aborted(FailureReason.PolicyViolation("allowedEffects", _), _, _) => true
+        case _                                                                                   => false
+      }) and
+      expect(permitRes match {
+        case c: TransactionResult.Committed => c.nullifierConsumptions.get(fid).exists(_.nonEmpty)
+        case _                              => false
+      })
+    }
+  }
+
+  // ── (7) sanitization: `_consumeNullifier` never leaks into stateData ────────────────────────────
+
+  test("sanitization: _consumeNullifier is stripped from the merged stateData (StateMerger `_`-key filter)") {
+    TestFixture.resource(Set(Alice)).use { fixture =>
+      implicit val sp: SecurityProvider[IO] = fixture.securityProvider
+      implicit val l0: L0NodeContext[IO] = fixture.l0Context
+      val combiner = Combiner.make[IO]()
+
+      val fiberId = UUID.fromString("d0c70000-0000-4000-8000-000000000007")
+      for {
+        fiber <- buildFiber(fiberId, fillJson(s""""$nfB""""), fixture.ordinal)
+        genesis = DataState(OnChain.genesis, CalculatedState.genesis.copy(stateMachines = SortedMap(fiberId -> fiber)))
+        pr    <- fixture.registry.generateProofs(fill(fiberId), Set(Alice))
+        after <- combiner.insert(genesis, Signed(fill(fiberId), pr))
+        stateKeys = after.calculated.stateMachines.get(fiberId).map(_.stateData).collect { case MapValue(m) =>
+          m.keySet
+        }
+      } yield expect(rejectionReasons(after).isEmpty) and
+      expect(stateKeys.exists(_.contains("filled"))) and
+      expect(stateKeys.exists(ks => !ks.exists(_.startsWith("_"))))
+    }
+  }
+}

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/NullifierExtractorSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/NullifierExtractorSuite.scala
@@ -1,0 +1,114 @@
+package xyz.kd5ujc.shared_data
+
+import cats.effect.IO
+
+import io.constellationnetwork.metagraph_sdk.json_logic._
+import io.constellationnetwork.schema.SnapshotOrdinal
+import io.constellationnetwork.security.hash.Hash
+
+import xyz.kd5ujc.schema.fiber._
+import xyz.kd5ujc.shared_data.fiber.core._
+import xyz.kd5ujc.shared_data.fiber.evaluation.EffectExtractor
+import xyz.kd5ujc.shared_data.lifecycle.combine.CombineRejected
+
+import weaver.SimpleIOSuite
+
+/**
+ * The `_consumeNullifier` extractor boundary (protocol-nullifier-set.md): each array item is a bare nf VALUE
+ * (a string literal or a sub-expression that evaluates to one) — no object wrapper, no domain field — and is
+ * NORMALIZED through [[NullifierHex]] (strip optional `0x`, lowercase, require exactly 64 hex chars).
+ * Asserts at [[EffectExtractor.extractNullifierConsumptions]] that:
+ *   - a single literal and a list of literals parse into [[FiberEffect.NullifierConsumed]] in authored order,
+ *   - an evaluated sub-expression (`{"var":..}` / `{"cat":[..]}`) resolves against the context (gas charged),
+ *   - `0x`-prefixed and uppercase inputs NORMALIZE to the canonical 64-lowercase-hex form,
+ *   - a malformed item (bad hex / wrong length / non-string) is REJECTED loudly ([[CombineRejected]]),
+ *   - an absent directive is a no-op (no items, no error).
+ */
+object NullifierExtractorSuite extends SimpleIOSuite {
+
+  import xyz.kd5ujc.shared_data.fiber.core.FiberTInstances._
+
+  private val nfA = "a1" * 32 // 64 lowercase hex chars
+  private val nfB = "0b" * 32
+
+  // Drive EffectExtractor.extractNullifierConsumptions in the same FiberT MTL stack the engine uses.
+  private def runExtract(
+    effectResult: JsonLogicValue,
+    ctx:          JsonLogicValue = MapValue(Map.empty)
+  ): IO[(List[FiberEffect.NullifierConsumed], Long)] = {
+    val prog: FiberT[IO, (List[FiberEffect.NullifierConsumed], Long)] =
+      for {
+        consumptions <- EffectExtractor.extractNullifierConsumptions[IO, FiberT[IO, *]](effectResult, ctx)
+        gasUsed      <- ExecutionOps.getGasUsed[FiberT[IO, *]]
+      } yield (consumptions, gasUsed)
+    prog
+      .run(
+        FiberContext(
+          SnapshotOrdinal.MinValue,
+          Hash.empty,
+          io.constellationnetwork.schema.epoch
+            .EpochProgress(eu.timepit.refined.types.numeric.NonNegLong.unsafeFrom(0L)),
+          ExecutionLimits(),
+          io.constellationnetwork.metagraph_sdk.json_logic.gas.GasConfig.Default,
+          FiberGasConfig.Default
+        )
+      )
+      .runA(ExecutionState.initial)
+  }
+
+  private def consumeEffect(items: JsonLogicValue*): JsonLogicValue =
+    MapValue(Map(ReservedKeys.CONSUME_NULLIFIER -> ArrayValue(items.toList)))
+
+  private def isRejected(io: IO[(List[FiberEffect.NullifierConsumed], Long)]): IO[Boolean] =
+    io.attempt.map(_.left.toOption.exists(_.isInstanceOf[CombineRejected]))
+
+  test("a single 64-hex literal parses into NullifierConsumed") {
+    runExtract(consumeEffect(StrValue(nfA))).map { case (consumptions, _) =>
+      expect(consumptions == List(FiberEffect.NullifierConsumed(Hash(nfA))))
+    }
+  }
+
+  test("a list of literals parses in authored order") {
+    runExtract(consumeEffect(StrValue(nfA), StrValue(nfB))).map { case (consumptions, _) =>
+      expect(
+        consumptions == List(FiberEffect.NullifierConsumed(Hash(nfA)), FiberEffect.NullifierConsumed(Hash(nfB)))
+      )
+    }
+  }
+
+  test("an evaluated sub-expression resolves against the context (and charges gas)") {
+    val ctx = MapValue(Map("nf" -> StrValue(nfA)))
+    val item = MapValue(Map(ReservedKeys.VAR -> StrValue("nf")))
+    runExtract(consumeEffect(item), ctx).map { case (consumptions, gasUsed) =>
+      expect(consumptions == List(FiberEffect.NullifierConsumed(Hash(nfA)))) and
+      expect(gasUsed > 0L)
+    }
+  }
+
+  test("0x-prefixed and uppercase inputs normalize to canonical 64-lowercase-hex") {
+    val upper = nfA.toUpperCase
+    for {
+      prefixed <- runExtract(consumeEffect(StrValue(s"0x$nfA"))).map(_._1)
+      upperRes <- runExtract(consumeEffect(StrValue(upper))).map(_._1)
+      both     <- runExtract(consumeEffect(StrValue(s"0X$upper"))).map(_._1)
+    } yield expect(prefixed == List(FiberEffect.NullifierConsumed(Hash(nfA)))) and
+    expect(upperRes == List(FiberEffect.NullifierConsumed(Hash(nfA)))) and
+    expect(both == List(FiberEffect.NullifierConsumed(Hash(nfA))))
+  }
+
+  test("malformed items are REJECTED loudly (bad hex / wrong length / non-string)") {
+    for {
+      badHex      <- isRejected(runExtract(consumeEffect(StrValue("z" * 64))))
+      tooShort    <- isRejected(runExtract(consumeEffect(StrValue("ab" * 16))))
+      tooLong     <- isRejected(runExtract(consumeEffect(StrValue("ab" * 33))))
+      nonString   <- isRejected(runExtract(consumeEffect(IntValue(BigInt(42)))))
+      firstBadAll <- isRejected(runExtract(consumeEffect(StrValue("nope"), StrValue(nfA))))
+    } yield expect(badHex) and expect(tooShort) and expect(tooLong) and expect(nonString) and expect(firstBadAll)
+  }
+
+  test("an absent directive is a no-op (no items, no error)") {
+    runExtract(MapValue(Map("filled" -> BoolValue(true)))).map { case (consumptions, _) =>
+      expect(consumptions.isEmpty)
+    }
+  }
+}

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/ParentChildStateMachineSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/ParentChildStateMachineSuite.scala
@@ -416,8 +416,8 @@ object ParentChildStateMachineSuite extends SimpleIOSuite {
 
         // Extract logEntries from the committed result
         logEntries = result match {
-          case TransactionResult.Committed(_, _, entries, _, _, _, _) => entries
-          case _                                                      => List.empty
+          case TransactionResult.Committed(_, _, entries, _, _, _, _, _) => entries
+          case _                                                         => List.empty
         }
 
         receipts = logEntries.collect { case r: EventReceipt => r }
@@ -502,8 +502,8 @@ object ParentChildStateMachineSuite extends SimpleIOSuite {
         result <- engine.process(fiberId, input, proofs)
 
         logEntries = result match {
-          case TransactionResult.Committed(_, _, entries, _, _, _, _) => entries
-          case _                                                      => List.empty
+          case TransactionResult.Committed(_, _, entries, _, _, _, _, _) => entries
+          case _                                                         => List.empty
         }
 
         receipts = logEntries.collect { case r: EventReceipt => r }
@@ -576,8 +576,8 @@ object ParentChildStateMachineSuite extends SimpleIOSuite {
         result <- engine.process(fiberId, input, proofs)
 
         logEntries = result match {
-          case TransactionResult.Committed(_, _, entries, _, _, _, _) => entries
-          case _                                                      => List.empty
+          case TransactionResult.Committed(_, _, entries, _, _, _, _, _) => entries
+          case _                                                         => List.empty
         }
 
         receipts = logEntries.collect { case r: EventReceipt => r }

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/RollbackCompensationSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/RollbackCompensationSuite.scala
@@ -214,7 +214,7 @@ object RollbackCompensationSuite extends SimpleIOSuite {
           expect(calculatedState.stateMachines.get(machineA).exists(_.sequenceNumber == FiberOrdinal.MinValue)) and
           expect(calculatedState.stateMachines.get(machineB).exists(_.sequenceNumber == FiberOrdinal.MinValue)) and
           expect(calculatedState.stateMachines.get(machineC).exists(_.sequenceNumber == FiberOrdinal.MinValue))
-        case TransactionResult.Committed(_, _, _, _, _, _, _) =>
+        case TransactionResult.Committed(_, _, _, _, _, _, _, _) =>
           failure("Expected Aborted due to C's failed guard, got Committed")
       }
     }
@@ -296,7 +296,7 @@ object RollbackCompensationSuite extends SimpleIOSuite {
             calculatedState.stateMachines.get(fiberId).exists(_.sequenceNumber == FiberOrdinal.unsafeApply(5L))
           ) and
           expect(calculatedState.stateMachines.get(fiberId).exists(_.stateData == initialData))
-        case TransactionResult.Committed(machines, _, _, _, _, _, _) =>
+        case TransactionResult.Committed(machines, _, _, _, _, _, _, _) =>
           // If it committed (JsonLogic might handle missing vars gracefully),
           // verify state was actually updated
           val updated = machines.get(fiberId)
@@ -435,7 +435,7 @@ object RollbackCompensationSuite extends SimpleIOSuite {
           expect(calculatedState.stateMachines.get(parentId).exists(_.sequenceNumber == FiberOrdinal.MinValue)) and
           // No children should exist
           expect(calculatedState.stateMachines.size == 1)
-        case Right(TransactionResult.Committed(machines, _, _, _, _, _, _)) =>
+        case Right(TransactionResult.Committed(machines, _, _, _, _, _, _, _)) =>
           // If it committed, the child's trigger might have been handled differently
           // Document the actual behavior
           expect(machines.contains(parentId))
@@ -497,7 +497,7 @@ object RollbackCompensationSuite extends SimpleIOSuite {
           expect(calculatedState.stateMachines.get(fiberId).exists(_.sequenceNumber == originalSeqNum)) and
           expect(calculatedState.stateMachines.get(fiberId).exists(_.stateData == initialData)) and
           expect(calculatedState.stateMachines.get(fiberId).exists(_.stateDataHash == initialHash))
-        case TransactionResult.Committed(_, _, _, _, _, _, _) =>
+        case TransactionResult.Committed(_, _, _, _, _, _, _, _) =>
           failure("Expected Aborted for event with no transitions, got Committed")
       }
     }

--- a/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/SpawnMachinesSuite.scala
+++ b/modules/shared-data/src/test/scala/xyz/kd5ujc/shared_data/SpawnMachinesSuite.scala
@@ -1103,7 +1103,7 @@ object SpawnMachinesSuite extends SimpleIOSuite {
             reason.isInstanceOf[FailureReason.GasExhaustedFailure],
             s"Expected GasExhaustedFailure, got ${reason.getClass.getSimpleName}: ${reason.toMessage}"
           )
-        case TransactionResult.Committed(_, _, _, _, _, _, _) =>
+        case TransactionResult.Committed(_, _, _, _, _, _, _, _) =>
           failure("Expected Aborted with GasExhaustedFailure, but transaction was committed")
       }
     }
@@ -1202,7 +1202,7 @@ object SpawnMachinesSuite extends SimpleIOSuite {
             reason.isInstanceOf[FailureReason.DuplicateChildId],
             s"Expected DuplicateChildId but got: ${reason.getClass.getSimpleName}"
           )
-        case TransactionResult.Committed(machines, _, _, _, _, _, _) =>
+        case TransactionResult.Committed(machines, _, _, _, _, _, _, _) =>
           // If duplicates are deduplicated (second overwrites first), verify exactly 1 child
           val childCount = machines.values.count(_.parentFiberId.contains(parentfiberId))
           expect(childCount == 1, s"Expected exactly 1 child after dedup, got $childCount")
@@ -1321,7 +1321,7 @@ object SpawnMachinesSuite extends SimpleIOSuite {
             reason.isInstanceOf[FailureReason.ChildIdCollision],
             s"Expected ChildIdCollision but got: ${reason.getClass.getSimpleName}: ${reason.toMessage}"
           )
-        case TransactionResult.Committed(_, _, _, _, _, _, _) =>
+        case TransactionResult.Committed(_, _, _, _, _, _, _, _) =>
           failure("Expected Aborted with ChildIdCollision, but transaction was committed")
       }
     }
@@ -1412,7 +1412,7 @@ object SpawnMachinesSuite extends SimpleIOSuite {
             reason.isInstanceOf[FailureReason.StateSizeTooLarge],
             s"Expected size-related failure but got: ${reason.getClass.getSimpleName}: ${reason.toMessage}"
           )
-        case TransactionResult.Committed(_, _, _, _, _, _, _) =>
+        case TransactionResult.Committed(_, _, _, _, _, _, _, _) =>
           failure("Expected Aborted for oversized initialData")
       }
     }
@@ -1684,7 +1684,7 @@ object SpawnMachinesSuite extends SimpleIOSuite {
           expect(dial == "spawnOwnerPolicy", s"Expected spawnOwnerPolicy PolicyViolation, got dial=$dial")
         case TransactionResult.Aborted(reason, _, _) =>
           failure(s"Expected PolicyViolation(spawnOwnerPolicy), got: ${reason.getClass.getSimpleName}")
-        case TransactionResult.Committed(_, _, _, _, _, _, _) =>
+        case TransactionResult.Committed(_, _, _, _, _, _, _, _) =>
           failure("Expected Aborted: a child owned by a non-parent address must be rejected by the subset floor")
       }
     }
@@ -1791,7 +1791,7 @@ object SpawnMachinesSuite extends SimpleIOSuite {
             reason.isInstanceOf[FailureReason.InvalidChildIdFormat],
             s"Expected InvalidChildIdFormat but got: ${reason.getClass.getSimpleName}"
           )
-        case Right(TransactionResult.Committed(_, _, _, _, _, _, _)) =>
+        case Right(TransactionResult.Committed(_, _, _, _, _, _, _, _)) =>
           failure("Expected error or Aborted for invalid UUID format, but transaction was committed")
       }
     }
@@ -1894,7 +1894,7 @@ object SpawnMachinesSuite extends SimpleIOSuite {
             reason.isInstanceOf[FailureReason.InvalidChildIdFormat],
             s"Expected InvalidChildIdFormat but got: ${reason.getClass.getSimpleName}"
           )
-        case Right(TransactionResult.Committed(_, _, _, _, _, _, _)) =>
+        case Right(TransactionResult.Committed(_, _, _, _, _, _, _, _)) =>
           failure("Expected error or Aborted for non-string childIdExpr, but transaction was committed")
       }
     }
@@ -1999,7 +1999,7 @@ object SpawnMachinesSuite extends SimpleIOSuite {
             reason.isInstanceOf[FailureReason.InvalidOwnersExpression],
             s"Expected InvalidOwnersExpression but got: ${reason.getClass.getSimpleName}"
           )
-        case Right(TransactionResult.Committed(_, _, _, _, _, _, _)) =>
+        case Right(TransactionResult.Committed(_, _, _, _, _, _, _, _)) =>
           failure("Expected error or Aborted for non-array ownersExpr, but transaction was committed")
       }
     }
@@ -2104,7 +2104,7 @@ object SpawnMachinesSuite extends SimpleIOSuite {
             reason.isInstanceOf[FailureReason.InvalidOwnerAddress],
             s"Expected InvalidOwnerAddress but got: ${reason.getClass.getSimpleName}"
           )
-        case Right(TransactionResult.Committed(_, _, _, _, _, _, _)) =>
+        case Right(TransactionResult.Committed(_, _, _, _, _, _, _, _)) =>
           failure("Expected error or Aborted for invalid owner address")
       }
     }


### PR DESCRIPTION
Implements `docs/proposals/protocol-nullifier-set.md` (committed as the first commit — the design of record; maintainer decisions: unbounded accepted with checkpoint exclusion + epoch-retrofittable keys, audit re-scoped to pre-mainnet, domain = emitting fiber id, combiner-only enforcement).

## What

- **State**: `CalculatedState.nullifiers: SortedMap[UUID, SortedMap[Hash, SnapshotOrdinal]]` (trailing default — near-zero blast radius), projected as TOTAL committed-view keys `nullifier/<domain>/<nf>` with the spend ordinal as the leaf value → present/absent light-client provable against the consensus-signed root (#164 machinery). Totality argument documented in place (110-char key, 3 valid segments).
- **Consumption**: new `_consumeNullifier` effect token through the existing `FiberDirective`/`EffectKind` architecture (array form, gas-metered eval per item, `NullifierHex` normalization, malformed = loud reject, absent = no-op, injection-immune via the authored-AST walk). Threaded emitter-keyed through FiberEngine primary + cascade paths — the emitter id IS the domain, so cross-app griefing is closed by construction.
- **Enforcement**: new `NullifierCombiner`, the sole writer of `calculated.nullifiers` — deterministic emitter order, per-emitter cap (`maxNullifierConsumptions = 32`), absent-check → insert-at-current-ordinal in one sequential fold (intra-transition dupes collide with their own insert), any hit ⇒ graceful `CombineRejected` ⇒ single `RejectionReceipt` (rule #2, the #154 lesson). **Never in `validateSignedUpdate`** (rule #3); `OnChain`/`CommitIndex`/DL1 are provably untouched.
- **Surface**: `GET /v1/nullifiers/{domain}/{nf}` (BadRequest on malformed nf, 404 unspent, presence state-proof + ordinal otherwise); `/v1/checkpoint` slims the map at the handler (the only whole-state JSON path — the unbounded-set mitigation); `DefinitionLinter` advisory for malformed nf literals.

## Tests

668 total, 0 failed (+17): `NullifierConsumeSuite` (happy path, double-spend receipt with state unmutated, cross-domain isolation, 33-item cap, malformed nf, `allowedEffects` NULLIFIER gate, stateData sanitization), `NullifierExtractorSuite` (list/eval/0x-normalization/malformed), committed-view projection case, linter cases. `scalafmtCheckAll` + `currencyL0`/`dataL1` compiles green (independently re-run by reviewer).

## Follow-ons (tracked)

metakit#60 (MPT absence proofs, open) → rc.8 → absence serving + SDK `verifyStateProof` absence arm; sdk `_consumeNullifier` types; riverdale-health migration (flips "one script, one fill" to protocol-enforced and enables the single-key PDMP query).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H4oQGYfRRwkFet4ZRrs4LS